### PR TITLE
Improve computation of Riemann solver for single precision

### DIFF
--- a/src/Model/common.hpp
+++ b/src/Model/common.hpp
@@ -42,6 +42,7 @@
 
 #include <Eigen/Eigen>
 
+#include "utils/logger.h"
 #include "Initializer/typedefs.hpp"
 #include "generated_code/init.h"
 
@@ -240,8 +241,12 @@ void seissol::model::getTransposedElasticGodunovState(Material const& local,
     chi(1,1) = 1.0;
     chi(2,2) = 1.0;
 
-    assert(Eigen::FullPivLU<Matrix99>(R).isInvertible());
-    const auto godunov = ((R*chi)*R.inverse()).eval();
+    const auto RDecomp = Eigen::FullPivLU<Matrix99>(R);
+    if (!RDecomp.isInvertible()) {
+      logError() << "Matrix of eigenvectors is not invertible - failed to construct Riemann solver.";
+    }
+
+    const auto godunov = ((R*chi)*RDecomp.inverse()).eval();
 
     // QgodLocal = I - QgodNeighbor
     for (unsigned i = 0; i < godunov.cols(); ++i) {

--- a/src/Model/common.hpp
+++ b/src/Model/common.hpp
@@ -47,7 +47,7 @@
 
 namespace seissol {
   namespace model {
-    using Matrix99 = Eigen::Matrix<real, 9, 9>;
+    using Matrix99 = Eigen::Matrix<double, 9, 9>;
 
     bool testIfAcoustic(real mu);
 
@@ -133,7 +133,7 @@ template<typename T>
 void seissol::model::getTransposedFreeSurfaceGodunovState(const Material& material,
                                                           T& QgodLocal,
                                                           T& QgodNeighbor,
-                                                          Eigen::Matrix<real, 9, 9>& R) {
+                                                          Matrix99& R) {
   for (int i = 0; i < 9; i++) {
     for (int j = 0; j < 9; j++) {
       QgodNeighbor(i,j) = std::numeric_limits<double>::signaling_NaN();
@@ -149,7 +149,7 @@ void seissol::model::getTransposedFreeSurfaceGodunovState(const Material& materi
   } else {
     std::array<int, 3> traction_indices = {0,3,5};
     std::array<int, 3> velocity_indices = {6,7,8};
-    using Matrix33 = Eigen::Matrix<real, 3, 3>;
+    using Matrix33 = Eigen::Matrix<double, 3, 3>;
     Matrix33 R11 = R(traction_indices, {0,1,2});
     Matrix33 R21 = R(velocity_indices, {0,1,2});
     auto S = - (R21 * R11.inverse()).eval();


### PR DESCRIPTION
- Always compute the Riemann solver in double precision (and store result in single/double)
- Exit with an error when the matrix of eigenvectors is not invertible. The computed inverse would be useless anyway.