### PR TITLE
Use relative path for submodules.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,36 +1,36 @@
 [submodule "submodules/xdmfwriter"]
 	path = submodules/xdmfwriter
-	url = https://github.com/TUM-I5/XdmfWriter.git
+	url = ../../TUM-I5/XdmfWriter.git
 [submodule "submodules/cxxtest"]
 	path = submodules/cxxtest
-	url = https://github.com/CxxTest/cxxtest.git
+	url = ../../CxxTest/cxxtest.git
 [submodule "submodules/utils"]
 	path = submodules/utils
-	url = https://github.com/TUM-I5/utils.git
+	url = ../../TUM-I5/utils.git
 [submodule "submodules/glm"]
 	path = submodules/glm
-	url = https://github.com/g-truc/glm.git
+	url = ../../g-truc/glm.git
 [submodule "submodules/async"]
 	path = submodules/async
-	url = https://github.com/TUM-I5/ASYNC.git
+	url = ../../TUM-I5/ASYNC.git
 [submodule "submodules/scons-tools"]
 	path = submodules/scons-tools
-	url = https://github.com/TUM-I5/scons-tools.git
+	url = ../../TUM-I5/scons-tools.git
 [submodule "submodules/PUML"]
 	path = submodules/PUML
-	url = https://github.com/TUM-I5/PUML2.git
+	url = ../../TUM-I5/PUML2.git
 [submodule "submodules/easi"]
 	path = submodules/easi
-	url = https://github.com/SeisSol/easi.git
+	url = ../../SeisSol/easi.git
 [submodule "submodules/yaml-cpp"]
 	path = submodules/yaml-cpp
-	url = https://github.com/jbeder/yaml-cpp.git
+	url = ../../jbeder/yaml-cpp.git
 [submodule "submodules/ImpalaJIT"]
 	path = submodules/ImpalaJIT
-	url = https://github.com/uphoffc/ImpalaJIT.git
+	url = ../../uphoffc/ImpalaJIT.git
 [submodule "submodules/yateto"]
 	path = submodules/yateto
-	url = https://github.com/SeisSol/yateto.git
+	url = ../../SeisSol/yateto.git
 [submodule "submodules/pythonXdmfReader"]
 	path = submodules/pythonXdmfReader
-	url = https://github.com/Thomas-Ulrich/pythonXdmfReader
+	url = ../../Thomas-Ulrich/pythonXdmfReader


### PR DESCRIPTION
This is a first step towards a repository that allows us to clone SeisSol recursively with
either ssh or https without worrying about changing the .gitmodules file manually.
This is accomplished by using relative paths for submodules.

Before this has a large effect, we'd need to update all dependencies.
Nevertheless, this is a good step towards a cleaner repository.