### PR TITLE
Fix for output flags

### DIFF
--- a/src/ResultWriter/WaveFieldWriter.cpp
+++ b/src/ResultWriter/WaveFieldWriter.cpp
@@ -49,7 +49,7 @@ void seissol::writer::WaveFieldWriter::init(unsigned int numVars,
 		const MeshReader &meshReader,
 		const double* dofs,  const double* pstrain,
 		const unsigned int* map,
-		int refinement, int timestep, int* output,
+		int refinement, int timestep, int* outputMask,
 		double timeTolerance)
 {
 	const int rank = seissol::MPI::mpi.rank();

--- a/src/ResultWriter/WaveFieldWriter.h
+++ b/src/ResultWriter/WaveFieldWriter.h
@@ -237,7 +237,7 @@ public:
 			const MeshReader &meshReader,
 			const double* dofs,  const double* pstrain,
 			const unsigned int* map,
-			int refinement, int timestep,
+			int refinement, int timestep, int* outputMask,
 			double timeTolerance);
 
 	/**

--- a/src/ResultWriter/WaveFieldWriterC.cpp
+++ b/src/ResultWriter/WaveFieldWriterC.cpp
@@ -7,17 +7,17 @@
  * @section LICENSE
  * Copyright (c) 2016, SeisSol Group
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
- * 
+ *
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- * 
+ *
  * 3. Neither the name of the copyright holder nor the names of its
  *    contributors may be used to endorse or promote products derived from this
  *    software without specific prior written permission.
@@ -55,7 +55,7 @@ extern "C"
 void wavefield_hdf_init(int rank, const char* outputPrefix,
 		const double* dofs, const double* pstrain,
 		int numVars, int order, int numBasisFuncs,
-        int refinement,  int timestep)
+        int refinement,  int timestep, int* outputMask)
 {
 	seissol::SeisSol::main.waveFieldWriter().enable();
 	seissol::SeisSol::main.waveFieldWriter().setFilename(outputPrefix);
@@ -70,7 +70,7 @@ void wavefield_hdf_init(int rank, const char* outputPrefix,
 		cellMap[i] = i;
 
 	seissol::SeisSol::main.waveFieldWriter().init(numVars, order, numBasisFuncs,
-			meshReader,	dofs, pstrain, cellMap, refinement, timestep, 0);
+			meshReader,	dofs, pstrain, cellMap, refinement, timestep, outputMask, 0);
 
 	// I/O is currently the last initialization that requires the mesh reader
 	seissol::SeisSol::main.freeMeshReader();

--- a/src/ResultWriter/WaveFieldWriterF.f90
+++ b/src/ResultWriter/WaveFieldWriterF.f90
@@ -7,21 +7,21 @@
 !! @section LICENSE
 !! Copyright (c) 2014, SeisSol Group
 !! All rights reserved.
-!! 
+!!
 !! Redistribution and use in source and binary forms, with or without
 !! modification, are permitted provided that the following conditions are met:
-!! 
+!!
 !! 1. Redistributions of source code must retain the above copyright notice,
 !!    this list of conditions and the following disclaimer.
-!! 
+!!
 !! 2. Redistributions in binary form must reproduce the above copyright notice,
 !!    this list of conditions and the following disclaimer in the documentation
 !!    and/or other materials provided with the distribution.
-!! 
+!!
 !! 3. Neither the name of the copyright holder nor the names of its
 !!    contributors may be used to endorse or promote products derived from this
 !!    software without specific prior written permission.
-!! 
+!!
 !! THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 !! AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
 !! IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -47,13 +47,14 @@ module WaveFieldWriter
     ! C functions
     interface
         subroutine wavefield_hdf_init(rank, outputPrefix, dofs, pstrain, numVars, order, &
-                numBasisFuncs, refinement, timestep) bind(C, name="wavefield_hdf_init")
+                numBasisFuncs, refinement, timestep, outputMask) bind(C, name="wavefield_hdf_init")
             use, intrinsic :: iso_c_binding
 
             integer( kind=c_int ), value                       :: rank
             character( kind=c_char ), dimension(*), intent(in) :: outputPrefix
             real( kind=c_double ), dimension(*), intent(in)    :: dofs
             real( kind=c_double ), dimension(*), intent(in)    :: pstrain
+            logical( kind=c_int ), dimension(*), intent(out)   :: outputMask
             integer( kind=c_int ), value                       :: numVars
             integer( kind=c_int ), value                       :: order
             integer( kind=c_int ), value                       :: numBasisFuncs
@@ -89,7 +90,7 @@ contains
             disc%galerkin%dgvar(:, :, :, 1), disc%galerkin%pstrain(:,:), &
             eqn%nVarTotal, disc%spaceorder, &
             disc%galerkin%nDegFr, &
-            io%Refinement, timestep)
+            io%Refinement, timestep, io%OutputMask)
     end subroutine waveFieldWriterInit
 
     subroutine waveFieldWriterWriteStep(time, disc, mesh, mpi)

--- a/src/ResultWriter/inioutput_seissol.f90
+++ b/src/ResultWriter/inioutput_seissol.f90
@@ -5,21 +5,21 @@
 !! @section LICENSE
 !! Copyright (c) SeisSol Group
 !! All rights reserved.
-!! 
+!!
 !! Redistribution and use in source and binary forms, with or without
 !! modification, are permitted provided that the following conditions are met:
-!! 
+!!
 !! 1. Redistributions of source code must retain the above copyright notice,
 !!    this list of conditions and the following disclaimer.
-!! 
+!!
 !! 2. Redistributions in binary form must reproduce the above copyright notice,
 !!    this list of conditions and the following disclaimer in the documentation
 !!    and/or other materials provided with the distribution.
-!! 
+!!
 !! 3. Neither the name of the copyright holder nor the names of its
 !!    contributors may be used to endorse or promote products derived from this
 !!    software without specific prior written permission.
-!! 
+!!
 !! THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 !! AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
 !! IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -64,7 +64,7 @@ MODULE inioutput_SeisSol_mod
 
 CONTAINS
 
-  SUBROUTINE inioutput_SeisSol(time,timestep,pvar,cvar,EQN,IC,MESH,MPI,      &         
+  SUBROUTINE inioutput_SeisSol(time,timestep,pvar,cvar,EQN,IC,MESH,MPI,      &
        SOURCE,DISC,BND,OptionalFields,IO,Analyse, &
        programTitle) !
     !--------------------------------------------------------------------------
@@ -75,7 +75,7 @@ CONTAINS
     USE receiver_mod
 #endif
     USE ini_calcSeisSol_mod
-    USE dg_setup_mod 
+    USE dg_setup_mod
     USE data_output_mod
 
 #ifdef GENERATEDKERNELS
@@ -110,7 +110,7 @@ CONTAINS
     TYPE (tAnalyse)                :: Analyse                                  !
     CHARACTER(LEN=100)             :: programTitle                             !
     ! local variable declaration                                               !
-    CHARACTER(LEN=256)             :: outfile   
+    CHARACTER(LEN=256)             :: outfile
     CHARACTER(LEN=5)               :: cmyrank
     integer                     :: timestepWavefield
     integer                     :: mkdirRet
@@ -193,7 +193,8 @@ CONTAINS
         i_strength  = disc%DynRup%strength,  &
         i_numSides  = mesh%fault%nSide,      &
         i_numBndGP  = disc%galerkin%nBndGP,  &
-        i_refinement= io%Refinement)
+        i_refinement= io%Refinement,         &
+        i_outputMask=io%OutputMask(4:12))
 #else
     if (IO%Format .eq. 6) then
         call waveFieldWriterInit(0, disc, eqn, io, mesh, mpi)

--- a/src/Solver/Interoperability.cpp
+++ b/src/Solver/Interoperability.cpp
@@ -161,9 +161,9 @@ extern "C" {
 
   void c_interoperability_initializeIO( double* mu, double* slipRate1, double* slipRate2,
 		  double* slip, double* slip1, double* slip2, double* state, double* strength,
-		  int numSides, int numBndGP, int refinement) {
+		  int numSides, int numBndGP, int refinement, int* outputMask) {
 	  e_interoperability.initializeIO(mu, slipRate1, slipRate2, slip, slip1, slip2, state, strength,
-			  numSides, numBndGP, refinement);
+			  numSides, numBndGP, refinement, outputMask);
   }
 
   void c_interoperability_addToDofs( int      i_meshId,
@@ -299,13 +299,13 @@ void seissol::Interoperability::initializeClusteredLts( int i_clustering ) {
 
   // get time stepping
   seissol::SeisSol::main.getLtsLayout().getCrossClusterTimeStepping( m_timeStepping );
-  
+
   seissol::SeisSol::main.getMemoryManager().fixateLtsTree(  m_timeStepping,
                                                             m_meshStructure );
 
   m_ltsTree = seissol::SeisSol::main.getMemoryManager().getLtsTree();
   m_lts = seissol::SeisSol::main.getMemoryManager().getLts();
-  
+
   unsigned* ltsToMesh;
   unsigned numberOfMeshCells;
   // get cell information & mappings
@@ -316,9 +316,9 @@ void seissol::Interoperability::initializeClusteredLts( int i_clustering ) {
   m_ltsLut.createLuts(  m_ltsTree,
                         ltsToMesh,
                         numberOfMeshCells );
-                        
+
   delete[] ltsToMesh;
-  
+
   // derive lts setups
   seissol::initializers::time_stepping::deriveLtsSetups( m_timeStepping.numberOfLocalClusters,
                                                          m_meshStructure,
@@ -499,7 +499,7 @@ void seissol::Interoperability::enableCheckPointing( double i_checkPointInterval
 void seissol::Interoperability::initializeIO(
 		  double* mu, double* slipRate1, double* slipRate2,
 		  double* slip, double* slip1, double* slip2, double* state, double* strength,
-		  int numSides, int numBndGP, int refinement)
+		  int numSides, int numBndGP, int refinement, int* outputMask)
 {
 	  // Initialize checkpointing
 	  double currentTime;
@@ -523,7 +523,7 @@ void seissol::Interoperability::initializeIO(
 			  reinterpret_cast<const double*>(m_ltsTree->var(m_lts->dofs)),
 			  reinterpret_cast<const double*>(m_ltsTree->var(m_lts->pstrain)),
 			  m_ltsLut.getMeshToLtsLut(m_lts->dofs.mask)[0],
-			  refinement, waveFieldTimeStep,
+			  refinement, waveFieldTimeStep, outputMask,
 			  seissol::SeisSol::main.timeManager().getTimeTolerance());
 
 	  // I/O initialization is the last step that requires the mesh reader
@@ -579,7 +579,7 @@ void seissol::Interoperability::getFaceDerInt( int    i_meshId,
                                                double o_timeIntegratedNeighbor[NUMBER_OF_DOFS] ) {
   // assert that the cell provides derivatives
   assert( (m_ltsLut.lookup(m_lts->cellInformation, i_meshId-1).ltsSetup >> 9)%2 == 1 );
-  
+
   real*&    derivatives       = m_ltsLut.lookup(m_lts->derivatives, i_meshId-1);
   real*   (&faceNeighbors)[4] = m_ltsLut.lookup(m_lts->faceNeighbors, i_meshId-1);
 

--- a/src/Solver/Interoperability.h
+++ b/src/Solver/Interoperability.h
@@ -80,7 +80,7 @@ class seissol::Interoperability {
 
     //! global data
     struct GlobalData* m_globalData;
-    
+
     seissol::initializers::LTSTree*   m_ltsTree;
     seissol::initializers::LTS*       m_lts;
 
@@ -232,7 +232,7 @@ class seissol::Interoperability {
 
    void initializeIO(double* mu, double* slipRate1, double* slipRate2,
 			  double* slip, double* slip1, double* slip2, double* state, double* strength,
-			  int numSides, int numBndGP, int refinement);
+			  int numSides, int numBndGP, int refinement, int* outputMask);
 
    /**
     * Get the current dynamic rupture time step

--- a/src/Solver/f_ftoc_bind_interoperability.f90
+++ b/src/Solver/f_ftoc_bind_interoperability.f90
@@ -8,21 +8,21 @@
 !! @section LICENSE
 !! Copyright (c) 2015, SeisSol Group
 !! All rights reserved.
-!! 
+!!
 !! Redistribution and use in source and binary forms, with or without
 !! modification, are permitted provided that the following conditions are met:
-!! 
+!!
 !! 1. Redistributions of source code must retain the above copyright notice,
 !!    this list of conditions and the following disclaimer.
-!! 
+!!
 !! 2. Redistributions in binary form must reproduce the above copyright notice,
 !!    this list of conditions and the following disclaimer in the documentation
 !!    and/or other materials provided with the distribution.
-!! 
+!!
 !! 3. Neither the name of the copyright holder nor the names of its
 !!    contributors may be used to endorse or promote products derived from this
 !!    software without specific prior written permission.
-!! 
+!!
 !! THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 !! AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
 !! IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -70,7 +70,7 @@ module f_ftoc_bind_interoperability
       integer(kind=c_int), value :: i_clustering
     end subroutine
   end interface
-  
+
   ! Don't forget to add // c_null_char to NRFFileName when using this interface
   interface
     subroutine c_interoperability_setupNRFPointSources( NRFFileName ) bind( C, name='c_interoperability_setupNRFPointSources' )
@@ -79,7 +79,7 @@ module f_ftoc_bind_interoperability
       character(kind=c_char), dimension(*), intent(in) :: NRFFileName
     end subroutine
   end interface
-  
+
   ! Don't forget to add // c_null_char to NRFFileName when using this interface
   interface
     subroutine c_interoperability_setupFSRMPointSources( momentTensor, numberOfSources, centres, strikes, dips, rakes, onsets, areas, timestep, numberOfSamples, timeHistories ) bind( C, name='c_interoperability_setupFSRMPointSources' )
@@ -114,7 +114,7 @@ module f_ftoc_bind_interoperability
       real(kind=c_double), value :: i_receiverSampling
     end subroutine
   end interface
-  
+
   interface c_interoperability_setMaterial
     subroutine c_interoperability_setMaterial( i_elem, i_side, i_materialVal, i_numMaterialVals ) bind( C, name='c_interoperability_setMaterial' )
     use iso_c_binding
@@ -134,7 +134,7 @@ module f_ftoc_bind_interoperability
       type(c_ptr), value :: i_initialLoading
     end subroutine
   end interface
-  
+
 
   interface c_interoperability_setPlasticParameters
     subroutine c_interoperability_setPlasticParameters( i_meshId, i_plasticParameters ) bind( C, name='c_interoperability_setPlasticParameters' )
@@ -182,7 +182,7 @@ module f_ftoc_bind_interoperability
     end subroutine
 
     subroutine c_interoperability_initializeIO( i_mu, i_slipRate1, i_slipRate2, i_slip, i_slip1, i_slip2, i_state, i_strength, &
-        i_numSides, i_numBndGP, i_refinement ) &
+        i_numSides, i_numBndGP, i_refinement, i_outputMask ) &
         bind( C, name='c_interoperability_initializeIO' )
       use iso_c_binding
       implicit none
@@ -195,6 +195,7 @@ module f_ftoc_bind_interoperability
       real(kind=c_double), dimension(*), intent(in) :: i_slip2
       real(kind=c_double), dimension(*), intent(in) :: i_state
       real(kind=c_double), dimension(*), intent(in) :: i_strength
+      logical(kind=c_int), dimension(*), intent(out) :: i_outputMask
       integer(kind=c_int), value                    :: i_numSides
       integer(kind=c_int), value                    :: i_numBndGP
       integer(kind=c_int), value                    :: i_refinement


### PR DESCRIPTION
The current fix makes it possible to define which variables are to be printed (as per the parameter file) when compiled using asyncio=none and asyncio=thread option.