### PR TITLE
Fix travis, deps now self-hosted

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,8 @@ dist: xenial
 before_install:
  - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
  - sudo apt-get update -qq
- - wget ftp://ftp.unidata.ucar.edu/pub/netcdf/netcdf-4.6.1.tar.gz
- - wget https://nchc.dl.sourceforge.net/project/scons/scons/3.1.1/scons-3.1.1.tar.gz
+ - wget https://syncandshare.lrz.de/dl/fiJNAokgbe2vNU66Ru17DAjT/netcdf-4.6.1.tar.gz
+ - wget https://syncandshare.lrz.de/dl/fiE4aBvw5mQ5fa5VEMmk3XNC/scons-3.1.1.tar.gz
  - wget https://github.com/hfp/libxsmm/archive/master.zip
 
 install:


### PR DESCRIPTION
Currently travis fails because downloading the dependencies fails (resource doesn't exist anymore). Quick fix: move it to lrz-cloud.
