### PR TITLE
Remove warning when compiling yaml on submodules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -139,7 +139,7 @@ target_compile_definitions(SeisSol-lib PUBLIC LOG_LEVEL=${LOG_LEVEL_MASTER}
 # Libs
 include(ExternalProject)
 
-find_package(YAML-CPP 0.5.3)
+find_package(YAML-CPP 0.5.3 QUIET)
 if (YAML-CPP_FOUND)
   target_link_libraries(SeisSol-lib PUBLIC ${YAML_CPP_LIBRARIES})
   target_include_directories(SeisSol-lib PUBLIC ${YAML_CPP_INCLUDE_DIR})


### PR DESCRIPTION
Removes this warning:

> 
> CMake Warning at CMakeLists.txt:142 (find_package):
>   By not providing "FindYAML-CPP.cmake" in CMAKE_MODULE_PATH this project has
>   asked CMake to find a package configuration file provided by "YAML-CPP",
>   but CMake did not find one.
> 
>   Could not find a package configuration file provided by "YAML-CPP"
>   (requested version 0.5.3) with any of the following names:
> 
>     YAML-CPPConfig.cmake
>     yaml-cpp-config.cmake
> 
>   Add the installation prefix of "YAML-CPP" to CMAKE_PREFIX_PATH or set
>   "YAML-CPP_DIR" to a directory containing one of the above files.  If
>   "YAML-CPP" provides a separate development package or SDK, be sure it has
>   been installed.