### PR TITLE
Add --disable-dap for netcdf compilation

### DIFF
--- a/Documentation/compilation.rst
+++ b/Documentation/compilation.rst
@@ -67,7 +67,7 @@ Installing netCDF
   wget https://syncandshare.lrz.de/dl/fiJNAokgbe2vNU66Ru17DAjT/netcdf-4.6.1.tar.gz
   tar -xaf netcdf-4.6.1.tar.gz
   cd netcdf-4.6.1
-  CFLAGS="-fPIC ${CFLAGS}" CC=h5pcc ./configure --enable-shared=no --prefix=$HOME 
+  CFLAGS="-fPIC ${CFLAGS}" CC=h5pcc ./configure --enable-shared=no --prefix=$HOME --disable-dap
   #NOTE: Check for this line to make sure netCDF is build with parallel I/O: 
   #"checking whether parallel I/O features are to be included... yes" This line comes at the very end (last 50 lines of configure run)!
   make -j8


### PR DESCRIPTION
On some machines we encountered problems with netCDF linking. The --disable-dap flag solves these issues. As we do not need netCDF with dap support, this can be the standard.