### PR TITLE
Require gcc 9

### DIFF
--- a/Documentation/compilation.rst
+++ b/Documentation/compilation.rst
@@ -7,7 +7,7 @@ In order to run SeisSol, you need to first install:
 -  Numpy (>= 1.12.0)
 -  hdf5 (>= 1.8, for instructions see below)
 -  netcdf (C-Release) (>= 4.4, for instructions see below)
--  Intel compiler (>= 18.0, icc, icpc, ifort) or GCC (>= 8.0, gcc, g++, gfortran)
+-  Intel compiler (>= 18.0, icc, icpc, ifort) or GCC (>= 9.0, gcc, g++, gfortran)
 -  Some MPI implementation (e.g. OpenMPI)
 -  ParMETIS for partitioning
 -  libxsmm (libxsmm\_gemm\_generator) for small matrix multiplications


### PR DESCRIPTION
GCC-8 does not support all needed target, e.g. on supermuc-ng:
```
ga24dib3@login02:~> module switch gcc/8
ga24dib3@login02:~> gcc --target-help | grep -o skylake-avx512
```

```
ga24dib3@login02:~> module switch gcc/9 
ga24dib3@login02:~> gcc --target-help | grep -o skylake-avx512
skylake-avx512
skylake-avx512
```