### PR TITLE
Change logicals to integers

### DIFF
--- a/src/ResultWriter/WaveFieldWriterF.f90
+++ b/src/ResultWriter/WaveFieldWriterF.f90
@@ -54,7 +54,7 @@ module WaveFieldWriter
             character( kind=c_char ), dimension(*), intent(in) :: outputPrefix
             real( kind=c_double ), dimension(*), intent(in)    :: dofs
             real( kind=c_double ), dimension(*), intent(in)    :: pstrain
-            logical( kind=c_int ), dimension(*), intent(out)   :: outputMask
+            integer( kind=c_int ), dimension(*), intent(out)   :: outputMask
             integer( kind=c_int ), value                       :: numVars
             integer( kind=c_int ), value                       :: order
             integer( kind=c_int ), value                       :: numBasisFuncs
@@ -80,17 +80,27 @@ contains
         implicit none
 
         integer, intent(in)    :: timestep
+        integer                :: i
+        integer                :: outputMaskInt(9)
         type (tDiscretization) :: disc
         type (tEquations)      :: eqn
         type (tInputOutput)    :: io
         type (tUnstructMesh)   :: mesh
         type (tMPI)            :: mpi
 
+        do i = 1, 9
+            if ( io%OutputMask(3+i) ) then
+                outputMaskInt(i) = 1
+            else
+                outputMaskInt(i) = 0
+            end if
+        end do
+
         call wavefield_hdf_init(mpi%myRank, trim(io%OutputFile) // c_null_char, &
             disc%galerkin%dgvar(:, :, :, 1), disc%galerkin%pstrain(:,:), &
             eqn%nVarTotal, disc%spaceorder, &
             disc%galerkin%nDegFr, &
-            io%Refinement, timestep, io%OutputMask)
+            io%Refinement, timestep, outputMaskInt)
     end subroutine waveFieldWriterInit
 
     subroutine waveFieldWriterWriteStep(time, disc, mesh, mpi)

--- a/src/ResultWriter/inioutput_seissol.f90
+++ b/src/ResultWriter/inioutput_seissol.f90
@@ -96,6 +96,8 @@ CONTAINS
 #endif
     REAL                           :: time,x,y,Variable(8),k1,k2               !
     INTEGER                        :: timestep                                 !
+    INTEGER                        :: i                                        !
+    INTEGER                        :: outputMaskInt(9)                         !
     REAL,POINTER                   :: pvar(:,:)                                ! @TODO, breuera: remove not used
     REAL,POINTER                   :: cvar(:,:)                                !
     TYPE (tEquations)              :: EQN                                      !
@@ -182,6 +184,13 @@ CONTAINS
 
 
 #ifdef GENERATEDKERNELS
+    do i = 1, 9
+        if ( io%OutputMask(3+i) ) then
+            outputMaskInt(i) = 1
+        else
+            outputMaskInt(i) = 0
+        end if
+    end do
     call c_interoperability_initializeIO(    &
         i_mu        = disc%DynRup%mu,        &
         i_slipRate1 = disc%DynRup%slipRate1, &
@@ -194,7 +203,7 @@ CONTAINS
         i_numSides  = mesh%fault%nSide,      &
         i_numBndGP  = disc%galerkin%nBndGP,  &
         i_refinement= io%Refinement,         &
-        i_outputMask=io%OutputMask(4:12))
+        i_outputMask= outputMaskInt)
 #else
     if (IO%Format .eq. 6) then
         call waveFieldWriterInit(0, disc, eqn, io, mesh, mpi)

--- a/src/Solver/f_ftoc_bind_interoperability.f90
+++ b/src/Solver/f_ftoc_bind_interoperability.f90
@@ -195,7 +195,7 @@ module f_ftoc_bind_interoperability
       real(kind=c_double), dimension(*), intent(in) :: i_slip2
       real(kind=c_double), dimension(*), intent(in) :: i_state
       real(kind=c_double), dimension(*), intent(in) :: i_strength
-      logical(kind=c_int), dimension(*), intent(out) :: i_outputMask
+      integer(kind=c_int), dimension(*), intent(out) :: i_outputMask
       integer(kind=c_int), value                    :: i_numSides
       integer(kind=c_int), value                    :: i_numBndGP
       integer(kind=c_int), value                    :: i_refinement


### PR DESCRIPTION
To avoid warnings from GCC, the logical array has been converted to integer considering that no implicit casting occurs and then passing it to the C function through an integer to integer binding.