### PR TITLE
Added fty to SeisSol as a submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -34,3 +34,6 @@
 [submodule "submodules/eigen3"]
 	path = submodules/eigen3
 	url = ../../eigenteam/eigen-git-mirror
+[submodule "submodules/fty"]
+	path = submodules/fty
+	url = https://github.com/ravil-mobile/fty.git

--- a/src/Initializer/MemoryManager.h
+++ b/src/Initializer/MemoryManager.h
@@ -85,6 +85,7 @@
 #include <Initializer/DynamicRupture.h>
 #include <Initializer/Boundary.h>
 #include <Initializer/ParameterDB.h>
+#include <yaml-cpp/yaml.h>
 
 namespace seissol {
   namespace initializers {
@@ -161,6 +162,8 @@ class seissol::initializers::MemoryManager {
     Boundary m_boundary;
 
     EasiBoundary m_easiBoundary;
+
+    YAML::Node m_inputParams;
 
     /**
      * Corrects the LTS Setups (buffer or derivatives, never both) in the ghost region
@@ -290,6 +293,10 @@ class seissol::initializers::MemoryManager {
 
     inline EasiBoundary* getEasiBoundaryReader() {
       return &m_easiBoundary;
+    }
+
+    inline void setInputParams(const YAML::Node& Params) {
+      m_inputParams = Params;
     }
 };
 

--- a/src/SeisSol.cpp
+++ b/src/SeisSol.cpp
@@ -167,4 +167,16 @@ void seissol::SeisSol::finalize()
 	logInfo(rank) << "SeisSol done. Goodbye.";
 }
 
+
+void seissol::SeisSol::setInputParams(const YAML::Node& Params) {
+  m_inputParams = Params;
+  const int rank = MPI::mpi.rank();
+  if (rank == 0) {
+    logInfo() << "Input Parameters:\n"
+              << m_inputParams;
+  }
+
+  m_memoryManager.setInputParams(m_inputParams);
+}
+
 seissol::SeisSol seissol::SeisSol::main;

--- a/src/SeisSol.h
+++ b/src/SeisSol.h
@@ -60,6 +60,8 @@
 
 #include "ResultWriter/AnalysisWriter.h"
 
+#include <yaml-cpp/yaml.h>
+
 class MeshReader;
 
 namespace seissol
@@ -121,6 +123,8 @@ private:
   //! Receiver writer module
   writer::ReceiverWriter m_receiverWriter;
 
+  //! Input parameters
+  YAML::Node m_inputParams;
 
 private:
 	/**
@@ -265,6 +269,20 @@ public:
 	{
 		return *m_meshReader;
 	}
+
+
+	/**
+	 * Sets input parameters of SeisSol
+	 */
+  void setInputParams(const YAML::Node& Params);
+
+
+  /**
+    * Returns input parameters of SeisSol
+    */
+  const YAML::Node& getInputParams() {
+    return m_inputParams;
+  }
 
 public:
 	/** The only instance of this class; the main C++ functionality */

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -54,7 +54,7 @@ int main(int argc, char* argv[])
   bool runSeisSol = seissol::SeisSol::main.init(argc, argv);
 
   // read and parse an input file with parameters
-  fty::Loader<fty::As_lowercase> Loader{};
+  fty::Loader<fty::AsLowercase> Loader{};
   try {
     YAML::Node Params = Loader.load(seissol::SeisSol::main.parameterFile());
     seissol::SeisSol::main.setInputParams(Params);


### PR DESCRIPTION
* reads parameters.par from disk and stores the info
  in a hash table i.e., YAML::Node

* FTY throws an exception if a NAMELIST block is not closed. Example: 
```
...
Thu Aug 20 18:37:02, Info:  Using OMP with #threads/rank: 6 
Thu Aug 20 18:37:02, Info:  The stack size ulimit is unlimited. 
Thu Aug 20 18:37:02, Error: ParsingError: cannot find the end of block: &Debugging 
Backtrace:
./SeisSol_Release_dhsw_elastic_6() [0x424538]
./SeisSol_Release_dhsw_elastic_6() [0x40f117]
...
```

* In case of success, SeisSol prints data retrieved from parameters.par stored in a YAML::Node:
```
...
Thu Aug 20 18:37:34, Info:  The stack size ulimit is unlimited. 
Thu Aug 20 18:37:34, Info:  Input Parameters:
 equations:
  materialfilename: material.yaml
boundaries:
  bc_fs: 1
  bc_dr: 1
  bc_of: 1
dynamicrupture:
  fl: 2
  modelfilename: fault.yaml
  gpwise: 1
  xref: 0.0
  yref: -1.0e5
  zref: 0
  rf_output_on: 1
  outputpointtype: 5
elementwise:
  printintervalcriterion: 2
  printtimeinterval_sec: 1.
  outputmask: 1 1 1 1 1 1 1 1 1  1
  refinement_strategy: 2
  refinement: 1
pickpoint:
  printtimeinterval: 1
  outputmask: 1 1 1 1
  noutpoints: 9
  ppfilename: FaultReceivers5.dat
meshnml:
  meshgenerator: PUML
  meshfile: mesh/tpv5.h5
discretization:
  order: 4
  material: 1
  cfl: 0.5
  fixtimestep: 5
  dgmethod: 1
  clusteredlts: 2
output:
  outputfile: output/tpv5
  ioutputmask: 1 1 1 1 1 1 1 1 1
  ioutputmaskmaterial: 1 1 1
  format: 10
  timeinterval: 0.25
  printintervalcriterion: 2
  pickdt: 0.005
  pickdttype: 1
  faultoutputflag: 1
  nrecordpoints: 6
  rfilename: Receivers5.dat
abortcriteria:
  endtime: 5.0 
...
```
