### PR TITLE
Optimization of FL103

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -94,6 +94,13 @@ vars.AddVariables(
                 allowed_values=('none', '2', '3', '4', '5', '6', '7', '8')
               ),
 
+  EnumVariable( 'numberOfTemporalIntegrationPoints',
+                'number of temporal integration points used for dynamic rupture',
+                'none',
+                allowed_values=('none', '1', '2', '3', '4', '5', '6', '7', '8')
+              ),
+
+
   ( 'numberOfMechanisms', 'Number of anelastic mechanisms (needs to be set if equations=viscoelastic).', '0' ),
   
   ( 'multipleSimulations', 'Fuse multiple simulations in one run.', '1' ),
@@ -454,6 +461,12 @@ env.Append(CXXFLAGS=['-std=c++11'])
 # set precompiler mode for the number of quantities and basis functions
 env.Append(CPPDEFINES=['CONVERGENCE_ORDER='+env['order']])
 env.Append(CPPDEFINES=['NUMBER_OF_QUANTITIES=' + str(numberOfQuantities[ env['equations'] ]), 'NUMBER_OF_RELAXATION_MECHANISMS=' + str(env['numberOfMechanisms'])])
+
+if env['numberOfTemporalIntegrationPoints'] != 'none':
+  env.Append(CPPDEFINES=['NUMBER_OF_TEMPORAL_INTEGRATION_POINTS={}'.format(env['numberOfTemporalIntegrationPoints'])])
+else:
+  env.Append(CPPDEFINES=['NUMBER_OF_TEMPORAL_INTEGRATION_POINTS={}'.format(env['order'])])
+  
 
 if env['equations'] in ['elastic', 'viscoelastic2']:
   env.Append(CPPDEFINES=['ENABLE_MATRIX_PREFETCH'])

--- a/auto_tuning/proxy/src/proxy_seissol_integrators.hpp
+++ b/auto_tuning/proxy/src/proxy_seissol_integrators.hpp
@@ -190,7 +190,7 @@ void computeDynRupGodunovState()
   DRGodunovData* godunovData = layerData.var(m_dynRup.godunovData);
   real** timeDerivativePlus = layerData.var(m_dynRup.timeDerivativePlus);
   real** timeDerivativeMinus = layerData.var(m_dynRup.timeDerivativeMinus);
-  real (*godunov)[CONVERGENCE_ORDER][seissol::tensor::godunovState::size()] = layerData.var(m_dynRup.godunov);
+  real (*godunov)[NUMBER_OF_TEMPORAL_INTEGRATION_POINTS][seissol::tensor::godunovState::size()] = layerData.var(m_dynRup.godunov);
 
 #ifdef _OPENMP
   #pragma omp parallel for schedule(static)

--- a/src/Initializer/DynamicRupture.h
+++ b/src/Initializer/DynamicRupture.h
@@ -53,7 +53,7 @@ namespace seissol {
 struct seissol::initializers::DynamicRupture {
   Variable<real*>                                                   timeDerivativePlus;
   Variable<real*>                                                   timeDerivativeMinus;
-  Variable<real[CONVERGENCE_ORDER][tensor::godunovState::size()]>   godunov;
+  Variable<real[NUMBER_OF_TEMPORAL_INTEGRATION_POINTS][tensor::godunovState::size()]>   godunov;
   Variable<real[tensor::godunovState::size()]>                      imposedStatePlus;
   Variable<real[tensor::godunovState::size()]>                      imposedStateMinus;
   Variable<DRGodunovData>                                           godunovData;

--- a/src/Kernels/DynamicRupture.cpp
+++ b/src/Kernels/DynamicRupture.cpp
@@ -158,7 +158,6 @@ void seissol::kernels::DynamicRupture::flopsGodunovState( DRFaceInformation cons
   o_nonZeroFlops += kernel::godunovState::nonZeroFlops(faceInfo.minusSide, faceInfo.faceRelation);
   o_hardwareFlops += kernel::godunovState::hardwareFlops(faceInfo.minusSide, faceInfo.faceRelation);
   
-  // TODO(Lukas) Is this correct?
   o_nonZeroFlops *= NUMBER_OF_TEMPORAL_INTEGRATION_POINTS;
   o_hardwareFlops *= NUMBER_OF_TEMPORAL_INTEGRATION_POINTS;
 }

--- a/src/Kernels/DynamicRupture.h
+++ b/src/Kernels/DynamicRupture.h
@@ -73,7 +73,7 @@ class seissol::kernels::DynamicRupture {
                               DRGodunovData const*        godunovData,
                               real const*                 timeDerivativePlus,
                               real const*                 timeDerivativeMinus,
-                              real                        godunov[CONVERGENCE_ORDER][tensor::godunovState::size()],
+                              real                        godunov[NUMBER_OF_TEMPORAL_INTEGRATION_POINTS][tensor::godunovState::size()],
                               real const*                 timeDerivativePlus_prefetch, 
                               real const*                 timeDerivativeMinus_prefetch);
 

--- a/src/Solver/Interoperability.cpp
+++ b/src/Solver/Interoperability.cpp
@@ -810,7 +810,7 @@ void seissol::Interoperability::faultOutput( double i_fullUpdateTime,
 }
 
 void seissol::Interoperability::evaluateFrictionLaw(  int face,
-                                                      real godunov[CONVERGENCE_ORDER][seissol::tensor::godunovState::size()],
+                                                      real godunov[NUMBER_OF_TEMPORAL_INTEGRATION_POINTS][seissol::tensor::godunovState::size()],
                                                       real imposedStatePlus[seissol::tensor::godunovState::size()],
                                                       real imposedStateMinus[seissol::tensor::godunovState::size()],
                                                       double i_fullUpdateTime,

--- a/src/Solver/Interoperability.h
+++ b/src/Solver/Interoperability.h
@@ -359,7 +359,7 @@ class seissol::Interoperability {
    void faultOutput( double i_fullUpdateTime, double i_timeStepWidth );
 
    void evaluateFrictionLaw(  int face,
-                              real   godunov[CONVERGENCE_ORDER][seissol::tensor::godunovState::size()],
+                              real   godunov[NUMBER_OF_TEMPORAL_INTEGRATION_POINTS][seissol::tensor::godunovState::size()],
                               real   imposedStatePlus[seissol::tensor::godunovState::size()],
                               real   imposedStateMinus[seissol::tensor::godunovState::size()],
                               double i_fullUpdateTime,

--- a/src/Solver/f_ctof_bind_interoperability.f90
+++ b/src/Solver/f_ctof_bind_interoperability.f90
@@ -175,7 +175,7 @@ module f_ctof_bind_interoperability
 
       ! convert c to fortran pointers
       call c_f_pointer( i_domain,             l_domain)
-      call c_f_pointer( i_godunov,            l_godunov, [i_godunovLd,9,CONVERGENCE_ORDER])
+      call c_f_pointer( i_godunov,            l_godunov, [i_godunovLd,9,NUMBER_OF_TEMPORAL_INTEGRATION_POINTS])
       call c_f_pointer( i_imposedStatePlus,   l_imposedStatePlus, [i_godunovLd,9])
       call c_f_pointer( i_imposedStateMinus,  l_imposedStateMinus, [i_godunovLd,9])
       call c_f_pointer( i_time,               l_time  )
@@ -190,7 +190,7 @@ module f_ctof_bind_interoperability
       rho_neig = densityMinus
       w_speed_neig(:) = (/ pWaveVelocityMinus, sWaveVelocityMinus, sWaveVelocityMinus /)
 
-      do j=1,CONVERGENCE_ORDER
+      do j=1,NUMBER_OF_TEMPORAL_INTEGRATION_POINTS
         do i=1,i_numberOfPoints
           NorStressGP(i,j) = l_godunov(i,1,j)
           XYStressGP(i,j) = l_godunov(i,4,j)
@@ -207,7 +207,7 @@ module f_ctof_bind_interoperability
       l_imposedStatePlus = 0.0
       l_imposedStateMinus = 0.0
 
-      do j=1,CONVERGENCE_ORDER
+      do j=1,NUMBER_OF_TEMPORAL_INTEGRATION_POINTS
         do i=1,i_numberOfPoints
           l_imposedStateMinus(i,1) = l_imposedStateMinus(i,1) + timeWeights(j) * l_godunov(i,1,j)
           l_imposedStateMinus(i,4) = l_imposedStateMinus(i,4) + timeWeights(j) * TractionGP_XY(i,j)

--- a/src/Solver/time_stepping/TimeCluster.cpp
+++ b/src/Solver/time_stepping/TimeCluster.cpp
@@ -227,15 +227,15 @@ void seissol::time_stepping::TimeCluster::computeDynamicRupture( seissol::initia
 
   m_loopStatistics->begin(m_regionComputeDynamicRupture);
 
-  DRFaceInformation*                    faceInformation                                                   = layerData.var(m_dynRup->faceInformation);
-  DRGodunovData*                        godunovData                                                       = layerData.var(m_dynRup->godunovData);
-  real**                                timeDerivativePlus                                                = layerData.var(m_dynRup->timeDerivativePlus);
-  real**                                timeDerivativeMinus                                               = layerData.var(m_dynRup->timeDerivativeMinus);
-  real                                (*godunov)[CONVERGENCE_ORDER][tensor::godunovState::size()]         = layerData.var(m_dynRup->godunov);
-  real                                (*imposedStatePlus)[tensor::godunovState::size()]                   = layerData.var(m_dynRup->imposedStatePlus);
-  real                                (*imposedStateMinus)[tensor::godunovState::size()]                  = layerData.var(m_dynRup->imposedStateMinus);
-  seissol::model::IsotropicWaveSpeeds*  waveSpeedsPlus                                                    = layerData.var(m_dynRup->waveSpeedsPlus);
-  seissol::model::IsotropicWaveSpeeds*  waveSpeedsMinus                                                   = layerData.var(m_dynRup->waveSpeedsMinus);
+  DRFaceInformation* faceInformation = layerData.var(m_dynRup->faceInformation);
+  DRGodunovData* godunovData = layerData.var(m_dynRup->godunovData);
+  real** timeDerivativePlus = layerData.var(m_dynRup->timeDerivativePlus);
+  real** timeDerivativeMinus  = layerData.var(m_dynRup->timeDerivativeMinus);
+  real (*godunov)[NUMBER_OF_TEMPORAL_INTEGRATION_POINTS][tensor::godunovState::size()] = layerData.var(m_dynRup->godunov);
+  real (*imposedStatePlus)[tensor::godunovState::size()] = layerData.var(m_dynRup->imposedStatePlus);
+  real (*imposedStateMinus)[tensor::godunovState::size()] = layerData.var(m_dynRup->imposedStateMinus);
+  seissol::model::IsotropicWaveSpeeds* waveSpeedsPlus = layerData.var(m_dynRup->waveSpeedsPlus);
+  seissol::model::IsotropicWaveSpeeds* waveSpeedsMinus = layerData.var(m_dynRup->waveSpeedsMinus);
 
 #ifdef _OPENMP
   #pragma omp parallel for schedule(static)


### PR DESCRIPTION
Two optimizations for FL103:

- Newton iteration now checks convergence for each spatial quad node separately.

- Number of time integration points can now be changed to a value independent of the polynomial order of the DG scheme.