### PR TITLE
Integrate quantities

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -154,7 +154,9 @@ vars.AddVariables(
 
   BoolVariable( 'commThread', 'use communication thread for MPI progression (option has no effect when not compiling hybrid target)', False ),
 
-  BoolVariable( 'plasticity', 'enable plasticity (generated kernels only)', False )
+  BoolVariable( 'plasticity', 'enable plasticity (generated kernels only)', False ),
+
+  BoolVariable( 'integrateQuants', 'enable computation and storage of integrated quantities (generated kernels only)', False )
 )
 
 # external variables
@@ -443,6 +445,9 @@ if env['parallelization'] in ['omp', 'hybrid']:
 
 if( env['plasticity'] ):
   env.Append(CPPDEFINES=['USE_PLASTICITY'])
+
+if( env['integrateQuants'] ):
+  env.Append(CPPDEFINES=['INTEGRATE_QUANTITIES'])
 
 # set pre compiler flags for matrix optimizations
 if env['generatedKernels']:

--- a/src/Initializer/MemoryManager.cpp
+++ b/src/Initializer/MemoryManager.cpp
@@ -787,9 +787,7 @@ void seissol::initializers::MemoryManager::fixateLtsTree( struct TimeStepping&  
   
   // Setup tree variables
   m_lts.addTo(m_ltsTree);
-#ifdef INTEGRATE_QUANTITIES
   seissol::SeisSol::main.postProcessor().allocateMemory(&m_ltsTree);
-#endif // INTEGRATE_QUANTITIES
   m_ltsTree.setNumberOfTimeClusters(i_timeStepping.numberOfLocalClusters);
 
   /// From this point, the tree layout, variables, and buckets cannot be changed anymore

--- a/src/Initializer/MemoryManager.cpp
+++ b/src/Initializer/MemoryManager.cpp
@@ -786,6 +786,9 @@ void seissol::initializers::MemoryManager::fixateLtsTree( struct TimeStepping&  
   
   // Setup tree variables
   m_lts.addTo(m_ltsTree);
+#ifdef INTEGRATE_QUANTITIES
+  seissol::SeisSol::main.postProcessor().allocateMemory(&m_ltsTree);
+#endif // INTEGRATE_QUANTITIES
   m_ltsTree.setNumberOfTimeClusters(i_timeStepping.numberOfLocalClusters);
 
   /// From this point, the tree layout, variables, and buckets cannot be changed anymore

--- a/src/Initializer/MemoryManager.cpp
+++ b/src/Initializer/MemoryManager.cpp
@@ -67,6 +67,7 @@
  * @section DESCRIPTION
  * Memory management of SeisSol.
  **/
+#include "SeisSol.h"
 #include "MemoryManager.h"
 #include "InternalState.h"
 

--- a/src/Initializer/ini_seissol.f90
+++ b/src/Initializer/ini_seissol.f90
@@ -109,6 +109,7 @@ CONTAINS
     INTEGER                        :: dummy(4)                                 !
     INTEGER                        :: nGraphVertex                             !
     INTEGER                        :: LocPoly                                  !
+	INTEGER						   :: IntegrationMask(1:9)					   !
     INTEGER, POINTER               :: MetisWeight(:)                           !
     REAL                           :: AnelasticFactor(7,10)                    ! Factor of additional cost due to anelasticity
     REAL                           :: OrderFactor(7)                           ! Factor of additional cost due to order
@@ -207,6 +208,18 @@ CONTAINS
                                                      i_checkPointFilename = trim(io%checkpoint%filename) // c_null_char, &
                                                      i_checkPointBackend = trim(io%checkpoint%backend) // c_null_char )
     endif
+
+#ifdef INTEGRATE_QUANTITIES
+	do i = 1,9
+		if ( io%IntegrationMask(i) ) then
+			IntegrationMask(i) = 1
+		else
+			IntegrationMask(i) = 0
+		end if
+	end do
+
+	call c_interoperability_getIntegrationMask( i_integrationMask = IntegrationMask(1:9) )
+#endif // INTEGRATE_QUANTITIES
 #endif
 
     ! Start mesh reading/computing section

--- a/src/Initializer/tree/LTSTree.hpp
+++ b/src/Initializer/tree/LTSTree.hpp
@@ -104,7 +104,7 @@ public:
     handle.index = varInfo.size();
     handle.mask = mask;
     MemoryInfo m;
-    m.bytes = sizeof(T);
+    m.bytes = sizeof(T)*handle.count;
     m.alignment = alignment;
     m.mask = mask;
     m.memkind = memkind;

--- a/src/Initializer/tree/Layer.hpp
+++ b/src/Initializer/tree/Layer.hpp
@@ -68,8 +68,8 @@ template<typename T>
 struct seissol::initializers::Variable {
   unsigned index;
   LayerMask mask;
-  
-  Variable() : index(std::numeric_limits<unsigned>::max()) {}
+  unsigned count;
+  Variable() : index(std::numeric_limits<unsigned>::max()), count(1) {}
 };
 
 struct seissol::initializers::Bucket {

--- a/src/Initializer/tree/Lut.hpp
+++ b/src/Initializer/tree/Lut.hpp
@@ -130,7 +130,7 @@ public:
   
   template<typename T>
   T& lookup(Variable<T> const& handle, unsigned meshId) const {
-    return m_ltsTree->var(handle)[ltsId(handle.mask, meshId)];
+    return m_ltsTree->var(handle)[ltsId(handle.mask, meshId)*handle.count];
   }
 };
 

--- a/src/Numerical_aux/typesdef.f90
+++ b/src/Numerical_aux/typesdef.f90
@@ -1399,6 +1399,9 @@ MODULE TypesDef
      LOGICAL                      ,POINTER  :: OutputMask(:)                    !< Mask for variable output
                                                                                 !< .TRUE.  = do output for this variable
                                                                                 !< .FALSE. = do no output for this variable
+	 LOGICAL                      ,POINTER  :: IntegrationMask(:)               !< Mask for integrating variables
+                                                                                !< .TRUE.  = integrate and output for this variable
+                                                                                !< .FALSE. = do not integrate and output for this variable
 	 REAL                         ,POINTER  :: OutputRegionBounds(:)            !< Region for which the output should be written
                                                                                 !< Format is xMin, xMax, yMin, yMax, zMin, zMax
      LOGICAL                      ,POINTER  :: RotationMask(:)                  !< Mask for rotational output

--- a/src/Reader/readpar.f90
+++ b/src/Reader/readpar.f90
@@ -151,6 +151,8 @@ CONTAINS
     !                                                                        !
     CALL readpar_output(EQN,DISC,IO,CalledFromStructCode)          !
     !                                                                        !        
+    CALL readpar_postprocessing(IO)          					   !
+    !                                                                        !
     CALL readpar_abort(DISC,IO)                                    !
     !                                                                        !        
     CALL readpar_analyse(ANALYSE,EQN,DISC,IC,IO)                             ! 
@@ -3206,7 +3208,40 @@ ALLOCATE( SpacePositionx(nDirac), &
         logInfo(*) 'Specified dt_fix            : ', DISC%FixTimeStep
         logInfo(*) 'Actual timestep is min of dt_CFL and dt_fix. '                                                     
     !                                                                         
-  END SUBROUTINE readpar_discretisation                              
+  END SUBROUTINE readpar_discretisation
+
+  !===========================================================================
+  ! P O S T P R O C E S S I N G               
+  !===========================================================================
+    SUBROUTINE readpar_postprocessing(IO)
+      !------------------------------------------------------------------------
+      IMPLICIT NONE 
+      !------------------------------------------------------------------------
+      TYPE (tInputOutput)   :: IO
+      !------------------------------------------------------------------------
+      ! local Variables
+      INTEGER               :: allocstat
+      !------------------------------------------------------------------------
+      INTENT(INOUT)      	:: IO
+      !------------------------------------------------------------------------
+      INTEGER				:: IntegrationMask(1:9)
+	  NAMELIST              /Postprocessing/ IntegrationMask
+  !------------------------------------------------------------------------  
+      !                                                                       
+      logInfo(*) '<--------------------------------------------------------->'        
+      logInfo(*) '<  P O S T P R O C E S S I N G                            >'        
+      logInfo(*) '<--------------------------------------------------------->'
+      ! Setting default values
+      IntegrationMask(:) = 0
+      !
+      READ(IO%UNIT%FileIn, nml = Postprocessing)                                                            
+      ALLOCATE(IO%IntegrationMask(9),STAT=allocstat )                        !
+      IF (allocStat .NE. 0) THEN                                             !
+        logError(*) 'could not allocate IO%IntegrationMask in readpar!'      !
+        STOP                                                                 !
+      END IF
+      IO%IntegrationMask(1:9) = IntegrationMask(1:9)
+    END SUBROUTINE readpar_postprocessing                              
                                                                                                    
   !===========================================================================
   ! O U T P U T               

--- a/src/ResultWriter/PostProcessor.cpp
+++ b/src/ResultWriter/PostProcessor.cpp
@@ -38,5 +38,9 @@ void seissol::writer::PostProcessor::allocateMemory(seissol::initializers::LTSTr
 }
 
 const double* seissol::writer::PostProcessor::getIntegrals(seissol::initializers::LTSTree* ltsTree) {
+	if (m_numberOfVariables == 0) {
+		return 0L;
+	} else {
 	return reinterpret_cast<const double*>(ltsTree->var(m_integrals));
+	}
 }

--- a/src/ResultWriter/PostProcessor.cpp
+++ b/src/ResultWriter/PostProcessor.cpp
@@ -53,9 +53,9 @@ void seissol::writer::PostProcessor::integrateQuantities(const double i_timestep
 void seissol::writer::PostProcessor::setIntegrationMask(const int * const i_integrationMask) {
 	unsigned int nextId = 0;
 	for (int i = 0; i < 9; i++) {
-		m_integrationMask[i] = (bool)i_integrationMask[i];
+		m_integrationMask[i] = (i_integrationMask[i] > 0);
 		if (m_integrationMask[i]) {
-			m_integerMap.push_back(nextId);
+			m_integerMap.push_back(i);
 			m_numberOfVariables++;
 			nextId++;
 		}
@@ -67,8 +67,10 @@ int seissol::writer::PostProcessor::getNumberOfVariables() {
 	return m_numberOfVariables;
 }
 
-bool* seissol::writer::PostProcessor::getIntegrationMask() {
-	return m_integrationMask;
+void seissol::writer::PostProcessor::getIntegrationMask(bool* transferTo) {
+	for(int i = 0; i < 9; i++) {
+		transferTo[i] = m_integrationMask[i];
+	}
 }
 
 void seissol::writer::PostProcessor::allocateMemory(seissol::initializers::LTSTree* ltsTree) {

--- a/src/ResultWriter/PostProcessor.cpp
+++ b/src/ResultWriter/PostProcessor.cpp
@@ -1,3 +1,42 @@
+/**
+ * @file
+ * This file is part of SeisSol.
+ *
+ * @author Vishal Sontakke (vishal.sontakke AT tum.de)
+ *
+ * @section LICENSE
+ * Copyright (c) 2016, SeisSol Group
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @section DESCRIPTION
+ */
+
 #include "PostProcessor.h"
 #include "SeisSol.h"
 
@@ -6,14 +45,14 @@ void seissol::writer::PostProcessor::integrateQuantities(const double i_timestep
 	const double * const i_dofs) {
 
 	real (*integrals) = i_layerData.var(m_integrals);
-	for (unsigned int i = 0; i < m_numberOfVariables; i++) {
+	for (int i = 0; i < m_numberOfVariables; i++) {
 		integrals[l_cell*m_numberOfVariables+i] += i_dofs[NUMBER_OF_ALIGNED_BASIS_FUNCTIONS*m_integerMap[i]]*i_timestep;
 	}
 }
 
 void seissol::writer::PostProcessor::setIntegrationMask(const int * const i_integrationMask) {
 	unsigned int nextId = 0;
-	for (unsigned int i = 0; i < 9; i++) {
+	for (int i = 0; i < 9; i++) {
 		m_integrationMask[i] = (bool)i_integrationMask[i];
 		if (m_integrationMask[i]) {
 			m_integerMap.push_back(nextId);
@@ -41,6 +80,6 @@ const double* seissol::writer::PostProcessor::getIntegrals(seissol::initializers
 	if (m_numberOfVariables == 0) {
 		return 0L;
 	} else {
-	return reinterpret_cast<const double*>(ltsTree->var(m_integrals));
+		return reinterpret_cast<const double*>(ltsTree->var(m_integrals));
 	}
 }

--- a/src/ResultWriter/PostProcessor.cpp
+++ b/src/ResultWriter/PostProcessor.cpp
@@ -1,0 +1,42 @@
+#include "PostProcessor.h"
+#include "SeisSol.h"
+
+void seissol::writer::PostProcessor::integrateQuantities(const double i_timestep,
+	seissol::initializers::Layer& i_layerData, const unsigned int l_cell,
+	const double * const i_dofs) {
+
+	real (*integrals) = i_layerData.var(m_integrals);
+	for (unsigned int i = 0; i < m_numberOfVariables; i++) {
+		integrals[l_cell*m_numberOfVariables+i] += i_dofs[NUMBER_OF_ALIGNED_BASIS_FUNCTIONS*m_integerMap[i]]*i_timestep;
+	}
+}
+
+void seissol::writer::PostProcessor::setIntegrationMask(const int * const i_integrationMask) {
+	unsigned int nextId = 0;
+	for (unsigned int i = 0; i < 9; i++) {
+		m_integrationMask[i] = (bool)i_integrationMask[i];
+		if (m_integrationMask[i]) {
+			m_integerMap.push_back(nextId);
+			m_numberOfVariables++;
+			nextId++;
+		}
+	}
+	m_integrals.count = m_numberOfVariables;
+}
+
+int seissol::writer::PostProcessor::getNumberOfVariables() {
+	return m_numberOfVariables;
+}
+
+bool* seissol::writer::PostProcessor::getIntegrationMask() {
+	return m_integrationMask;
+}
+
+void seissol::writer::PostProcessor::allocateMemory(seissol::initializers::LTSTree* ltsTree) {
+	ltsTree->addVar( m_integrals, seissol::initializers::LayerMask(Ghost), PAGESIZE_HEAP,
+      seissol::memory::Standard );
+}
+
+const double* seissol::writer::PostProcessor::getIntegrals(seissol::initializers::LTSTree* ltsTree) {
+	return reinterpret_cast<const double*>(ltsTree->var(m_integrals));
+}

--- a/src/ResultWriter/PostProcessor.h
+++ b/src/ResultWriter/PostProcessor.h
@@ -1,0 +1,42 @@
+#ifndef POST_PROCESSOR_H
+#define POST_PROCESSOR_H
+
+#include <vector>
+#include <Initializer/tree/Layer.hpp>
+#include <Initializer/tree/LTSTree.hpp>
+#include <Initializer/typedefs.hpp>
+
+namespace seissol
+{
+
+namespace writer
+{
+
+class PostProcessor {
+private:
+    bool m_integrationMask[9];
+    int m_numberOfVariables;
+    std::vector<int> m_integerMap;
+    seissol::initializers::Variable<real> m_integrals;
+public:
+    PostProcessor (): m_numberOfVariables(0), m_integerMap(0L) {
+        for (size_t i = 0; i < 9; i++) {
+            m_integrationMask[i] = false;
+        }
+    }
+    virtual ~PostProcessor () {}
+    void integrateQuantities(const double i_timestep,
+    	seissol::initializers::Layer& i_layerData, const unsigned int l_cell,
+    	const double * const i_dofs);
+    void setIntegrationMask(const int * const i_integrationMask);
+    int getNumberOfVariables();
+    bool* getIntegrationMask();
+    void allocateMemory(seissol::initializers::LTSTree* ltsTree);
+    const double* getIntegrals(seissol::initializers::LTSTree* ltsTree);
+};
+
+}
+
+}
+
+#endif // POST_PROCESSOR_H

--- a/src/ResultWriter/PostProcessor.h
+++ b/src/ResultWriter/PostProcessor.h
@@ -70,7 +70,7 @@ public:
     	const double * const i_dofs);
     void setIntegrationMask(const int * const i_integrationMask);
     int getNumberOfVariables();
-    bool* getIntegrationMask();
+    void getIntegrationMask(bool* transferTo);
     void allocateMemory(seissol::initializers::LTSTree* ltsTree);
     const double* getIntegrals(seissol::initializers::LTSTree* ltsTree);
 };

--- a/src/ResultWriter/PostProcessor.h
+++ b/src/ResultWriter/PostProcessor.h
@@ -1,10 +1,50 @@
+/**
+ * @file
+ * This file is part of SeisSol.
+ *
+ * @author Vishal Sontakke (vishal.sontakke AT tum.de)
+ *
+ * @section LICENSE
+ * Copyright (c) 2016, SeisSol Group
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @section DESCRIPTION
+ */
+
 #ifndef POST_PROCESSOR_H
 #define POST_PROCESSOR_H
 
 #include <vector>
+#include <Initializer/typedefs.hpp>
 #include <Initializer/tree/Layer.hpp>
 #include <Initializer/tree/LTSTree.hpp>
-#include <Initializer/typedefs.hpp>
+#include <Initializer/preProcessorMacros.fpp>
 
 namespace seissol
 {

--- a/src/ResultWriter/SConscript
+++ b/src/ResultWriter/SConscript
@@ -59,6 +59,7 @@ writerFiles = [ 'analyse_seissol.f90',
 writerFiles += [ 'WaveFieldWriterC.cpp',
                  'WaveFieldWriterF.f90',
                  'WaveFieldWriter.cpp',
+				 'PostProcessor.cpp',
                  'FaultWriterC.cpp',
                  'FaultWriterF.f90' ]
 

--- a/src/ResultWriter/SConscript
+++ b/src/ResultWriter/SConscript
@@ -59,9 +59,11 @@ writerFiles = [ 'analyse_seissol.f90',
 writerFiles += [ 'WaveFieldWriterC.cpp',
                  'WaveFieldWriterF.f90',
                  'WaveFieldWriter.cpp',
-				 'PostProcessor.cpp',
                  'FaultWriterC.cpp',
                  'FaultWriterF.f90' ]
+
+if env['generatedKernels']:
+	writerFiles += ['PostProcessor.cpp']
 
 for i in writerFiles:
   env.sourceFiles.append(env.Object(i))

--- a/src/ResultWriter/WaveFieldWriter.cpp
+++ b/src/ResultWriter/WaveFieldWriter.cpp
@@ -304,7 +304,6 @@ void seissol::writer::WaveFieldWriter::init(unsigned int numVars,
 		} else {
 			numLowVars = WaveFieldWriterExecutor::NUM_LOWVARIABLES + m_numIntegratedVariables;
 		}
-		logInfo(rank) << "Total number of extra variables " << numLowVars;
 
 		for (unsigned int i = 1; i < numLowVars; i++)
 			addBuffer(0L, pLowMeshRefiner->getNumCells() * sizeof(double));

--- a/src/ResultWriter/WaveFieldWriter.cpp
+++ b/src/ResultWriter/WaveFieldWriter.cpp
@@ -241,14 +241,12 @@ void seissol::writer::WaveFieldWriter::init(unsigned int numVars,
 #ifdef GENERATEDKERNELS
 	// Set up for low order output flags
 	m_lowOutputFlags = new bool[WaveFieldWriterExecutor::NUM_LOWVARIABLES];
+	m_numIntegratedVariables = seissol::SeisSol::main.postProcessor().getNumberOfVariables();
 	for (size_t i = 0; i < WaveFieldWriterExecutor::NUM_PLASTICITY_VARIABLES; i++) {
 		m_lowOutputFlags[i] = (pstrain != 0L);
 	}
-	for (size_t i = 0; i < WaveFieldWriterExecutor::NUM_INTEGRATED_VARIABLES; i++) {
-		m_lowOutputFlags[i+WaveFieldWriterExecutor::NUM_PLASTICITY_VARIABLES] = seissol::SeisSol::main.postProcessor().getIntegrationMask()[i];
-	}
+	seissol::SeisSol::main.postProcessor().getIntegrationMask(&m_lowOutputFlags[WaveFieldWriterExecutor::NUM_PLASTICITY_VARIABLES]);
 	param.bufferIds[LOW_OUTPUT_FLAGS] = addSyncBuffer(m_lowOutputFlags, WaveFieldWriterExecutor::NUM_LOWVARIABLES*sizeof(bool), true);
-	m_numIntegratedVariables = seissol::SeisSol::main.postProcessor().getNumberOfVariables();
 #endif
 	//
 	//  Low order I/O

--- a/src/ResultWriter/WaveFieldWriter.h
+++ b/src/ResultWriter/WaveFieldWriter.h
@@ -84,8 +84,14 @@ class WaveFieldWriter : private async::Module<WaveFieldWriterExecutor, WaveField
 	/** Number of variables */
 	unsigned int m_numVariables;
 
+	/** Number of integrated variables */
+	unsigned int m_numIntegratedVariables;
+
 	/** Flag indicated which variables should be written */
 	bool* m_outputFlags;
+
+	/** Flag indicated which low variables should be written */
+	bool* m_lowOutputFlags;
 
 	/** Refined number of cells */
 	unsigned int m_numCells;
@@ -98,6 +104,9 @@ class WaveFieldWriter : private async::Module<WaveFieldWriterExecutor, WaveField
 
 	/** Pointer to the plastic strain */
 	const double* m_pstrain;
+
+	/** Pointer to the integrals */
+	const double* m_integrals;
 
 	/** Mapping from the cell order to dofs order */
 	unsigned int* m_map;
@@ -130,8 +139,9 @@ public:
 		  m_variableSubsampler(0L),
 		  m_numVariables(0),
 		  m_outputFlags(0L),
+		  m_lowOutputFlags(0L),
 		  m_numCells(0), m_numLowCells(0),
-		  m_dofs(0L), m_pstrain(0L),
+		  m_dofs(0L), m_pstrain(0L), m_integrals(0L),
 		  m_map(0L),
 		  m_lastTimeStep(-1),
 		  m_timeTolerance(0),
@@ -179,7 +189,7 @@ public:
 	 */
 	void init(unsigned int numVars, int order, int numAlignedDOF,
 			const MeshReader &meshReader,
-			const double* dofs,  const double* pstrain,
+			const double* dofs,  const double* pstrain, const double* integrals,
 			unsigned int* map,
 			int refinement, int timestep, int* outputMask, double* outputRegionBounds,
 			double timeTolerance);
@@ -248,6 +258,33 @@ public:
 			}
 		}
 
+		if (m_integrals) {
+			unsigned int offset = 0;
+			unsigned int flagOffset = WaveFieldWriterExecutor::NUM_LOWVARIABLES;
+		if (m_pstrain) {
+				offset = WaveFieldWriterExecutor::NUM_LOWVARIABLES;
+				flagOffset = 0;
+			}
+
+			nextId = offset;
+			for (unsigned int i = offset; i < offset+WaveFieldWriterExecutor::NUM_INTEGRATED_VARIABLES; i++) {
+				if (!m_lowOutputFlags[i+flagOffset])
+					continue;
+				double* managedBuffer = async::Module<WaveFieldWriterExecutor,
+				WaveFieldInitParam, WaveFieldParam>::managedBuffer<double*>(m_variableBufferIds[1]+nextId);
+
+#ifdef _OPENMP
+				#pragma omp parallel for schedule(static)
+#endif // _OPENMP
+				for (unsigned int j = 0; j < m_numLowCells; j++)
+					managedBuffer[j] = m_integrals[m_map[j]
+							* m_numIntegratedVariables + nextId-offset];
+
+				sendBuffer(m_variableBufferIds[1]+nextId, m_numLowCells*sizeof(double));
+				nextId++;
+			}
+		}
+
 		WaveFieldParam param;
 		param.time = time;
 		call(param);
@@ -277,6 +314,8 @@ public:
 		m_variableSubsampler = 0L;
 		delete [] m_outputFlags;
 		m_outputFlags = 0L;
+		delete [] m_lowOutputFlags;
+		m_lowOutputFlags = 0L;
 		if (m_extractRegion) {
 			delete [] m_map;
 			m_map = 0L;

--- a/src/ResultWriter/WaveFieldWriterC.cpp
+++ b/src/ResultWriter/WaveFieldWriterC.cpp
@@ -70,7 +70,7 @@ void wavefield_hdf_init(int rank, const char* outputPrefix,
 		cellMap[i] = i;
 
 	seissol::SeisSol::main.waveFieldWriter().init(numVars, order, numBasisFuncs,
-			meshReader,	dofs, pstrain, cellMap, refinement, timestep, outputMask,
+			meshReader,	dofs, pstrain, 0L, cellMap, refinement, timestep, outputMask,
 			outputRegionBounds, 0);
 
 	// I/O is currently the last initialization that requires the mesh reader

--- a/src/ResultWriter/WaveFieldWriterExecutor.h
+++ b/src/ResultWriter/WaveFieldWriterExecutor.h
@@ -195,7 +195,7 @@ public:
 			m_lowOutputFlags = static_cast<const bool*>(info.buffer(param.bufferIds[LOW_OUTPUT_FLAGS]));
 			// Variables
 			std::vector<const char*> lowVariables;
-			const char* lowVarNames[NUM_TOTALLOWVARS] = {
+			const char* lowVarNames[NUM_LOWVARIABLES] = {
 				"ep_xx",
 				"ep_yy",
 				"ep_zz",
@@ -214,7 +214,7 @@ public:
 				"displacement_z"
 			};
 
-			for (size_t i = 0; i < NUM_TOTALLOWVARS; i++) {
+			for (size_t i = 0; i < NUM_LOWVARIABLES; i++) {
 				if (m_lowOutputFlags[i]) {
 					lowVariables.push_back(lowVarNames[i]);
 				}
@@ -274,7 +274,7 @@ public:
 			m_lowWaveFieldWriter->addTimeStep(param.time);
 
 		nextId = 0;
-		for (unsigned int i = 0; i < NUM_TOTALLOWVARS; i++) {
+		for (unsigned int i = 0; i < NUM_LOWVARIABLES; i++) {
 			if (m_lowOutputFlags[i]) {
 				m_lowWaveFieldWriter->writeData(nextId,
 					static_cast<const double*>(info.buffer(m_variableBufferIds[1]+nextId)));
@@ -306,9 +306,9 @@ public:
 	}
 
 public:
-	static const unsigned int NUM_LOWVARIABLES = 7;
+	static const unsigned int NUM_PLASTICITY_VARIABLES = 7;
 	static const unsigned int NUM_INTEGRATED_VARIABLES = 9;
-	static const unsigned int NUM_TOTALLOWVARS = 16;
+	static const unsigned int NUM_LOWVARIABLES = NUM_PLASTICITY_VARIABLES+NUM_INTEGRATED_VARIABLES;
 };
 
 }

--- a/src/ResultWriter/WaveFieldWriterExecutor.h
+++ b/src/ResultWriter/WaveFieldWriterExecutor.h
@@ -66,6 +66,7 @@ enum BufferTags {
 	VARIABLE0,
 	LOWCELLS,
 	LOWVERTICES,
+	LOW_OUTPUT_FLAGS,
 	LOWVARIABLE0,
 	BUFFERTAG_MAX = LOWVARIABLE0
 };
@@ -100,6 +101,9 @@ private:
 	/** Flag indicated which variables should be written */
 	const bool* m_outputFlags;
 
+	/** Flags indicating which low order variables should be written */
+	const bool* m_lowOutputFlags;
+
 #ifdef USE_MPI
 	/** The MPI communicator for the XDMF writer */
 	MPI_Comm m_comm;
@@ -110,7 +114,8 @@ public:
 		: m_waveFieldWriter(0L),
 		  m_lowWaveFieldWriter(0L),
 		  m_numVariables(0),
-		  m_outputFlags(0L)
+		  m_outputFlags(0L),
+		  m_lowOutputFlags(0L)
 #ifdef USE_MPI
 		  , m_comm(MPI_COMM_NULL)
 #endif // USE_MPI
@@ -186,17 +191,34 @@ public:
 		// Low order I/O
 		//
 		if (param.bufferIds[LOWCELLS] >= 0) {
-			// Pstrain enabled
-
+			// Pstrain or Integrated quantities enabled
+			m_lowOutputFlags = static_cast<const bool*>(info.buffer(param.bufferIds[LOW_OUTPUT_FLAGS]));
 			// Variables
-			std::vector<const char*> lowVariables(NUM_LOWVARIABLES);
-			lowVariables[0] = "ep_xx";
-			lowVariables[1] = "ep_yy";
-			lowVariables[2] = "ep_zz";
-			lowVariables[3] = "ep_xy";
-			lowVariables[4] = "ep_yz";
-			lowVariables[5] = "ep_xz";
-			lowVariables[6] = "eta";
+			std::vector<const char*> lowVariables;
+			const char* lowVarNames[NUM_TOTALLOWVARS] = {
+				"ep_xx",
+				"ep_yy",
+				"ep_zz",
+				"ep_xy",
+				"ep_yz",
+				"ep_xz",
+				"eta",
+				"int_sigma_xx",
+				"int_sigma_yy",
+				"int_sigma_zz",
+				"int_sigma_xy",
+				"int_sigma_yz",
+				"int_sigma_xz",
+				"displacement_x",
+				"displacement_y",
+				"displacement_z"
+			};
+
+			for (size_t i = 0; i < NUM_TOTALLOWVARS; i++) {
+				if (m_lowOutputFlags[i]) {
+					lowVariables.push_back(lowVarNames[i]);
+				}
+			}
 
 			m_lowWaveFieldWriter = new xdmfwriter::XdmfWriter<xdmfwriter::TETRAHEDRON>(
 				rank, (std::string(outputPrefix)+"-low").c_str(), lowVariables, param.timestep);
@@ -251,10 +273,15 @@ public:
 		if (m_lowWaveFieldWriter) {
 			m_lowWaveFieldWriter->addTimeStep(param.time);
 
-			for (unsigned int i = 0; i < NUM_LOWVARIABLES; i++) {
-				m_lowWaveFieldWriter->writeData(i,
-					static_cast<const double*>(info.buffer(m_variableBufferIds[1]+i)));
+		nextId = 0;
+		for (unsigned int i = 0; i < NUM_TOTALLOWVARS; i++) {
+			if (m_lowOutputFlags[i]) {
+				m_lowWaveFieldWriter->writeData(nextId,
+					static_cast<const double*>(info.buffer(m_variableBufferIds[1]+nextId)));
+
+			nextId++;
 			}
+		}
 
 			m_lowWaveFieldWriter->flush();
 		}
@@ -280,6 +307,8 @@ public:
 
 public:
 	static const unsigned int NUM_LOWVARIABLES = 7;
+	static const unsigned int NUM_INTEGRATED_VARIABLES = 9;
+	static const unsigned int NUM_TOTALLOWVARS = 16;
 };
 
 }

--- a/src/SeisSol.h
+++ b/src/SeisSol.h
@@ -51,11 +51,11 @@
 #include "Initializer/time_stepping/LtsLayout.h"
 #include "Checkpoint/Manager.h"
 #include "SourceTerm/Manager.h"
+#include "ResultWriter/PostProcessor.h"
 #endif // GENERATEDKERNELS
 
 #include "ResultWriter/AsyncIO.h"
 #include "ResultWriter/WaveFieldWriter.h"
-#include "ResultWriter/PostProcessor.h"
 
 #define SEISSOL_VERSION_STRING "SVN Mainline"
 
@@ -97,13 +97,14 @@ private:
 
 	/** Source term module */
 	sourceterm::Manager m_sourceTermManager;
+
+	/** PostProcessor module **/
+        writer::PostProcessor m_postProcessor;
+
 #endif // GENERATEDKERNELS
 
 	/** Wavefield output module */
 	writer::WaveFieldWriter m_waveFieldWriter;
-
-	/** PostProcessor module **/
-	writer::PostProcessor m_postProcessor;
 
 private:
 	/**
@@ -160,6 +161,13 @@ public:
 	{
 		return m_sourceTermManager;
 	}
+
+	/** Get the post processor module
+         */
+         writer::PostProcessor& postProcessor()
+         {
+                 return m_postProcessor;
+         }
 #endif // GENERATEDKERNELS
 
 	io::AsyncIO& asyncIO()
@@ -174,13 +182,6 @@ public:
 	{
 		return m_waveFieldWriter;
 	}
-
-	/** Get the post processor module
-	 */
-	 writer::PostProcessor& postProcessor()
-	 {
-		 return m_postProcessor;
-	 }
 
 	/**
 	 * Set the mesh reader

--- a/src/SeisSol.h
+++ b/src/SeisSol.h
@@ -55,6 +55,7 @@
 
 #include "ResultWriter/AsyncIO.h"
 #include "ResultWriter/WaveFieldWriter.h"
+#include "ResultWriter/PostProcessor.h"
 
 #define SEISSOL_VERSION_STRING "SVN Mainline"
 
@@ -100,6 +101,9 @@ private:
 
 	/** Wavefield output module */
 	writer::WaveFieldWriter m_waveFieldWriter;
+
+	/** PostProcessor module **/
+	writer::PostProcessor m_postProcessor;
 
 private:
 	/**
@@ -170,6 +174,13 @@ public:
 	{
 		return m_waveFieldWriter;
 	}
+
+	/** Get the post processor module
+	 */
+	 writer::PostProcessor& postProcessor()
+	 {
+		 return m_postProcessor;
+	 }
 
 	/**
 	 * Set the mesh reader

--- a/src/Solver/Interoperability.cpp
+++ b/src/Solver/Interoperability.cpp
@@ -159,6 +159,10 @@ extern "C" {
     		i_checkPointFilename, i_checkPointBackend );
   }
 
+  void c_interoperability_getIntegrationMask( int* i_integrationMask ) {
+    e_interoperability.getIntegrationMask( i_integrationMask );
+  }
+
   void c_interoperability_initializeIO( double* mu, double* slipRate1, double* slipRate2,
 		  double* slip, double* slip1, double* slip2, double* state, double* strength,
 		  int numSides, int numBndGP, int refinement, int* outputMask, double* outputRegionBounds) {
@@ -478,6 +482,10 @@ void seissol::Interoperability::enableWaveFieldOutput( double i_waveFieldInterva
   seissol::SeisSol::main.waveFieldWriter().setFilename( i_waveFieldFilename );
 }
 
+void seissol::Interoperability::getIntegrationMask( int* i_integrationMask ) {
+  seissol::SeisSol::main.postProcessor().setIntegrationMask(i_integrationMask);
+}
+
 void seissol::Interoperability::enableCheckPointing( double i_checkPointInterval,
 		const char *i_checkPointFilename, const char *i_checkPointBackend ) {
   seissol::SeisSol::main.simulator().setCheckPointInterval( i_checkPointInterval );
@@ -523,6 +531,7 @@ void seissol::Interoperability::initializeIO(
 			  seissol::SeisSol::main.meshReader(),
 			  reinterpret_cast<const double*>(m_ltsTree->var(m_lts->dofs)),
 			  reinterpret_cast<const double*>(m_ltsTree->var(m_lts->pstrain)),
+              seissol::SeisSol::main.postProcessor().getIntegrals(m_ltsTree),
 			  m_ltsLut.getMeshToLtsLut(m_lts->dofs.mask)[0],
 			  refinement, waveFieldTimeStep, outputMask, outputRegionBounds,
 			  seissol::SeisSol::main.timeManager().getTimeTolerance());

--- a/src/Solver/Interoperability.h
+++ b/src/Solver/Interoperability.h
@@ -230,6 +230,11 @@ class seissol::Interoperability {
    void enableCheckPointing( double i_checkPointInterval,
 		   const char *i_checkPointFilename, const char* i_checkPointBackend );
 
+   /**
+    * Gets the integration mask from the parameter file
+    **/
+   void getIntegrationMask( int* i_integrationMask );
+
    void initializeIO(double* mu, double* slipRate1, double* slipRate2,
 			  double* slip, double* slip1, double* slip2, double* state, double* strength,
 			  int numSides, int numBndGP, int refinement, int* outputMask,

--- a/src/Solver/f_ftoc_bind_interoperability.f90
+++ b/src/Solver/f_ftoc_bind_interoperability.f90
@@ -181,6 +181,12 @@ module f_ftoc_bind_interoperability
       character(kind=c_char), dimension(*), intent(in) :: i_checkPointBackend
     end subroutine
 
+    subroutine c_interoperability_getIntegrationMask( i_integrationMask ) bind( C, name='c_interoperability_getIntegrationMask' )
+      use iso_c_binding
+      implicit none
+      integer(kind=c_int), dimension(*), intent(out) :: i_integrationMask
+    end subroutine
+
     subroutine c_interoperability_initializeIO( i_mu, i_slipRate1, i_slipRate2, i_slip, i_slip1, i_slip2, i_state, i_strength, &
         i_numSides, i_numBndGP, i_refinement, i_outputMask, i_outputRegionBounds ) &
         bind( C, name='c_interoperability_initializeIO' )

--- a/src/Solver/time_stepping/TimeCluster.cpp
+++ b/src/Solver/time_stepping/TimeCluster.cpp
@@ -75,6 +75,7 @@
 #include <omp.h>
 #endif
 
+#include "SeisSol.h"
 #include "TimeCluster.h"
 #include <Solver/Interoperability.h>
 #include <SourceTerm/PointSource.h>
@@ -588,6 +589,12 @@ void seissol::time_stepping::TimeCluster::computeNeighboringIntegration( seissol
                                          energy[l_cell],
                                          pstrain[l_cell] );
 #endif
+#ifdef INTEGRATE_QUANTITIES
+  seissol::SeisSol::main.postProcessor().integrateQuantities( m_timeStepWidth,
+                                                              i_layerData,
+                                                              l_cell,
+                                      			              dofs[l_cell] );
+#endif // INTEGRATE_QUANTITIES
   }
 }
 


### PR DESCRIPTION
By setting the `integrateQuants` flag to `yes` while compiling we can enable the computation and storage of 1st order time integration of the variables.

To enable or disable a variable for computation and storage a new section has been incorporated in the parameter file. The following example illustrates the new section:
```
&Postprocessing
IntegrationMask = 0 1 0 1 1 0 0 1 1  ! Integrate and output these vars
/
```
In this example, the variables `sigma_xx`, `sigma_xz`, `sigma_zz` and `u` will not be integrated and stored.