### PR TITLE
Fix pinning for async i/o.

### DIFF
--- a/src/Checkpoint/Manager.h
+++ b/src/Checkpoint/Manager.h
@@ -120,14 +120,12 @@ public:
 	void setUp()
 	{
 		setExecutor(m_executor);
-#if defined(_OPENMP) && defined(USE_MPI)
 		auto freeCpus = parallel::getFreeCPUsMask();
 		logInfo(seissol::MPI::mpi.rank()) << "Checkpoint thread affinity:" << parallel::maskToString(parallel::getFreeCPUsMask());
 		if (parallel::freeCPUsMaskEmpty(freeCpus)) {
 		  logError() << "There are no free CPUs left. Make sure to leave one for the I/O thread(s).";
 		}
 		setAffinityIfNecessary(freeCpus);
-#endif
 	}
 
 	/**

--- a/src/Checkpoint/Manager.h
+++ b/src/Checkpoint/Manager.h
@@ -126,8 +126,8 @@ public:
 		if (parallel::freeCPUsMaskEmpty(freeCpus)) {
 		  logError() << "There are no free CPUs left. Make sure to leave one for the I/O thread(s).";
 		}
-#endif
 		setAffinityIfNecessary(freeCpus);
+#endif
 	}
 
 	/**

--- a/src/Checkpoint/Manager.h
+++ b/src/Checkpoint/Manager.h
@@ -42,6 +42,7 @@
 #define CHECKPOINT_MANAGER_H
 
 #include "Parallel/MPI.h"
+#include "Parallel/Pin.h"
 
 #include <cassert>
 #include <cstring>
@@ -119,6 +120,14 @@ public:
 	void setUp()
 	{
 		setExecutor(m_executor);
+#if defined(_OPENMP) && defined(USE_MPI)
+		auto freeCpus = parallel::getFreeCPUsMask();
+		logInfo(seissol::MPI::mpi.rank()) << "Checkpoint thread affinity:" << parallel::maskToString(parallel::getFreeCPUsMask());
+		if (parallel::freeCPUsMaskEmpty(freeCpus)) {
+		  logError() << "There are no free CPUs left. Make sure to leave one for the I/O thread(s).";
+		}
+#endif
+		setAffinityIfNecessary(freeCpus);
 	}
 
 	/**

--- a/src/Checkpoint/Manager.h
+++ b/src/Checkpoint/Manager.h
@@ -120,12 +120,14 @@ public:
 	void setUp()
 	{
 		setExecutor(m_executor);
-		auto freeCpus = parallel::getFreeCPUsMask();
-		logInfo(seissol::MPI::mpi.rank()) << "Checkpoint thread affinity:" << parallel::maskToString(parallel::getFreeCPUsMask());
-		if (parallel::freeCPUsMaskEmpty(freeCpus)) {
-		  logError() << "There are no free CPUs left. Make sure to leave one for the I/O thread(s).";
+		if (isAffinityNecessary()) {
+		  const auto freeCpus = parallel::getFreeCPUsMask();
+		  logInfo(seissol::MPI::mpi.rank()) << "Checkpoint thread affinity:" << parallel::maskToString(parallel::getFreeCPUsMask());
+		  if (parallel::freeCPUsMaskEmpty(freeCpus)) {
+		    logError() << "There are no free CPUs left. Make sure to leave one for the I/O thread(s).";
+		  }
+		  setAffinityIfNecessary(freeCpus);
 		}
-		setAffinityIfNecessary(freeCpus);
 	}
 
 	/**

--- a/src/ResultWriter/FaultWriter.h
+++ b/src/ResultWriter/FaultWriter.h
@@ -91,14 +91,12 @@ public:
 	void setUp()
 	{
 		setExecutor(m_executor);
-#if defined(_OPENMP) && defined(USE_MPI)
 		auto freeCpus = parallel::getFreeCPUsMask();
 		logInfo(seissol::MPI::mpi.rank()) << "Fault writer thread affinity:" << parallel::maskToString(parallel::getFreeCPUsMask());
 		if (parallel::freeCPUsMaskEmpty(freeCpus)) {
 		  logError() << "There are no free CPUs left. Make sure to leave one for the I/O thread(s).";
 		}
 		setAffinityIfNecessary(freeCpus);
-#endif
 	}
 
 	void setTimestep(unsigned int timestep)

--- a/src/ResultWriter/FaultWriter.h
+++ b/src/ResultWriter/FaultWriter.h
@@ -91,12 +91,14 @@ public:
 	void setUp()
 	{
 		setExecutor(m_executor);
-		auto freeCpus = parallel::getFreeCPUsMask();
-		logInfo(seissol::MPI::mpi.rank()) << "Fault writer thread affinity:" << parallel::maskToString(parallel::getFreeCPUsMask());
-		if (parallel::freeCPUsMaskEmpty(freeCpus)) {
-		  logError() << "There are no free CPUs left. Make sure to leave one for the I/O thread(s).";
+		if (isAffinityNecessary()) {
+		  const auto freeCpus = parallel::getFreeCPUsMask();
+		  logInfo(seissol::MPI::mpi.rank()) << "Fault writer thread affinity:" << parallel::maskToString(parallel::getFreeCPUsMask());
+		  if (parallel::freeCPUsMaskEmpty(freeCpus)) {
+		    logError() << "There are no free CPUs left. Make sure to leave one for the I/O thread(s).";
+		  }
+		  setAffinityIfNecessary(freeCpus);
 		}
-		setAffinityIfNecessary(freeCpus);
 	}
 
 	void setTimestep(unsigned int timestep)

--- a/src/ResultWriter/FaultWriter.h
+++ b/src/ResultWriter/FaultWriter.h
@@ -97,8 +97,8 @@ public:
 		if (parallel::freeCPUsMaskEmpty(freeCpus)) {
 		  logError() << "There are no free CPUs left. Make sure to leave one for the I/O thread(s).";
 		}
-#endif
 		setAffinityIfNecessary(freeCpus);
+#endif
 	}
 
 	void setTimestep(unsigned int timestep)

--- a/src/ResultWriter/FaultWriter.h
+++ b/src/ResultWriter/FaultWriter.h
@@ -41,6 +41,7 @@
 #define FAULTWRITER_H
 
 #include "Parallel/MPI.h"
+#include "Parallel/Pin.h"
 
 #include "utils/logger.h"
 
@@ -90,6 +91,14 @@ public:
 	void setUp()
 	{
 		setExecutor(m_executor);
+#if defined(_OPENMP) && defined(USE_MPI)
+		auto freeCpus = parallel::getFreeCPUsMask();
+		logInfo(seissol::MPI::mpi.rank()) << "Fault writer thread affinity:" << parallel::maskToString(parallel::getFreeCPUsMask());
+		if (parallel::freeCPUsMaskEmpty(freeCpus)) {
+		  logError() << "There are no free CPUs left. Make sure to leave one for the I/O thread(s).";
+		}
+#endif
+		setAffinityIfNecessary(freeCpus);
 	}
 
 	void setTimestep(unsigned int timestep)

--- a/src/ResultWriter/FreeSurfaceWriter.h
+++ b/src/ResultWriter/FreeSurfaceWriter.h
@@ -97,8 +97,8 @@ public:
 		if (parallel::freeCPUsMaskEmpty(freeCpus)) {
 		  logError() << "There are no free CPUs left. Make sure to leave one for the I/O thread(s).";
 		}
-#endif
 		setAffinityIfNecessary(freeCpus);
+#endif
 	}
 
 	void enable();

--- a/src/ResultWriter/FreeSurfaceWriter.h
+++ b/src/ResultWriter/FreeSurfaceWriter.h
@@ -91,12 +91,14 @@ public:
 	void setUp()
 	{
 		setExecutor(m_executor);
-		auto freeCpus = parallel::getFreeCPUsMask();
-		logInfo(seissol::MPI::mpi.rank()) << "Free surface writer thread affinity:" << parallel::maskToString(parallel::getFreeCPUsMask());
-		if (parallel::freeCPUsMaskEmpty(freeCpus)) {
-		  logError() << "There are no free CPUs left. Make sure to leave one for the I/O thread(s).";
+		if (isAffinityNecessary()) {
+		  const auto freeCpus = parallel::getFreeCPUsMask();
+		  logInfo(seissol::MPI::mpi.rank()) << "Free surface writer thread affinity:" << parallel::maskToString(parallel::getFreeCPUsMask());
+		  if (parallel::freeCPUsMaskEmpty(freeCpus)) {
+		    logError() << "There are no free CPUs left. Make sure to leave one for the I/O thread(s).";
+		  }
+		  setAffinityIfNecessary(freeCpus);
 		}
-		setAffinityIfNecessary(freeCpus);
 	}
 
 	void enable();

--- a/src/ResultWriter/FreeSurfaceWriter.h
+++ b/src/ResultWriter/FreeSurfaceWriter.h
@@ -42,6 +42,7 @@
 #define FREESURFACEWRITER_H
 
 #include "Parallel/MPI.h"
+#include "Parallel/Pin.h"
 
 #include <Geometry/MeshReader.h>
 #include <utils/logger.h>
@@ -90,6 +91,14 @@ public:
 	void setUp()
 	{
 		setExecutor(m_executor);
+#if defined(_OPENMP) && defined(USE_MPI)
+		auto freeCpus = parallel::getFreeCPUsMask();
+		logInfo(seissol::MPI::mpi.rank()) << "Free surface writer thread affinity:" << parallel::maskToString(parallel::getFreeCPUsMask());
+		if (parallel::freeCPUsMaskEmpty(freeCpus)) {
+		  logError() << "There are no free CPUs left. Make sure to leave one for the I/O thread(s).";
+		}
+#endif
+		setAffinityIfNecessary(freeCpus);
 	}
 
 	void enable();

--- a/src/ResultWriter/FreeSurfaceWriter.h
+++ b/src/ResultWriter/FreeSurfaceWriter.h
@@ -91,14 +91,12 @@ public:
 	void setUp()
 	{
 		setExecutor(m_executor);
-#if defined(_OPENMP) && defined(USE_MPI)
 		auto freeCpus = parallel::getFreeCPUsMask();
 		logInfo(seissol::MPI::mpi.rank()) << "Free surface writer thread affinity:" << parallel::maskToString(parallel::getFreeCPUsMask());
 		if (parallel::freeCPUsMaskEmpty(freeCpus)) {
 		  logError() << "There are no free CPUs left. Make sure to leave one for the I/O thread(s).";
 		}
 		setAffinityIfNecessary(freeCpus);
-#endif
 	}
 
 	void enable();

--- a/src/ResultWriter/WaveFieldWriter.h
+++ b/src/ResultWriter/WaveFieldWriter.h
@@ -181,14 +181,12 @@ public:
 	void setUp()
 	{
 		setExecutor(m_executor);
-#if defined(_OPENMP) && defined(USE_MPI)
 		auto freeCpus = parallel::getFreeCPUsMask();
 		logInfo(seissol::MPI::mpi.rank()) << "Wave field writer thread affinity:" << parallel::maskToString(parallel::getFreeCPUsMask());
 		if (parallel::freeCPUsMaskEmpty(freeCpus)) {
 		  logError() << "There are no free CPUs left. Make sure to leave one for the I/O thread(s).";
 		}
 		setAffinityIfNecessary(freeCpus);
-#endif
 	}
 
   void setWaveFieldInterval(double interval) {

--- a/src/ResultWriter/WaveFieldWriter.h
+++ b/src/ResultWriter/WaveFieldWriter.h
@@ -41,6 +41,7 @@
 #define WAVE_FIELD_WRITER_H
 
 #include "Parallel/MPI.h"
+#include "Parallel/Pin.h"
 
 #include <algorithm>
 #include <cassert>
@@ -180,6 +181,14 @@ public:
 	void setUp()
 	{
 		setExecutor(m_executor);
+#if defined(_OPENMP) && defined(USE_MPI)
+		auto freeCpus = parallel::getFreeCPUsMask();
+		logInfo(seissol::MPI::mpi.rank()) << "Wave field writer thread affinity:" << parallel::maskToString(parallel::getFreeCPUsMask());
+		if (parallel::freeCPUsMaskEmpty(freeCpus)) {
+		  logError() << "There are no free CPUs left. Make sure to leave one for the I/O thread(s).";
+		}
+#endif
+		setAffinityIfNecessary(freeCpus);
 	}
 
   void setWaveFieldInterval(double interval) {

--- a/src/ResultWriter/WaveFieldWriter.h
+++ b/src/ResultWriter/WaveFieldWriter.h
@@ -181,12 +181,14 @@ public:
 	void setUp()
 	{
 		setExecutor(m_executor);
-		auto freeCpus = parallel::getFreeCPUsMask();
-		logInfo(seissol::MPI::mpi.rank()) << "Wave field writer thread affinity:" << parallel::maskToString(parallel::getFreeCPUsMask());
-		if (parallel::freeCPUsMaskEmpty(freeCpus)) {
-		  logError() << "There are no free CPUs left. Make sure to leave one for the I/O thread(s).";
+		if (isAffinityNecessary()) {
+		  const auto freeCpus = parallel::getFreeCPUsMask();
+		  logInfo(seissol::MPI::mpi.rank()) << "Wave field writer thread affinity:" << parallel::maskToString(parallel::getFreeCPUsMask());
+		  if (parallel::freeCPUsMaskEmpty(freeCpus)) {
+		    logError() << "There are no free CPUs left. Make sure to leave one for the I/O thread(s).";
+		  }
+		  setAffinityIfNecessary(freeCpus);
 		}
-		setAffinityIfNecessary(freeCpus);
 	}
 
   void setWaveFieldInterval(double interval) {

--- a/src/ResultWriter/WaveFieldWriter.h
+++ b/src/ResultWriter/WaveFieldWriter.h
@@ -187,8 +187,8 @@ public:
 		if (parallel::freeCPUsMaskEmpty(freeCpus)) {
 		  logError() << "There are no free CPUs left. Make sure to leave one for the I/O thread(s).";
 		}
-#endif
 		setAffinityIfNecessary(freeCpus);
+#endif
 	}
 
   void setWaveFieldInterval(double interval) {


### PR DESCRIPTION
This fixes some pinning issues with the asyn IO.

Old behavior: I/O thread is pinned to some thread, depending on the implementation in the async library.

New behavior: I/O thread is pinned to threads that are not utilized by OpenMP and thus uses identical pinning as the communication thread.

Related changes in the ASYNC library are [here](https://github.com/TUM-I5/ASYNC/commit/5a55cdf94fad642232e5c48acd92beea8542c3ae)
