### PR TITLE
Update gmsh2gambit to handle lines and physical names

### DIFF
--- a/preprocessing/meshing/gmsh2gambit/src/GAMBITWriter.h
+++ b/preprocessing/meshing/gmsh2gambit/src/GAMBITWriter.h
@@ -110,7 +110,8 @@ void writeNEU(char const* filename, GMSH<DIM> const& msh) {
     fprintf(file, "       BOUNDARY CONDITIONS 2.0.0\n");
     // collect members in group
     auto region = msh.regions.find(boundaryCondition->first);
-    fprintf(file, "%32d%8d%8lu%8d%8d\n", boundaryCondition->first, 1, boundaryCondition->second.size(), 0, region != msh.regions.end() ? region->second : 6);
+    fprintf(file, "%32s%8d%8lu%8d%8d\n", region != msh.regions.end() ? region->second.name.c_str() : std::to_string(boundaryCondition->first).c_str(),
+            1, boundaryCondition->second.size(), 0, region != msh.regions.end() ? region->second.type : 6);
     for (auto boundary = boundaryCondition->second.begin(); boundary < boundaryCondition->second.end(); ++boundary) {
       fprintf(file, "%10d %5d %5d\n", boundary->element+1, GambitInfo<DIM>::Type, boundary->side+1);
     }

--- a/preprocessing/meshing/gmsh2gambit/src/GAMBITWriter.h
+++ b/preprocessing/meshing/gmsh2gambit/src/GAMBITWriter.h
@@ -78,7 +78,7 @@ void writeNEU(char const* filename, GMSH<DIM> const& msh) {
   }
   fprintf(file, "ENDOFSECTION\n");
 
-  // Tetrahedrons
+  // Tetrahedra
   fprintf(file, "      ELEMENTS/CELLS 2.0.0\n");
   for (unsigned tet = 0; tet < msh.numTetrahedra; ++tet) {
     fprintf(file, "%8d %2d %2d ", tet+1, GambitInfo<DIM>::Type, GMSH<DIM>::Tetrahedron::NumNodes);

--- a/preprocessing/meshing/gmsh2gambit/src/GMSH.cpp
+++ b/preprocessing/meshing/gmsh2gambit/src/GMSH.cpp
@@ -115,6 +115,10 @@ unsigned boundary_code(std::string name)
   return boundary_codes[name];
 }
 
+Region::Region(unsigned id, unsigned type, std::string name)
+  : id(id), type(type), name(name) {}
+Region::Region() : Region(-1, -1, "") {};
+
 // Uses GAMBIT neu conventions. See GAMBIT NEUTRAL FILE FORMAT Appendix C.2.
 template<> unsigned const Simplex<2>::Face2Nodes[][2] = {{0, 1}, {1, 2}, {2, 0}};
 template<> unsigned const Simplex<3>::Face2Nodes[][3] = {{1, 0, 2}, {0, 1, 3}, {1, 2, 3}, {2, 0, 3}};

--- a/preprocessing/meshing/gmsh2gambit/src/GMSH.cpp
+++ b/preprocessing/meshing/gmsh2gambit/src/GMSH.cpp
@@ -109,9 +109,8 @@ void error(std::string const& errMessage)
   exit(-1);
 }
 
-unsigned boundary_code(std::string const& regionName)
+unsigned boundary_code(std::string name)
 {
-  auto name = regionName.substr(1, regionName.size()-2);
   std::transform(name.begin(), name.end(),name.begin(), ::toupper);
   return boundary_codes[name];
 }

--- a/preprocessing/meshing/gmsh2gambit/src/GMSH.cpp
+++ b/preprocessing/meshing/gmsh2gambit/src/GMSH.cpp
@@ -7,17 +7,17 @@
  * @section LICENSE
  * Copyright (c) 2015, SeisSol Group
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
- * 
+ *
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- * 
+ *
  * 3. Neither the name of the copyright holder nor the names of its
  *    contributors may be used to endorse or promote products derived from this
  *    software without specific prior written permission.
@@ -39,8 +39,69 @@
 
 #include "GMSH.h"
 
+#include <algorithm>
 #include <iostream>
 #include <cstdlib>
+#include <unordered_map>
+
+namespace
+{
+  static std::unordered_map<std::string, unsigned> boundary_codes {
+    {"UNSPECIFIED", 0},
+    {"AXIS", 1},
+    {"CONJUGATE", 2},
+    {"CONVECTION", 3},
+    {"CYCLIC", 4},
+    {"DEAD", 5},
+    {"ELEMENT_SID", 6},
+    {"ESPECIES", 7},
+    {"EXHAUST_FAN", 8},
+    {"FAN", 9},
+    {"FREE_SURFACE", 10},
+    {"GAP", 11},
+    {"INFLOW", 12},
+    {"INLET", 13},
+    {"INLET_VENT", 14},
+    {"INTAKE_FAN", 15},
+    {"INTERFACE", 16},
+    {"INTERIOR", 17},
+    {"INTERNAL", 18},
+    {"LIVE", 19},
+    {"MASS_FLOW_INLET", 20},
+    {"MELT", 21},
+    {"MELT_INTERFACE", 22},
+    {"MOVING_BOUNDARY", 23},
+    {"NODE", 24},
+    {"OUTFLOW", 25},
+    {"OUTLET", 26},
+    {"OUTLET_VENT", 27},
+    {"PERIODIC", 28},
+    {"PLOT", 29},
+    {"POROUS", 30},
+    {"POROUS_JUMP", 31},
+    {"PRESSURE", 32},
+    {"PRESSURE_FAR_FIELD", 33},
+    {"PRESSURE_INFLOW", 34},
+    {"PRESSURE_INLET", 35},
+    {"PRESSURE_OUTFLOW", 36},
+    {"PRESSURE_OUTLET", 37},
+    {"RADIATION", 38},
+    {"RADIATOR", 39},
+    {"RECIRCULATION_INLET", 40},
+    {"RECIRCULATION_OUTLET", 41},
+    {"SLIP", 42},
+    {"SREACTION", 43},
+    {"SURFACE", 44},
+    {"SYMMETRY", 45},
+    {"TRACTION", 46},
+    {"TRAJECTORY", 47},
+    {"VELOCITY", 48},
+    {"VELOCITY_INLET", 49},
+    {"VENT", 50},
+    {"WALL", 51},
+    {"SPRING", 52},
+  };
+}
 
 void error(std::string const& errMessage)
 {
@@ -48,7 +109,13 @@ void error(std::string const& errMessage)
   exit(-1);
 }
 
+unsigned boundary_code(std::string const& regionName)
+{
+  auto name = regionName.substr(1, regionName.size()-2);
+  std::transform(name.begin(), name.end(),name.begin(), ::toupper);
+  return boundary_codes[name];
+}
+
 // Uses GAMBIT neu conventions. See GAMBIT NEUTRAL FILE FORMAT Appendix C.2.
 template<> unsigned const Simplex<2>::Face2Nodes[][2] = {{0, 1}, {1, 2}, {2, 0}};
 template<> unsigned const Simplex<3>::Face2Nodes[][3] = {{1, 0, 2}, {0, 1, 3}, {1, 2, 3}, {2, 0, 3}};
-

--- a/preprocessing/meshing/gmsh2gambit/src/GMSH.h
+++ b/preprocessing/meshing/gmsh2gambit/src/GMSH.h
@@ -70,6 +70,16 @@ struct Boundary {
   unsigned side;
 };
 
+struct Region {
+  Region(unsigned id, unsigned type, std::string name)
+    : id(id), type(type), name(name) {}
+  Region() : Region(-1, -1, "") {};
+
+  unsigned id;
+  unsigned type;
+  std::string name;
+};
+
 template<unsigned DIM>
 struct GMSH {
   typedef Simplex<DIM> Tetrahedron;
@@ -84,7 +94,7 @@ struct GMSH {
 
   std::unordered_map<unsigned, std::vector<unsigned> > materialGroups;
   std::unordered_map<unsigned, std::vector<Boundary> > boundaryConditions;
-  std::unordered_map<unsigned, unsigned> regions;
+  std::unordered_map<unsigned, Region> regions;
 
   explicit GMSH(char const* filename);
 
@@ -95,7 +105,7 @@ struct GMSH {
 };
 
 void error(std::string const& errMessage);
-unsigned boundary_code(std::string const& name);
+unsigned boundary_code(std::string name);
 
 template<unsigned DIM>
 GMSH<DIM>::GMSH(char const* filename)
@@ -122,8 +132,9 @@ GMSH<DIM>::GMSH(char const* filename)
         unsigned dim, id;
         std::string name;
         in >> dim >> id >> name;
+        name = name.substr(1, name.size()-2);
 
-        regions[id] = boundary_code(name);
+        regions[id] = Region(id, boundary_code(name), name);
       }
     } else if (block.compare("$Nodes") == 0) {
       in >> numVertices;

--- a/preprocessing/meshing/gmsh2gambit/src/GMSH.h
+++ b/preprocessing/meshing/gmsh2gambit/src/GMSH.h
@@ -43,7 +43,13 @@
 #include <vector>
 #include <unordered_map>
 
-#define MAX_NUMBER_OF_TAGS 16
+namespace
+{
+  #define MAX_NUMBER_OF_TAGS 16
+}
+
+void error(std::string const& errMessage);
+unsigned boundary_code(std::string name);
 
 template<unsigned N>
 struct Simplex {
@@ -71,9 +77,9 @@ struct Boundary {
 };
 
 struct Region {
-  Region(unsigned id, unsigned type, std::string name)
-    : id(id), type(type), name(name) {}
-  Region() : Region(-1, -1, "") {};
+  explicit Region(unsigned id, unsigned type, std::string name);
+  explicit Region();
+  virtual ~Region() = default;
 
   unsigned id;
   unsigned type;
@@ -103,9 +109,6 @@ struct GMSH {
     delete[] tetrahedra;
   }
 };
-
-void error(std::string const& errMessage);
-unsigned boundary_code(std::string name);
 
 template<unsigned DIM>
 GMSH<DIM>::GMSH(char const* filename)


### PR DESCRIPTION
Add capability to parse 3D `msh` files with Line elements. For the case of gambit, the data is simply parsed and ignored.

Also add ability to parse physical name data from a `msh` file and properly translate that information into a gambit boundary condition.