### PR TITLE
Add normalize button to Viewrec

### DIFF
--- a/postprocessing/visualization/receiver/src/View.py
+++ b/postprocessing/visualization/receiver/src/View.py
@@ -108,6 +108,10 @@ class View(QWidget):
     saveAll = QPushButton(QIcon.fromTheme('document-save'), '', self)
     saveAll.clicked.connect(self.savePlots)
 
+    self.normalize = QPushButton('Normalize', self) 
+    self.normalize.setCheckable(True)
+    self.normalize.clicked.connect(self.plot)
+
     toolLayout = QHBoxLayout()
     toolLayout.addWidget(addNaviButton)
     toolLayout.addWidget(self.diff)
@@ -115,6 +119,7 @@ class View(QWidget):
     toolLayout.addWidget(self.maxFreq)
     toolLayout.addWidget(autoRefresh)
     toolLayout.addWidget(saveAll)
+    toolLayout.addWidget(self.normalize)
     toolLayout.addWidget(toolbar)
     plotLayout = QVBoxLayout()
     plotLayout.addLayout(toolLayout)
@@ -152,7 +157,12 @@ class View(QWidget):
       if filt.isChecked():
         for wf in wfc:
           filt.apply(wf)
-          
+
+    if self.normalize.isChecked():
+      #normalize traces
+      for nWf, wf in enumerate(wfc):
+        wfc[nWf].normalize()
+
     if self.diff.isChecked() and len(wfc) > 0:
       wf0 = wfc.pop()
       for nWf, wf in enumerate(wfc):

--- a/postprocessing/visualization/receiver/src/Waveform.py
+++ b/postprocessing/visualization/receiver/src/Waveform.py
@@ -44,11 +44,13 @@ class Waveform:
     data = numpy.array(data)
     
     self.waveforms = dict()
+    self.norm = dict()
     for i in range(0, len(names)):
       if names[i] == 'Time':
         self.time = data[:,i]
       else:
         self.waveforms[ names[i] ] = data[:,i]
+        self.norm[ names[i] ] = numpy.max(numpy.abs(data[:,i]))
     
     self.coordinates = numpy.array(coordinates)
 
@@ -60,4 +62,9 @@ class Waveform:
       wf1 = numpy.interp(newTime, self.time, self.waveforms[name])
       self.waveforms[name] = wf1 - wf0
     self.time = newTime
+
+  def normalize(self):
+    for name, wf in self.waveforms.items():
+      if self.norm[name] > numpy.finfo(float).eps:
+        self.waveforms[name] = wf / self.norm[name]
     


### PR DESCRIPTION
Hi, I have to compare traces of SeisSol with the ones from collaborators who use other codes. Sometimes it is unnecessarily complicated to think about comparisons of magnitudes and we are just interested in the wave form. That's why I added a normalize button to viewrec. Maybe that's useful for the one or other...