### PR TITLE
Remove the error "Did not find dynamic rupture surfaces"

### DIFF
--- a/src/Geometry/MeshReaderCBinding.f90
+++ b/src/Geometry/MeshReaderCBinding.f90
@@ -159,8 +159,6 @@ contains
             mesh%Fault%nSide = size(mesh%Fault%Face, 1)
             if (mesh%Fault%nSide .eq. 0) then
                 eqn%DR = 0
-                logError(*) "Did not find dynamic rupture surfaces in the mesh although dynamic rupture was declared in the parameter file."
-                stop
             endif
         endif
 


### PR DESCRIPTION
as it causes too much trouble.

This has been tested for the TPV12 scenario.