### PR TITLE
Fix ASAGI link

### DIFF
--- a/Documentation/compilation.rst
+++ b/Documentation/compilation.rst
@@ -120,7 +120,7 @@ libmetis.a. Otherwise, compile error: cannot find parmetis.)
 Installing ASAGI (Optional)
 ---------------------------
 
-See section :ref:`Installing ASAGI <installing_ASAGI>`.
+See section :ref:`ASAGI <ASAGI>`.
 
 .. _compiling-seissol:
 


### PR DESCRIPTION
previous installing ASAGI link is lead back to compilation.rst, change it to ASAGI.rst