### PR TITLE
Include an error message, 

### DIFF
--- a/src/Geometry/MeshReaderCBinding.f90
+++ b/src/Geometry/MeshReaderCBinding.f90
@@ -159,6 +159,8 @@ contains
             mesh%Fault%nSide = size(mesh%Fault%Face, 1)
             if (mesh%Fault%nSide .eq. 0) then
                 eqn%DR = 0
+                logError(*) "Did not find dynamic rupture surfaces in the mesh although dynamic rupture was declared in the parameter file."
+                stop
             endif
         endif
 


### PR DESCRIPTION
when one supplies a mesh without dynamic rupture surfaces although dynamic rupture was declared in the parameter file.
Otherwise SeisSol will crash a few moments later and one does not see why in the first place.