### PR TITLE
Add force sources

### DIFF
--- a/Documentation/point-source-older-implementation.rst
+++ b/Documentation/point-source-older-implementation.rst
@@ -23,6 +23,8 @@ Where source.dat has the following format
    M11 M12 M13
    M21 M22 M23
    M31 M32 M33
+   header line (optional, but has to contain 'velocity' to be recognized)
+   d1 d2 d3    (optional)
    header line (e.g. 'Number of subfaults')
    nsubfaults
    header line (e.g. 'x y z strike dip rake area Onset time')
@@ -40,8 +42,20 @@ Where source.dat has the following format
    STF(2,1)
    ...
    STF(nsubfaults,1)
+   ...
+   STF(nsubfault,ndt)
 
-From the source, it seems that Mij is defined in a fault local
-coordinate system defined by strike, dip and rake, see for instance
-here:
-`https://github.com/SeisSol/SeisSol/blob/master/src/SourceTerm/PointSource.cpp#L45 <https://github.com/SeisSol/SeisSol/blob/master/src/SourceTerm/PointSource.cpp#L45>`__
+Using this implementation one can specify point sources in the following form:
+
+.. math ::
+  \begin{aligned}
+  \frac{\partial}{\partial t}\sigma_{ij} + \dots &= M_{ij} \cdot S_k(t)\cdot \delta(x - \xi_k) \\
+  \rho \frac{\partial}{\partial t} u_i + \dots &= d_i \cdot S_k(t) \cdot \delta(x - \xi_k)
+  \end{aligned}
+
+For details about the source term read section 3.3 of `An arbitrary high-order discontinuous Galerkin method for elastic
+waves on unstructured meshes – I. The two-dimensional isotropic case with external source terms 
+<https://academic.oup.com/gji/article-lookup/doi/10.1111/j.1365-246X.2006.03051.x>`__
+
+Mij is defined in a fault local coordinate system defined by strike, dip and rake, see for instance here:
+`https://github.com/SeisSol/SeisSol/blob/master/src/SourceTerm/PointSource.cpp#L48 <https://github.com/SeisSol/SeisSol/blob/master/src/SourceTerm/PointSource.cpp#L48>`__

--- a/src/Initializer/dg_setup.f90
+++ b/src/Initializer/dg_setup.f90
@@ -595,17 +595,18 @@ CONTAINS
     case(42)
       call c_interoperability_setupNRFPointSources(trim(SOURCE%NRFFileName) // c_null_char)
     case(50)
-      call c_interoperability_setupFSRMPointSources( momentTensor     = SOURCE%RP%MomentTensor,  &
-                                                     numberOfSources  = SOURCE%RP%nSbfs(1),      &
-                                                     centres          = SOURCE%RP%SpacePosition, &
-                                                     strikes          = SOURCE%RP%Strks,         &
-                                                     dips             = SOURCE%RP%Dips,          &
-                                                     rakes            = SOURCE%RP%Rake,          &
-                                                     onsets           = SOURCE%RP%Tonset,        &
-                                                     areas            = SOURCE%RP%Area,          &
-                                                     timestep         = SOURCE%RP%t_samp,        &
-                                                     numberOfSamples  = SOURCE%RP%nsteps,        &
-                                                     timeHistories    = SOURCE%RP%TimeHist       )
+      call c_interoperability_setupFSRMPointSources( momentTensor      = SOURCE%RP%MomentTensor,      &
+                                                     velocityComponent = SOURCE%RP%VelocityComponent, &
+                                                     numberOfSources   = SOURCE%RP%nSbfs(1),          &
+                                                     centres           = SOURCE%RP%SpacePosition,     &
+                                                     strikes           = SOURCE%RP%Strks,             &
+                                                     dips              = SOURCE%RP%Dips,              &
+                                                     rakes             = SOURCE%RP%Rake,              &
+                                                     onsets            = SOURCE%RP%Tonset,            &
+                                                     areas             = SOURCE%RP%Area,              &
+                                                     timestep          = SOURCE%RP%t_samp,            &
+                                                     numberOfSamples   = SOURCE%RP%nsteps,            &
+                                                     timeHistories     = SOURCE%RP%TimeHist       )
     case default
       logError(*) 'Generated Kernels: Unsupported source type: ', SOURCE%Type
       stop

--- a/src/Numerical_aux/typesdef.f90
+++ b/src/Numerical_aux/typesdef.f90
@@ -1409,6 +1409,7 @@ MODULE TypesDef
      REAL, POINTER                   :: n_dip(:)                                !< Normal vector along dip
      REAL, POINTER                   :: corner(:)                               !< Position of the top left corner of the rupture plane
      REAL                            :: MomentTensor(3,3)                       !< The seismic moment tensor
+     REAL                            :: VelocityComponent(3)                    !< The source velocity component
      REAL                            :: TensorRotation(3,3)                     !< The rotation matrix of the moment tensor
      REAL                            :: TensorRotationT(3,3)                    !< The transpose rotation matrix of the moment tensor
      REAL, POINTER                   :: TWindowStart(:)                         !< Point in Time when a Time Window starts

--- a/src/Reader/readpar.f90
+++ b/src/Reader/readpar.f90
@@ -1803,9 +1803,14 @@ CONTAINS
        READ(IO%UNIT%other01,*) SOURCE%RP%MomentTensor(1,:)               ! Read Moment Tensor
        READ(IO%UNIT%other01,*) SOURCE%RP%MomentTensor(2,:)               ! Read Moment Tensor
        READ(IO%UNIT%other01,*) SOURCE%RP%MomentTensor(3,:)               ! Read Moment Tensor
-       READ(IO%UNIT%other01,*)                                           ! Read comment
+       READ(IO%UNIT%other01,'(a15)') char_dummy                          ! Read comment
+       SOURCE%RP%VelocityComponent(:) = 0.
+       IF( index(char_dummy, 'velocity').gt.0 ) THEN                     ! Check for velocity component (optional)
+           READ(IO%UNIT%other01,*) SOURCE%RP%VelocityComponent           ! Read velocity component
+           READ(IO%UNIT%other01,'(a15)')                                 ! Read comment
+       ENDIF 
        READ(IO%UNIT%other01,*) SOURCE%RP%nSbfs(1)                        ! Read number of subfaults
-       READ(IO%UNIT%other01,*)                                           ! Read comment
+       READ(IO%UNIT%other01,*)                                           ! Read comment 
        ALLOCATE ( dummy(8) )
        ALLOCATE ( SOURCE%RP%SpacePosition(3,SOURCE%RP%nSbfs(1)), &
                   SOURCE%RP%Strks(1,SOURCE%RP%nSbfs(1)),         &

--- a/src/Solver/Interoperability.cpp
+++ b/src/Solver/Interoperability.cpp
@@ -87,6 +87,7 @@ extern "C" {
   }
 
   void c_interoperability_setupFSRMPointSources( double*  momentTensor,
+                                                 double*  velocityComponent,
                                                  int      numberOfSources,
                                                  double*  centres,
                                                  double*  strikes,
@@ -99,6 +100,7 @@ extern "C" {
                                                  double*  timeHistories )
   {
     e_interoperability.setupFSRMPointSources( momentTensor,
+                                              velocityComponent,
                                               numberOfSources,
                                               centres,
                                               strikes,
@@ -415,6 +417,7 @@ void seissol::Interoperability::setupNRFPointSources( char const* fileName )
 #endif
 
 void seissol::Interoperability::setupFSRMPointSources( double const* momentTensor,
+                                                       double const* velocityComponent,
                                                        int           numberOfSources,
                                                        double const* centres,
                                                        double const* strikes,
@@ -428,6 +431,7 @@ void seissol::Interoperability::setupFSRMPointSources( double const* momentTenso
 {
   SeisSol::main.sourceTermManager().loadSourcesFromFSRM(
     momentTensor,
+    velocityComponent,
     numberOfSources,
     centres,
     strikes,

--- a/src/Solver/Interoperability.h
+++ b/src/Solver/Interoperability.h
@@ -155,6 +155,7 @@ class seissol::Interoperability {
 
    //! \todo Documentation
    void setupFSRMPointSources( double const* momentTensor,
+                               double const* velocityComponent,
                                int           numberOfSources,
                                double const* centres,
                                double const* strikes,

--- a/src/Solver/f_ftoc_bind_interoperability.f90
+++ b/src/Solver/f_ftoc_bind_interoperability.f90
@@ -92,10 +92,11 @@ module f_ftoc_bind_interoperability
 
   ! Don't forget to add // c_null_char to NRFFileName when using this interface
   interface
-    subroutine c_interoperability_setupFSRMPointSources( momentTensor, numberOfSources, centres, strikes, dips, rakes, onsets, areas, timestep, numberOfSamples, timeHistories ) bind( C, name='c_interoperability_setupFSRMPointSources' )
+    subroutine c_interoperability_setupFSRMPointSources( momentTensor, velocityComponent, numberOfSources, centres, strikes, dips, rakes, onsets, areas, timestep, numberOfSamples, timeHistories ) bind( C, name='c_interoperability_setupFSRMPointSources' )
       use iso_c_binding, only: c_double, c_int
       implicit none
       real(kind=c_double), dimension(*), intent(in) :: momentTensor
+      real(kind=c_double), dimension(*), intent(in) :: velocityComponent 
       integer(kind=c_int), value                    :: numberOfSources
       real(kind=c_double), dimension(*), intent(in) :: centres
       real(kind=c_double), dimension(*), intent(in) :: strikes

--- a/src/Solver/time_stepping/TimeCluster.cpp
+++ b/src/Solver/time_stepping/TimeCluster.cpp
@@ -212,7 +212,6 @@ void seissol::time_stepping::TimeCluster::computeSources() {
         for (unsigned source = startSource; source < endSource; ++source) {
           sourceterm::addTimeIntegratedPointSourceFSRM( m_pointSources->mInvJInvPhisAtSources[source],
                                                         m_pointSources->tensor[source],
-                                                        m_pointSources->velocityComponent[source],
                                                         &m_pointSources->slipRates[source][0],
                                                         m_fullUpdateTime,
                                                         m_fullUpdateTime + m_timeStepWidth,

--- a/src/Solver/time_stepping/TimeCluster.cpp
+++ b/src/Solver/time_stepping/TimeCluster.cpp
@@ -212,6 +212,7 @@ void seissol::time_stepping::TimeCluster::computeSources() {
         for (unsigned source = startSource; source < endSource; ++source) {
           sourceterm::addTimeIntegratedPointSourceFSRM( m_pointSources->mInvJInvPhisAtSources[source],
                                                         m_pointSources->tensor[source],
+                                                        m_pointSources->velocityComponent[source],
                                                         &m_pointSources->slipRates[source][0],
                                                         m_fullUpdateTime,
                                                         m_fullUpdateTime + m_timeStepWidth,

--- a/src/SourceTerm/Manager.cpp
+++ b/src/SourceTerm/Manager.cpp
@@ -269,6 +269,10 @@ void seissol::sourceterm::Manager::loadSourcesFromFSRM( double const*           
   for (unsigned i = 0; i < 9; ++i) {
     *(&localMomentTensor[0][0] + i) = momentTensor[i];
   }
+  real localVelocityComponent[3];
+  for (unsigned i = 0; i < 3; i++) {
+    localVelocityComponent[i] = velocityComponent[i];
+  }
   
   sources = new PointSources[ltsTree->numChildren()];
   for (unsigned cluster = 0; cluster < ltsTree->numChildren(); ++cluster) {
@@ -295,7 +299,7 @@ void seissol::sourceterm::Manager::loadSourcesFromFSRM( double const*           
                                                        sources[cluster].mInvJInvPhisAtSources[clusterSource] );
 
       transformMomentTensor( localMomentTensor,
-                             velocityComponent,
+                             localVelocityComponent,
                              strikes[fsrmIndex],
                              dips[fsrmIndex],
                              rakes[fsrmIndex],

--- a/src/SourceTerm/Manager.cpp
+++ b/src/SourceTerm/Manager.cpp
@@ -303,8 +303,8 @@ void seissol::sourceterm::Manager::loadSourcesFromFSRM( double const*           
                              strikes[fsrmIndex],
                              dips[fsrmIndex],
                              rakes[fsrmIndex],
-                             sources[cluster].tensor[clusterSource],
-                             sources[cluster].velocityComponent[clusterSource]);
+                             sources[cluster].tensor[clusterSource]);
+
       for (unsigned i = 0; i < 9; ++i) {
         sources[cluster].tensor[clusterSource][i] *= areas[fsrmIndex];
       }

--- a/src/SourceTerm/Manager.cpp
+++ b/src/SourceTerm/Manager.cpp
@@ -282,10 +282,6 @@ void seissol::sourceterm::Manager::loadSourcesFromFSRM( double const*           
     if (error) {
       logError() << "posix_memalign failed in source term manager.";
     }
-    error = posix_memalign(reinterpret_cast<void**>(&sources[cluster].velocityComponent), ALIGNMENT, 3*sizeof(real));
-    if (error) {
-      logError() << "posix_memalign failed in source term manager.";
-    }
     sources[cluster].slipRates             = new PiecewiseLinearFunction1D[cmps[cluster].numberOfSources][3];
 
     for (unsigned clusterSource = 0; clusterSource < cmps[cluster].numberOfSources; ++clusterSource) {
@@ -310,8 +306,7 @@ void seissol::sourceterm::Manager::loadSourcesFromFSRM( double const*           
       }
       seissol::model::Material& material = ltsLut->lookup(lts->material, meshIds[sourceIndex] - 1).local;
       for (unsigned i = 0; i < 3; ++i) {
-        sources[cluster].velocityComponent[clusterSource][i] *= areas[fsrmIndex];
-        sources[cluster].velocityComponent[clusterSource][i] /= material.rho;
+        sources[cluster].tensor[clusterSource][6+i] /= material.rho;
       }
 
       samplesToPiecewiseLinearFunction1D( &timeHistories[fsrmIndex * numberOfSamples],

--- a/src/SourceTerm/Manager.h
+++ b/src/SourceTerm/Manager.h
@@ -80,8 +80,8 @@ public:
                                   seissol::initializers::LTS*     lts,
                                   seissol::initializers::Lut*     ltsLut );
 
-  /// \todo Throw this out
   void loadSourcesFromFSRM( double const*                   momentTensor,
+                            double const*                   velocityComponent,
                             int                             numberOfSources,
                             double const*                   centres,
                             double const*                   strikes,

--- a/src/SourceTerm/PointSource.cpp
+++ b/src/SourceTerm/PointSource.cpp
@@ -50,8 +50,7 @@ void seissol::sourceterm::transformMomentTensor(real const i_localMomentTensor[3
                                                 real strike,
                                                 real dip,
                                                 real rake,
-                                                real o_momentTensor[NUMBER_OF_QUANTITIES],
-                                                real o_velocityComponent[3])
+                                                real o_forceComponents[NUMBER_OF_QUANTITIES])
 {
   real cstrike = cos(strike);
   real sstrike = sin(strike);
@@ -86,26 +85,30 @@ void seissol::sourceterm::transformMomentTensor(real const i_localMomentTensor[3
       }
     }
   }
+  real f[3] = {0.0, 0.0, 0.0};
+  for (unsigned j = 0; j < 3; ++j) {
+    for (unsigned k = 0; k < 3; ++k) {
+        f[k] += R[k][j] * i_localVelocityComponent[j];
+    }
+  }
   
 #if NUMBER_OF_QUANTITIES < 6
   #error You cannot use PointSource with less than 6 quantities.
 #endif
   
   // Save in order (\sigma_{xx}, \sigma_{yy}, \sigma_{zz}, \sigma_{xy}, \sigma_{yz}, \sigma_{xz}, u, v, w)
-  o_momentTensor[0] = M[0][0];
-  o_momentTensor[1] = M[1][1];
-  o_momentTensor[2] = M[2][2];
-  o_momentTensor[3] = M[0][1];
-  o_momentTensor[4] = M[1][2];
-  o_momentTensor[5] = M[0][2];
-  for (unsigned m = 6; m < NUMBER_OF_QUANTITIES; ++m) {
-    o_momentTensor[m] = 0.0;
-  }
+  o_forceComponents[0] = M[0][0];
+  o_forceComponents[1] = M[1][1];
+  o_forceComponents[2] = M[2][2];
+  o_forceComponents[3] = M[0][1];
+  o_forceComponents[4] = M[1][2];
+  o_forceComponents[5] = M[0][2];
+  o_forceComponents[6] = f[0];
+  o_forceComponents[7] = f[1];
+  o_forceComponents[8] = f[2];
 
-  for (unsigned j = 0; j < 3; ++j) {
-    for (unsigned k = 0; k < 3; ++k) {
-        o_velocityComponent[k] += R[k][j] * i_localVelocityComponent[j];
-    }
+  for (unsigned m = 9; m < NUMBER_OF_QUANTITIES; ++m) {
+    o_forceComponents[m] = 0.0;
   }
 }
 
@@ -184,25 +187,16 @@ void seissol::sourceterm::addTimeIntegratedPointSourceNRF( real const i_mInvJInv
 }
 
 void seissol::sourceterm::addTimeIntegratedPointSourceFSRM( real const i_mInvJInvPhisAtSources[tensor::mInvJInvPhisAtSources::size()],
-                                                            real const i_momentTensor[tensor::momentFSRM::size()],
-                                                            real const i_velocityComponent[3],
+                                                            real const i_forceComponents[tensor::momentFSRM::size()],
                                                             PiecewiseLinearFunction1D const* i_pwLF,
                                                             double i_fromTime,
                                                             double i_toTime,
                                                             real o_dofUpdate[tensor::Q::size()] )
 {
-  real moment[tensor::momentFSRM::size()];
-  for(int i = 0; i < 6; i++)
-    moment[i] = i_momentTensor[i];
-  for(int i = 0; i < 3; i++)
-    moment[6+i] = i_velocityComponent[i];
-  for(unsigned i = 9; i < tensor::momentFSRM::size(); i++)
-    moment[i] = 0;
-
   kernel::sourceFSRM krnl;
   krnl.Q = o_dofUpdate;
   krnl.mInvJInvPhisAtSources = i_mInvJInvPhisAtSources;
-  krnl.momentFSRM = moment;
+  krnl.momentFSRM = i_forceComponents;
   krnl.stfIntegral = computePwLFTimeIntegral(i_pwLF, i_fromTime, i_toTime);
 #ifdef MULTIPLE_SIMULATIONS
   krnl.oneSimToMultSim = init::oneSimToMultSim::Values;

--- a/src/SourceTerm/PointSource.h
+++ b/src/SourceTerm/PointSource.h
@@ -64,10 +64,12 @@ namespace seissol {
      *
      **/    
     void transformMomentTensor(real const i_localMomentTensor[3][3],
+                               real const i_localVelocityComponent[3],
                                real strike,
                                real dip,
                                real rake,
-                               real o_momentTensor[NUMBER_OF_QUANTITIES]);
+                               real o_momentTensor[NUMBER_OF_QUANTITIES],
+                               real o_velocityComponente[3]);
 
     /** Converts equally spaced time samples to a one-dimensional
      *  piecewise linear function.
@@ -141,6 +143,7 @@ namespace seissol {
      **/                                      
     void addTimeIntegratedPointSourceFSRM( real const i_mInvJInvPhisAtSources[tensor::mInvJInvPhisAtSources::size()],
                                            real const i_momentTensor[tensor::momentFSRM::size()],
+                                           real const i_velocityComponent[3],
                                            PiecewiseLinearFunction1D const* i_pwLF,
                                            double i_fromTime,
                                            double i_toTime,

--- a/src/SourceTerm/PointSource.h
+++ b/src/SourceTerm/PointSource.h
@@ -68,8 +68,7 @@ namespace seissol {
                                real strike,
                                real dip,
                                real rake,
-                               real o_momentTensor[NUMBER_OF_QUANTITIES],
-                               real o_velocityComponente[3]);
+                               real o_forceComponents[NUMBER_OF_QUANTITIES]);
 
     /** Converts equally spaced time samples to a one-dimensional
      *  piecewise linear function.
@@ -142,8 +141,7 @@ namespace seissol {
      * be scaled with the time integral of the source term).
      **/                                      
     void addTimeIntegratedPointSourceFSRM( real const i_mInvJInvPhisAtSources[tensor::mInvJInvPhisAtSources::size()],
-                                           real const i_momentTensor[tensor::momentFSRM::size()],
-                                           real const i_velocityComponent[3],
+                                           real const i_forceComponents[tensor::momentFSRM::size()],
                                            PiecewiseLinearFunction1D const* i_pwLF,
                                            double i_fromTime,
                                            double i_toTime,

--- a/src/SourceTerm/typedefs.hpp
+++ b/src/SourceTerm/typedefs.hpp
@@ -75,8 +75,6 @@ namespace seissol {
        * FSRM: Moment tensor */
       real (*tensor)[TensorSize];
 
-      real (*velocityComponent)[3];
-
       /// mu*Area
       real *muA;
 

--- a/src/SourceTerm/typedefs.hpp
+++ b/src/SourceTerm/typedefs.hpp
@@ -75,6 +75,8 @@ namespace seissol {
        * FSRM: Moment tensor */
       real (*tensor)[TensorSize];
 
+      real (*velocityComponent)[3];
+
       /// mu*Area
       real *muA;
 

--- a/src/tests/Physics/PointSource.t.h
+++ b/src/tests/Physics/PointSource.t.h
@@ -68,10 +68,9 @@ public:
     };
     real l_localVelocityComponent[3] = {0.0, 0.0, 0.0};
 
-    real l_velocityComponent[3];
     real l_momentTensor[NUMBER_OF_QUANTITIES];
     
-    seissol::sourceterm::transformMomentTensor(l_localMomentTensorXY, l_localVelocityComponent, strike, dip, rake, l_momentTensor, l_velocityComponent);
+    seissol::sourceterm::transformMomentTensor(l_localMomentTensorXY, l_localVelocityComponent, strike, dip, rake, l_momentTensor);
     
     // Compare to hand-computed reference solution
     TS_ASSERT_DELTA(l_momentTensor[0], -5.0*sqrt(3.0)/32.0, 100 * EPSILON);
@@ -96,7 +95,7 @@ public:
       {  0.602398893453385,   1.572402458710038,   2.769437029884877 },
     };
     
-    seissol::sourceterm::transformMomentTensor(l_localMomentTensorXZ, l_localVelocityComponent, strike, dip, rake, l_momentTensor, l_velocityComponent);
+    seissol::sourceterm::transformMomentTensor(l_localMomentTensorXZ, l_localVelocityComponent, strike, dip, rake, l_momentTensor);
     
     // Compare to hand-computed reference solution
     TS_ASSERT_DELTA(l_momentTensor[0], -0.415053502680640, 100 * EPSILON);

--- a/src/tests/Physics/PointSource.t.h
+++ b/src/tests/Physics/PointSource.t.h
@@ -68,10 +68,10 @@ public:
     };
     real l_localVelocityComponent[3] = {0.0, 0.0, 0.0};
 
-    real l_veloctiyComponent[3];
+    real l_velocityComponent[3];
     real l_momentTensor[NUMBER_OF_QUANTITIES];
     
-    seissol::sourceterm::transformMomentTensor(l_localMomentTensorXY, l_localVelocityComponent, strike, dip, rake, l_momentTensor, l_veloctiyComponent);
+    seissol::sourceterm::transformMomentTensor(l_localMomentTensorXY, l_localVelocityComponent, strike, dip, rake, l_momentTensor, l_velocityComponent);
     
     // Compare to hand-computed reference solution
     TS_ASSERT_DELTA(l_momentTensor[0], -5.0*sqrt(3.0)/32.0, 100 * EPSILON);
@@ -96,7 +96,7 @@ public:
       {  0.602398893453385,   1.572402458710038,   2.769437029884877 },
     };
     
-    seissol::sourceterm::transformMomentTensor(l_localMomentTensorXZ, l_localVelocityComponent, strike, dip, rake, l_momentTensor, l_veloctiyComponent);
+    seissol::sourceterm::transformMomentTensor(l_localMomentTensorXZ, l_localVelocityComponent, strike, dip, rake, l_momentTensor, l_velocityComponent);
     
     // Compare to hand-computed reference solution
     TS_ASSERT_DELTA(l_momentTensor[0], -0.415053502680640, 100 * EPSILON);

--- a/src/tests/Physics/PointSource.t.h
+++ b/src/tests/Physics/PointSource.t.h
@@ -66,10 +66,12 @@ public:
       { 1.0, 0.0, 0.0 },
       { 0.0, 0.0, 0.0 },
     };
-    
+    real l_localVelocityComponent[3] = {0.0, 0.0, 0.0};
+
+    real l_veloctiyComponent[3];
     real l_momentTensor[NUMBER_OF_QUANTITIES];
     
-    seissol::sourceterm::transformMomentTensor(l_localMomentTensorXY, strike, dip, rake, l_momentTensor);
+    seissol::sourceterm::transformMomentTensor(l_localMomentTensorXY, l_localVelocityComponent, strike, dip, rake, l_momentTensor, l_veloctiyComponent);
     
     // Compare to hand-computed reference solution
     TS_ASSERT_DELTA(l_momentTensor[0], -5.0*sqrt(3.0)/32.0, 100 * EPSILON);
@@ -94,7 +96,7 @@ public:
       {  0.602398893453385,   1.572402458710038,   2.769437029884877 },
     };
     
-    seissol::sourceterm::transformMomentTensor(l_localMomentTensorXZ, strike, dip, rake, l_momentTensor);
+    seissol::sourceterm::transformMomentTensor(l_localMomentTensorXZ, l_localVelocityComponent, strike, dip, rake, l_momentTensor, l_veloctiyComponent);
     
     // Compare to hand-computed reference solution
     TS_ASSERT_DELTA(l_momentTensor[0], -0.415053502680640, 100 * EPSILON);


### PR DESCRIPTION
Until now it was not possible to use point sources acting on the velocity components directly. This pull request adds this new feature. 
The feature is implemented for the old version of point sources (Type = 50). After the moment tensor block you can now specify an optional velocity component for the three space dimension.
The feature was tested against an analytic solution. The force is located at the origin and acting in direction (1, 1, 0). The time history is a Ricker impulse. Receivers are placed at (0.0, 0.0, 500.0), (0.0, 500.0, 0.0), (500.0, 0.0, 0.0). See attached pictures for comparisons between the analytic and numerical solution. 
![Receiver_1](https://user-images.githubusercontent.com/24592027/65589112-d72b5b80-df88-11e9-8d21-e59affaf5f07.png)
![Receiver_2](https://user-images.githubusercontent.com/24592027/65589113-d72b5b80-df88-11e9-9a26-ede44e2fc143.png)
![Receiver_3](https://user-images.githubusercontent.com/24592027/65589115-d72b5b80-df88-11e9-8ce1-41534d9361d5.png)
Note that the resolution is quite rough (66,000 cells) so sharp features are not well resolved. Nevertheless, the results show, that the implementation does what it is supposed to do.