### PR TITLE
Sr imposed on dr boundary

### DIFF
--- a/Documentation/dynamic-rupture.rst
+++ b/Documentation/dynamic-rupture.rst
@@ -154,7 +154,7 @@ Linear-Slip Weakening Friction
 Rate-and-State Friction
 ^^^^^^^^^^^^^^^^^^^^^^^
 
-Slip-rate imposed on a DR Boundary Condition
+Slip-rate imposed on a DR boundary condition
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 This friction law allows imposing slip-rate on a dynamic rupture boundary (potentially any kinematic models, but the current implementation is limited, see below).
 The FL id for this friction law is 33.

--- a/Documentation/dynamic-rupture.rst
+++ b/Documentation/dynamic-rupture.rst
@@ -158,15 +158,15 @@ Slip-rate imposed on a DR boundary condition
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 This friction law allows imposing slip-rate on a dynamic rupture boundary (potentially any kinematic models, but the current implementation is limited, see below).
 The FL id for this friction law is 33.
-The potential advantages of this approch, compared to a multi point-sources representation are:
-
-- offset discontinuity at the free-surface accurately accounted for
-- wavefield (including final stress or displacement) not impacted by the discretization in the near-field.
+The advantage of this approach compared to a multi point-sources representation is that the fault slip is not condensed to points. 
+Therefore the discontinuity of the displacement across the fault can be accurately accounted for, and more generally the wavefield is accurate in the near-field.
 
 The current implementation allows imposing a slip distribution on the DR Boundary using the same arbitrary smooth-step SR function everywhere on the fault.
 The slip distribution is imposed simultaneously everywhere on the fault, smoothly over a time ``t_0``, where ``t_0`` is a parameter of the ``DynamicRupture`` namelist.
 This is an expensive way of getting the final stress distribution from a given slip distribution.
-The slip distribution is defined using easi by the ``strike_slip`` and ``dip_slip`` variables. Below is an example of input file for defining the slip distribution:
+The slip distribution is defined using easi by the ``strike_slip`` and ``dip_slip`` variables. 
+Warning: the direction of positive ``strike_slip`` and ``dip_slip`` is based on the convention of Seissol (e.g. positive strike_slip for right-lateral faulting). 
+Below is an example of input file for defining the slip distribution:
 
 .. code-block:: YAML
 
@@ -186,11 +186,4 @@ The slip distribution is defined using easi by the ``strike_slip`` and ``dip_sli
           map:
             strike_slip: 0.05
             dip_slip: 0.05
-    #T_n,T_s,T_d are given to avoid crash when SeisSol try defining 'faultParameterizedByTraction' 
-    [T_n,T_s,T_d]: !ConstantMap
-      map:
-        T_n: 0.0
-        T_s: 0.0
-        T_d: 0.0
-
 

--- a/Documentation/dynamic-rupture.rst
+++ b/Documentation/dynamic-rupture.rst
@@ -153,3 +153,44 @@ Linear-Slip Weakening Friction
 
 Rate-and-State Friction
 ^^^^^^^^^^^^^^^^^^^^^^^
+
+Slip-rate imposed on a DR Boundary Condition
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+This friction law allows imposing slip-rate on a dynamic rupture boundary (potentially any kinematic models, but the current implementation is limited, see below).
+The FL id for this friction law is 33.
+The potential advantages of this approch, compared to a multi point-sources representation are:
+
+- offset discontinuity at the free-surface accurately accounted for
+- wavefield (including final stress or displacement) not impacted by the discretization in the near-field.
+
+The current implementation allows imposing a slip distribution on the DR Boundary using the same arbitrary smooth-step SR function everywhere on the fault.
+The slip distribution is imposed simultaneously everywhere on the fault, smoothly over a time ``t_0``, where ``t_0`` is a parameter of the ``DynamicRupture`` namelist.
+This is an expensive way of getting the final stress distribution from a given slip distribution.
+The slip distribution is defined using easi by the ``strike_slip`` and ``dip_slip`` variables. Below is an example of input file for defining the slip distribution:
+
+.. code-block:: YAML
+
+    !Switch
+    [strike_slip, dip_slip]: !Any
+      components:
+       - !AxisAlignedCuboidalDomainFilter
+          limits:
+            x: [-1000, 0]
+            y: [-1e10, 1e10]
+            z: [-5000, -3000]
+          components: !ConstantMap
+            map:
+              strike_slip:   0.01
+              dip_slip: 0.1
+       - !ConstantMap
+          map:
+            strike_slip: 0.05
+            dip_slip: 0.05
+    #T_n,T_s,T_d are given to avoid crash when SeisSol try defining 'faultParameterizedByTraction' 
+    [T_n,T_s,T_d]: !ConstantMap
+      map:
+        T_n: 0.0
+        T_s: 0.0
+        T_d: 0.0
+
+

--- a/src/Numerical_aux/create_fault_rotationmatrix.f90
+++ b/src/Numerical_aux/create_fault_rotationmatrix.f90
@@ -47,9 +47,13 @@ MODULE create_fault_rotationmatrix_mod
   PRIVATE
   !---------------------------------------------------------------------------!
   PUBLIC  :: create_fault_rotationmatrix
+  PUBLIC  :: create_strike_dip_unit_vectors
   !---------------------------------------------------------------------------!  
   INTERFACE create_fault_rotationmatrix
      MODULE PROCEDURE create_fault_rotationmatrix
+  END INTERFACE
+  INTERFACE create_strike_dip_unit_vectors
+     MODULE PROCEDURE create_strike_dip_unit_vectors
   END INTERFACE
 
 CONTAINS
@@ -91,6 +95,29 @@ CONTAINS
     ! s = MESH%Fault%geoTangent1(1:3,iFace)
     ! t = MESH%Fault%geoTangent2(1:3,iFace)
 
+    CALL create_strike_dip_unit_vectors(n, strike_vector, dip_vector)
+    
+    CALL RotationMatrix3D(n,strike_vector,dip_vector,T(:,:),iT(:,:),EQN)
+    rotmat = iT(1:6,1:6)
+
+    if(present(iRotmat)) then
+      iRotmat = T(1:6,1:6)
+    endif  
+  END SUBROUTINE create_fault_rotationmatrix
+
+  SUBROUTINE create_strike_dip_unit_vectors(n, strike_vector, dip_vector)
+    !> creates strike and dip unit vectors given a fautl normal vector
+    !-------------------------------------------------------------------------!
+    IMPLICIT NONE    
+    ! Local variable declaration                                              !
+    REAL                            :: n(1:3)                                 !< normal vector to fault, pointing away from reference point
+    REAL                            :: strike_vector(1:3)                     !< strike vector
+    REAL                            :: dip_vector(1:3)                        !< dip vector
+    REAL                            :: norm                                   !< norm
+    !-------------------------------------------------------------------------!
+    INTENT(IN)    :: n                                                        !
+    intent(out)   :: strike_vector, dip_vector                                !
+    !-------------------------------------------------------------------------!
     strike_vector(1) = n(2)/sqrt(n(1)**2+n(2)**2)
     strike_vector(2) = -n(1)/sqrt(n(1)**2+n(2)**2)
     strike_vector(3) = 0.0D0
@@ -102,13 +129,6 @@ CONTAINS
     dip_vector(1) = dip_vector(1)*norm
     dip_vector(2) = dip_vector(2)*norm
     dip_vector(3) = dip_vector(3)*norm
-    
-    CALL RotationMatrix3D(n,strike_vector,dip_vector,T(:,:),iT(:,:),EQN)
-    rotmat = iT(1:6,1:6)
-
-    if(present(iRotmat)) then
-      iRotmat = T(1:6,1:6)
-    endif  
-  END SUBROUTINE create_fault_rotationmatrix
-  
+  END SUBROUTINE create_strike_dip_unit_vectors
+ 
 END MODULE create_fault_rotationmatrix_mod

--- a/src/Physics/Evaluate_friction_law.f90
+++ b/src/Physics/Evaluate_friction_law.f90
@@ -64,6 +64,7 @@ MODULE Eval_friction_law_mod
   PRIVATE :: no_fault
   PRIVATE :: Linear_slip_weakening_bimaterial
   PRIVATE :: Linear_slip_weakening_TPV1617
+  PRIVATE :: ImposedSlipRateOnDRBoundary
   PRIVATE :: rate_and_state
   PRIVATE :: rate_and_state_vw
   PRIVATE :: rate_and_state_nuc101
@@ -135,6 +136,15 @@ MODULE Eval_friction_law_mod
                                 resampleMatrix,                            &
                                 DISC,EQN,MESH,MPI,IO)                          
                                 
+        CASE(33)
+           CALL ImposedSlipRateOnDRBoundary(                               & !
+                                TractionGP_XY,TractionGP_XZ,               & ! OUT: traction
+                                NorStressGP,XYStressGP,XZStressGP,         & ! IN: Godunov status
+                                iFace,iSide,iElem,nBndGP,nTimeGP,          & ! IN: element ID and GP lengths
+                                rho,rho_neig,w_speed,w_speed_neig,         & ! IN: background values
+                                time,DeltaT,                               & ! IN: time
+                                DISC,EQN,MESH,MPI,IO)                 
+
         CASE(3,4) ! Rate-and-state friction
         
            CALL rate_and_state(                                            & !
@@ -525,6 +535,109 @@ MODULE Eval_friction_law_mod
 
   END SUBROUTINE Linear_slip_weakening_TPV1617
 
+
+  !< T. Ulrich 27.07.17
+  !< This friction law allows imposing a slip rate on the DR boundary
+  SUBROUTINE ImposedSlipRateOnDRBoundary(TractionGP_XY,TractionGP_XZ,       & ! OUT: traction
+                                   NorStressGP,XYStressGP,XZStressGP,         & ! IN: Godunov status
+                                   iFace,iSide,iElem,nBndGP,nTimeGP,          & ! IN: element ID and GP lengths
+                                   rho,rho_neig,w_speed,w_speed_neig,         & ! IN: background values
+                                   time,DeltaT,                               & ! IN: time
+                                   DISC,EQN,MESH,MPI,IO)
+    !-------------------------------------------------------------------------!
+    IMPLICIT NONE
+    !-------------------------------------------------------------------------!
+    TYPE(tEquations)               :: EQN
+    TYPE(tDiscretization), target  :: DISC
+    TYPE(tUnstructMesh)            :: MESH
+    TYPE(tMPI)                     :: MPI
+    TYPE(tInputOutput)             :: IO    
+    INTEGER     :: iBndGP,iTimeGP,nBndGP,nTimeGP
+    INTEGER     :: iFace,iSide,iElem
+    REAL        :: time
+    REAL        :: NorStressGP(nBndGP,nTimeGP)
+    REAL        :: XYStressGP(nBndGP,nTimeGP)
+    REAL        :: XZStressGP(nBndGP,nTimeGP)
+    REAL        :: TractionGP_XY(nBndGP,nTimeGP)
+    REAL        :: TractionGP_XZ(nBndGP,nTimeGP)
+    real        :: LocTracXY(nBndGP)
+    real        :: LocTracXZ(nBndGP)
+    real        :: tmpSlip(nBndGP)
+    real        :: Strength(nBndGP), ShTest(nBndGP)
+    real        :: LocSR(nBndGP)
+    REAL        :: rho,rho_neig,w_speed(:),w_speed_neig(:)
+    REAL        :: time_inc
+    REAL        :: Deltat(1:nTimeGP)
+    REAL        :: Tnuc, Gnuc, Gnucprev, dt, prevtime
+    real        :: tn, eta
+    !-------------------------------------------------------------------------!
+    INTENT(IN)    :: NorStressGP,XYStressGP,XZStressGP,iFace,iSide,iElem
+    INTENT(IN)    :: rho,rho_neig,w_speed,w_speed_neig,time,nBndGP,nTimeGP,DeltaT
+    INTENT(IN)    :: MESH,MPI,IO
+    INTENT(INOUT) :: EQN, DISC,TractionGP_XY,TractionGP_XZ
+    !-------------------------------------------------------------------------! 
+    Tnuc = DISC%DynRup%t_0
+    tmpSlip = 0.0D0
+    
+    eta = (w_speed(2)*rho*w_speed_neig(2)*rho_neig) / (w_speed(2)*rho + w_speed_neig(2)*rho_neig)
+    tn = time
+    
+    dt = sum(DeltaT(:))
+
+    do iTimeGP=1,nTimeGP
+      time_inc = DeltaT(iTimeGP)
+      prevtime = tn
+      tn=tn + time_inc
+
+      IF (time.LE.Tnuc) THEN
+         Gnucprev = EXP((prevtime-Tnuc)**2/(prevtime*(prevtime-2.0D0*Tnuc)))
+         Gnuc=EXP((tn-Tnuc)**2/(tn*(tn-2.0D0*Tnuc))) - Gnucprev
+         Gnuc=Gnuc/time_inc
+      ELSE
+         Gnuc=0.0D0
+      ENDIF
+
+      !EQN%NucleationStressInFaultCS (4 and 6) contains the slip in FaultCS
+      LocTracXY(:)  = XYStressGP(:,iTimeGP) + eta * EQN%NucleationStressInFaultCS(:,4,iFace)*Gnuc
+      LocTracXZ(:) =  XZStressGP(:,iTimeGP) + eta * EQN%NucleationStressInFaultCS(:,6,iFace)*Gnuc
+      DISC%DynRup%SlipRate1(:,iFace)     = EQN%NucleationStressInFaultCS(:,4,iFace)*Gnuc
+      DISC%DynRup%SlipRate2(:,iFace)     = EQN%NucleationStressInFaultCS(:,6,iFace)*Gnuc
+      LocSR                              = SQRT(DISC%DynRup%SlipRate1(:,iFace)**2 + DISC%DynRup%SlipRate2(:,iFace)**2)
+      
+      ! Update slip
+      DISC%DynRup%Slip1(:,iFace) = DISC%DynRup%Slip1(:,iFace) + DISC%DynRup%SlipRate1(:,iFace)*time_inc
+      DISC%DynRup%Slip2(:,iFace) = DISC%DynRup%Slip2(:,iFace) + DISC%DynRup%SlipRate2(:,iFace)*time_inc
+      DISC%DynRup%Slip(:,iFace)  = DISC%DynRup%Slip(:,iFace)  + LocSR(:)*time_inc      
+      tmpSlip = tmpSlip(:) + LocSR(:)*time_inc
+      
+     TractionGP_XY(:,iTimeGP) = LocTracXY(:)
+     TractionGP_XZ(:,iTimeGP) = LocTracXZ(:)      
+    enddo
+
+     ! output rupture front 
+     ! outside of iTimeGP loop in order to safe an 'if' in a loop
+     ! this way, no subtimestep resolution possible
+    where (DISC%DynRup%RF(:,iFace) .AND. LocSR .GT. 0.001D0)
+      DISC%DynRup%rupture_time(:,iFace)=time
+      DISC%DynRup%RF(:,iFace) = .FALSE.
+    end where
+
+    where (LocSR(:).GT.DISC%DynRup%PeakSR(:,iFace))
+      DISC%DynRup%PeakSR(:,iFace) = LocSR
+    end where
+
+    DISC%DynRup%TracXY(:,iFace)    = LocTracXY
+    DISC%DynRup%TracXZ(:,iFace)    = LocTracXZ
+
+    !---compute and store slip to determine the magnitude of an earthquake ---
+    !    to this end, here the slip is computed and averaged per element
+    !    in calc_seissol.f90 this value will be multiplied by the element surface
+    !    and an output happened once at the end of the simulation
+    IF (DISC%DynRup%magnitude_out(iFace)) THEN
+        DISC%DynRup%averaged_Slip(iFace) = DISC%DynRup%averaged_Slip(iFace) + sum(tmpSlip)/nBndGP
+    ENDIF
+
+  END SUBROUTINE ImposedSlipRateOnDRBoundary
 
   !> friction case 3,4: rate and state friction
   !> aging (3) and slip law (4)

--- a/src/Physics/Evaluate_friction_law.f90
+++ b/src/Physics/Evaluate_friction_law.f90
@@ -598,10 +598,10 @@ MODULE Eval_friction_law_mod
       ENDIF
 
       !EQN%NucleationStressInFaultCS (4 and 6) contains the slip in FaultCS
-      LocTracXY(:)  = XYStressGP(:,iTimeGP) + eta * EQN%NucleationStressInFaultCS(:,4,iFace)*Gnuc
-      LocTracXZ(:) =  XZStressGP(:,iTimeGP) + eta * EQN%NucleationStressInFaultCS(:,6,iFace)*Gnuc
-      DISC%DynRup%SlipRate1(:,iFace)     = EQN%NucleationStressInFaultCS(:,4,iFace)*Gnuc
-      DISC%DynRup%SlipRate2(:,iFace)     = EQN%NucleationStressInFaultCS(:,6,iFace)*Gnuc
+      LocTracXY(:)  = XYStressGP(:,iTimeGP) - eta * EQN%NucleationStressInFaultCS(:,1,iFace)*Gnuc
+      LocTracXZ(:) =  XZStressGP(:,iTimeGP) - eta * EQN%NucleationStressInFaultCS(:,2,iFace)*Gnuc
+      DISC%DynRup%SlipRate1(:,iFace)     = EQN%NucleationStressInFaultCS(:,1,iFace)*Gnuc
+      DISC%DynRup%SlipRate2(:,iFace)     = EQN%NucleationStressInFaultCS(:,2,iFace)*Gnuc
       LocSR                              = SQRT(DISC%DynRup%SlipRate1(:,iFace)**2 + DISC%DynRup%SlipRate2(:,iFace)**2)
       
       ! Update slip

--- a/src/Physics/Evaluate_friction_law.f90
+++ b/src/Physics/Evaluate_friction_law.f90
@@ -1302,6 +1302,7 @@ MODULE Eval_friction_law_mod
                             DISC,EQN,MESH,MPI,IO,BND)
     !-------------------------------------------------------------------------!
     USE Thermalpressure_mod
+    USE NucleationFunctions_mod
     !-------------------------------------------------------------------------!
     IMPLICIT NONE
     !-------------------------------------------------------------------------!
@@ -1376,15 +1377,7 @@ MODULE Eval_friction_law_mod
     !dt = DISC%Galerkin%TimeGaussP(nTimeGP) + DeltaT(1)
     dt = sum(DeltaT(:))
     IF (time.LE.Tnuc) THEN
-    IF (time.GT.0.0D0) THEN
-        Gnuc=EXP((time-Tnuc)**2/(time*(time-2.0D0*Tnuc)))
-        prevtime = time - dt
-        IF (prevtime.GT.0.0D0) THEN
-        Gnuc= Gnuc - EXP((prevtime-Tnuc)**2/(prevtime*(prevtime-2.0D0*Tnuc)))
-        ENDIF
-    ELSE
-        Gnuc=0.0D0
-    ENDIF
+    Gnuc = Calc_SmoothStepIncrement(time, Tnuc, dt)
 
     !DISC%DynRup%NucBulk_** is already in fault coordinate system
     EQN%InitialStressInFaultCS(:,1,iFace)=EQN%InitialStressInFaultCS(:,1,iFace)+EQN%NucleationStressInFaultCS(:,1,iFace)*Gnuc

--- a/src/Physics/Evaluate_friction_law.f90
+++ b/src/Physics/Evaluate_friction_law.f90
@@ -545,6 +545,8 @@ MODULE Eval_friction_law_mod
                                    time,DeltaT,                               & ! IN: time
                                    DISC,EQN,MESH,MPI,IO)
     !-------------------------------------------------------------------------!
+    USE NucleationFunctions_mod
+    !-------------------------------------------------------------------------!
     IMPLICIT NONE
     !-------------------------------------------------------------------------!
     TYPE(tEquations)               :: EQN
@@ -586,18 +588,10 @@ MODULE Eval_friction_law_mod
 
     do iTimeGP=1,nTimeGP
       time_inc = DeltaT(iTimeGP)
-      prevtime = tn
       tn=tn + time_inc
+      Gnuc = Calc_SmoothStepIncrement(tn, Tnuc, time_inc)/time_inc
 
-      IF (time.LE.Tnuc) THEN
-         Gnucprev = EXP((prevtime-Tnuc)**2/(prevtime*(prevtime-2.0D0*Tnuc)))
-         Gnuc=EXP((tn-Tnuc)**2/(tn*(tn-2.0D0*Tnuc))) - Gnucprev
-         Gnuc=Gnuc/time_inc
-      ELSE
-         Gnuc=0.0D0
-      ENDIF
-
-      !EQN%NucleationStressInFaultCS (4 and 6) contains the slip in FaultCS
+      !EQN%NucleationStressInFaultCS (1 and 2) contains the slip in FaultCS
       LocTracXY(:)  = XYStressGP(:,iTimeGP) - eta * EQN%NucleationStressInFaultCS(:,1,iFace)*Gnuc
       LocTracXZ(:) =  XZStressGP(:,iTimeGP) - eta * EQN%NucleationStressInFaultCS(:,2,iFace)*Gnuc
       DISC%DynRup%SlipRate1(:,iFace)     = EQN%NucleationStressInFaultCS(:,1,iFace)*Gnuc

--- a/src/Physics/NucleationFunctions.f90
+++ b/src/Physics/NucleationFunctions.f90
@@ -1,0 +1,106 @@
+!>
+!! @file
+!! This file is part of SeisSol.
+!!
+!! @author Thomas Ulrich
+!!
+!! @section LICENSE
+!! Copyright (c) 2007-2020, SeisSol Group
+!! All rights reserved.
+!!
+!! Redistribution and use in source and binary forms, with or without
+!! modification, are permitted provided that the following conditions are met:
+!!
+!! 1. Redistributions of source code must retain the above copyright notice,
+!!    this list of conditions and the following disclaimer.
+!!
+!! 2. Redistributions in binary form must reproduce the above copyright notice,
+!!    this list of conditions and the following disclaimer in the documentation
+!!    and/or other materials provided with the distribution.
+!!
+!! 3. Neither the name of the copyright holder nor the names of its
+!!    contributors may be used to endorse or promote products derived from this
+!!    software without specific prior written permission.
+!!
+!! THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+!! AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+!! IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+!! ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+!! LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+!! CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+!! SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+!! INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+!! CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+!! ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+!! POSSIBILITY OF SUCH DAMAGE.
+!!
+!! @section DESCRIPTION
+!! Smooth step function used to smoothly nucleate a rupture over time Tnuc 
+!! similarly with SCEC TPV103 benchmark  
+
+#ifdef BG 
+#include "../Initializer/preProcessorMacros.fpp"
+#else
+#include "Initializer/preProcessorMacros.fpp"
+#endif
+
+MODULE NucleationFunctions_mod
+  !---------------------------------------------------------------------------!
+  USE TypesDef
+  !---------------------------------------------------------------------------!
+  IMPLICIT NONE
+  !PRIVATE
+  !---------------------------------------------------------------------------!
+  INTERFACE Calc_SmoothStepIncrement
+     MODULE PROCEDURE Calc_SmoothStepIncrement
+  END INTERFACE
+  INTERFACE Calc_SmoothStep
+     MODULE PROCEDURE Calc_SmoothStep
+  END INTERFACE
+  !---------------------------------------------------------------------------!
+  PUBLIC  :: Calc_SmoothStepIncrement
+  PUBLIC  :: Calc_SmoothStep
+  !---------------------------------------------------------------------------!
+
+CONTAINS
+
+  FUNCTION Calc_SmoothStepIncrement(time, Tnuc, dt)result(Gnuc)
+    !-------------------------------------------------------------------------!
+    !-------------------------------------------------------------------------!
+    IMPLICIT NONE
+    !-------------------------------------------------------------------------!
+    ! Argument list declaration                                               !
+    REAL        :: time, Tnuc, dt, Gnuc, prevtime, Gnuc_prev
+    !-------------------------------------------------------------------------!
+    IF ((time.GT.0.0D0).AND.(time.LE.Tnuc)) THEN
+        Gnuc = Calc_SmoothStep(time, Tnuc)
+        prevtime = time - dt
+        IF (prevtime.GT.0.0D0) THEN
+            Gnuc= Gnuc - Calc_SmoothStep(prevtime, Tnuc)
+        ENDIF
+    ELSE
+        Gnuc=0.0D0
+    ENDIF
+  END FUNCTION Calc_SmoothStepIncrement
+
+  FUNCTION Calc_SmoothStep(time, Tnuc)result(Gnuc)
+    !-------------------------------------------------------------------------!
+    !-------------------------------------------------------------------------!
+    IMPLICIT NONE
+    !-------------------------------------------------------------------------!
+    ! Argument list declaration                                               !
+    REAL        :: time, Tnuc, Gnuc
+    !-------------------------------------------------------------------------!
+    if (time.LE.0) then
+        Gnuc=0.0
+    else 
+        if (time.LT.Tnuc) then
+            Gnuc = EXP((time-Tnuc)**2/(time*(time-2.0D0*Tnuc)))
+        else
+            Gnuc=1d0
+        endif
+    endif
+  END FUNCTION Calc_SmoothStep
+
+
+END MODULE NucleationFunctions_mod

--- a/src/Physics/SConscript
+++ b/src/Physics/SConscript
@@ -44,7 +44,8 @@ Import('env')
 physicsFiles = [ 'Evaluate_friction_law.f90',
                  'ini_model.f90',
                  'ini_model_DR.f90',
-                 'thermalpressure.f90' ]
+                 'thermalpressure.f90',
+                 'NucleationFunctions.f90' ]
 
 for i in physicsFiles:
   env.sourceFiles.append(env.Object(i))

--- a/src/Physics/ini_model_DR.f90
+++ b/src/Physics/ini_model_DR.f90
@@ -383,6 +383,7 @@ MODULE ini_model_DR_mod
 
   SUBROUTINE rotateSlipToFaultCS(EQN, MESH, nBndGP, StrikeSlip , DipSlip, SlipInFaultCS)
     USE common_operators_mod
+    USE create_fault_rotationmatrix_mod, only: create_strike_dip_unit_vectors
     !-------------------------------------------------------------------------!
     IMPLICIT NONE
     !-------------------------------------------------------------------------!
@@ -402,15 +403,12 @@ MODULE ini_model_DR_mod
     intent(inout)                       :: StrikeSlip, DipSlip
     intent(inout)                       :: SlipInFaultCS
     do i = 1, MESH%Fault%nSide
+          
           NormalVect_n = MESH%Fault%geoNormals(1:3,i)
           NormalVect_s = MESH%Fault%geoTangent1(1:3,i)
           NormalVect_t = MESH%Fault%geoTangent2(1:3,i)
- 
-          strike_vector(1) = NormalVect_n(2)/sqrt(NormalVect_n(1)**2+NormalVect_n(2)**2)
-          strike_vector(2) = -NormalVect_n(1)/sqrt(NormalVect_n(1)**2+NormalVect_n(2)**2)
-          strike_vector(3) = 0.0D0
-          dip_vector = NormalVect_n .x. strike_vector
-          dip_vector = dip_vector / sqrt(dip_vector(1)**2+dip_vector(2)**2+dip_vector(3)**2)
+          CALL create_strike_dip_unit_vectors(NormalVect_n, strike_vector, dip_vector)
+
           cos1 = dot_product(strike_vector(:),NormalVect_s(:))
           crossprod(:) = strike_vector(:) .x. NormalVect_s(:)
           scalarprod = dot_product(crossprod(:),NormalVect_n(:))

--- a/src/Reader/readpar.f90
+++ b/src/Reader/readpar.f90
@@ -1048,7 +1048,11 @@ CONTAINS
              DISC%DynRup%L = L
              CONTINUE
            CASE(33) !ImposedSlipRateOnDRBoundary
-               DISC%DynRup%t_0 = t_0
+             DISC%DynRup%t_0 = t_0
+             IF (DISC%DynRup%SlipRateOutputType.EQ.1) THEN
+               logInfo0(*) 'ImposedSlipRateOnDRBoundary only works with SlipRateOutputType=0, and this parameter is therefore set to 0'
+               DISC%DynRup%SlipRateOutputType = 0
+             ENDIF
            CASE(3,4,7,101,103)
              DISC%DynRup%RS_f0 = RS_f0    ! mu_0, reference friction coefficient
              DISC%DynRup%RS_sr0 = RS_sr0  ! V0, reference velocity scale

--- a/src/Reader/readpar.f90
+++ b/src/Reader/readpar.f90
@@ -1047,6 +1047,8 @@ CONTAINS
              DISC%DynRup%v_star = v_star
              DISC%DynRup%L = L
              CONTINUE
+           CASE(33) !ImposedSlipRateOnDRBoundary
+               DISC%DynRup%t_0 = t_0
            CASE(3,4,7,101,103)
              DISC%DynRup%RS_f0 = RS_f0    ! mu_0, reference friction coefficient
              DISC%DynRup%RS_sr0 = RS_sr0  ! V0, reference velocity scale

--- a/src/ResultWriter/faultoutput.f90
+++ b/src/ResultWriter/faultoutput.f90
@@ -214,6 +214,7 @@ CONTAINS
     USE common_operators_mod
     USE JacobiNormal_mod
     USE DGBasis_mod
+    USE NucleationFunctions_mod
     !-------------------------------------------------------------------------!
     IMPLICIT NONE
     !-------------------------------------------------------------------------!
@@ -393,13 +394,8 @@ CONTAINS
           if (EQN%FL.eq.33) then 
              !case of ImposedSlipRateOnDRBoundary 'friction law': we add the additional stress to the fault output
              !to show the imposed SR
-             Tnuc = DISC%DynRup%t_0
              eta = (w_speed(2)*rho*w_speed_neig(2)*rho_neig) / (w_speed(2)*rho + w_speed_neig(2)*rho_neig)
-             IF (time.LE.Tnuc) THEN
-                Gnuc = EXP((time-Tnuc)**2/(time*(time-2.0D0*Tnuc)))
-             else
-                Gnuc=1d0
-             endif
+             Gnuc = Calc_SmoothStep(time, DISC%DynRup%t_0)
              S_XY = S_XY - eta * EQN%NucleationStressInFaultCS(iBndGP,1,iFace)*Gnuc
              S_XZ = S_XZ - eta * EQN%NucleationStressInFaultCS(iBndGP,2,iFace)*Gnuc
           endif

--- a/src/ResultWriter/faultoutput.f90
+++ b/src/ResultWriter/faultoutput.f90
@@ -208,6 +208,7 @@ CONTAINS
 !<
   SUBROUTINE calc_FaultOutput( DynRup_output, DISC, EQN, MESH, MaterialVal, BND, time )
     use  f_ftoc_bind_interoperability
+    USE create_fault_rotationmatrix_mod, only: create_strike_dip_unit_vectors
     use iso_c_binding, only: c_loc
 
     !-------------------------------------------------------------------------!
@@ -496,13 +497,8 @@ CONTAINS
 
           ! rotate into fault system
           LocMat = MATMUL(rotmat,tmp_mat)
-          
-          ! z must not be +/- (0,0,1) for the following to work (see also create_fault_rotationmatrix)
-          strike_vector(1) = NormalVect_n(2)/sqrt(NormalVect_n(1)**2+NormalVect_n(2)**2)
-          strike_vector(2) = -NormalVect_n(1)/sqrt(NormalVect_n(1)**2+NormalVect_n(2)**2)
-          strike_vector(3) = 0.0D0
-          dip_vector = NormalVect_n .x. strike_vector
-          dip_vector = dip_vector / sqrt(dip_vector(1)**2+dip_vector(2)**2+dip_vector(3)**2)
+         
+          CALL create_strike_dip_unit_vectors(NormalVect_n, strike_vector, dip_vector)
 
           ! sliprate
           if (DISC%DynRup%SlipRateOutputType .eq. 1) then

--- a/src/ResultWriter/faultoutput.f90
+++ b/src/ResultWriter/faultoutput.f90
@@ -400,8 +400,8 @@ CONTAINS
              else
                 Gnuc=1d0
              endif
-             S_XY = S_XY + eta * EQN%NucleationStressInFaultCS(iBndGP,4,iFace)*Gnuc
-             S_XZ = S_XZ + eta * EQN%NucleationStressInFaultCS(iBndGP,6,iFace)*Gnuc
+             S_XY = S_XY - eta * EQN%NucleationStressInFaultCS(iBndGP,1,iFace)*Gnuc
+             S_XZ = S_XZ - eta * EQN%NucleationStressInFaultCS(iBndGP,2,iFace)*Gnuc
           endif
 
           !
@@ -530,11 +530,6 @@ CONTAINS
              !case of ImposedSlipRateOnDRBoundary 'friction law': we plot the Stress from Godunov state, because we want to see the traction change from the imposed slip distribution
              TracMat(4)=LocMat(4)
              TracMat(6)=LocMat(6)
-             !if DISC%DynRup%SlipRateOutputType .eq. 1 switch back to 0 
-             if (DISC%DynRup%SlipRateOutputType .eq. 1) then
-                LocSRs = dot_product(SideVal2(8) * NormalVect_s + SideVal2(9) * NormalVect_t, strike_vector) - dot_product(SideVal(8) * NormalVect_s + SideVal(9) * NormalVect_t, strike_vector)
-                LocSRd = dot_product(SideVal2(8) * NormalVect_s + SideVal2(9) * NormalVect_t, dip_vector   ) - dot_product(SideVal(8) * NormalVect_s + SideVal(9) * NormalVect_t, dip_vector   )
-             endif
           endif
 
           OutVars = 0


### PR DESCRIPTION
This new friction law allows imposing Slip (via SR) on the boundary condition.
The most direct use is (a very expensive way) for computing the final traction distribution from a slip distribution (potential application for the Norcia earthquake).