### PR TITLE
Carsten/multiple materials

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.13)
 
 if(POLICY CMP0075)
   cmake_policy(SET CMP0075 NEW)
@@ -29,7 +29,7 @@ set(HARDWARE_DEFINITIONS "ALIGNMENT=${ALIGNMENT}"
 # TODO: Move one dir up.
 set(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake" ${CMAKE_MODULE_PATH})
 
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS
@@ -260,7 +260,7 @@ if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
 elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Intel")
   # using Intel C++
   # todo remove std?, is ffreestanding needed?
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -qopenmp")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -qopenmp")
 
   # only if openmp
   set(CMAKE_EXE_LINKER_FLAGS  "${CMAKE_EXE_LINKER_FLAGS} -qopenmp")
@@ -268,7 +268,7 @@ elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Intel")
   # Activate interprocedual optimization.
   #set_property(TARGET SeisSol-lib PROPERTY INTERPROCEDURAL_OPTIMIZATION TRUE) 
 elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -fopenmp=libomp")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fopenmp=libomp")
 elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "CRAY")
   # TODO: Cray
 endif()

--- a/SConstruct
+++ b/SConstruct
@@ -424,7 +424,7 @@ if env['compileMode'] in ['relWithDebInfo', 'release']:
         env.Append(F90FLAGS = ['-fno-alias'])
 
 # C++ Standard
-env.Append(CXXFLAGS=['-std=c++11'])
+env.Append(CXXFLAGS=['-std=c++17'])
 
 #
 # Basic preprocessor defines

--- a/src/Equations/anisotropic/Model/datastructures.hpp
+++ b/src/Equations/anisotropic/Model/datastructures.hpp
@@ -265,10 +265,6 @@ namespace seissol {
         double muBar = (c44 + c55 + c66) / 3.0;
         return std::sqrt(muBar / rho);
       }
-
-      MaterialType getMaterialType() const {
-        return MaterialType::anisotropic;
-      }
     };
 
 

--- a/src/Equations/elastic/Model/datastructures.hpp
+++ b/src/Equations/elastic/Model/datastructures.hpp
@@ -101,10 +101,6 @@ namespace seissol {
       double getSWaveSpeed() const final {
         return std::sqrt(mu / rho);
       }
-
-      MaterialType getMaterialType() const override{
-        return MaterialType::elastic;
-      }
     };
   }
 }

--- a/src/Equations/viscoelastic2/Model/datastructures.hpp
+++ b/src/Equations/viscoelastic2/Model/datastructures.hpp
@@ -83,10 +83,6 @@ namespace seissol {
       }
 
       virtual ~ViscoElasticMaterial() {};
-
-      MaterialType getMaterialType() const override {
-        return MaterialType::viscoelastic;
-      }
     };
   }
 }

--- a/src/Model/Visitor.h
+++ b/src/Model/Visitor.h
@@ -1,0 +1,14 @@
+#ifndef MODEL_VISITOR_H_
+#define MODEL_VISITOR_H_
+
+namespace seissol {
+  template<typename... Types>
+  struct make_visitor : Types... {
+    using Types::operator()...;
+  };
+  // make_visitor template deduction guide
+  template<typename... Types>
+  make_visitor(Types...) -> make_visitor<Types...>;
+}
+
+#endif

--- a/src/Model/common_datastructures.hpp
+++ b/src/Model/common_datastructures.hpp
@@ -43,23 +43,17 @@
 
 #include <Kernels/precision.hpp>
 #include <array>
+#include "Visitor.h"
 
 
 namespace seissol {
   namespace model {
-    enum class MaterialType {
-      elastic,
-      viscoelastic,
-      anisotropic
-    };
-
     struct Material {
       double rho;
       virtual double getMaxWaveSpeed() const = 0;
       virtual double getPWaveSpeed() const = 0;
       virtual double getSWaveSpeed() const = 0;
       virtual void getFullStiffnessTensor(std::array<real, 81>& fullTensor) const = 0; 
-      virtual MaterialType getMaterialType() const = 0 ;
       virtual ~Material() {};
     };
 


### PR DESCRIPTION
Hi,

this is not really a pull request (did not test too much) but rather I'd like to start a discussion.

An open question how to store multiple material types within the LTS tree. My idea would be that one may specify multiple types for a field of the tree. The time cluster then stores an int which indicates which type is actually stored in the time cluster. This is essentially the same method that std::variant uses for a type-safe union. Therefore, the interface to the tree could be std::variant (or similar). That is, when I request a material from the time cluster, then I get returned a std::variant<ElasticMaterial*, AnisotropicMaterial*, ...>.

The implications on CellLocalMatrices of this approach are shown in this pull request. Basically, one can use std::visit then to implement multiple dispatch, e.g. to choose the correct Riemann solver.

What do you think?

Regards,
Carsten

PS: Requires c++17 btw.