### PR TITLE
exit to MPIABORT

### DIFF
--- a/azure-pipelines-seissol-template.yml
+++ b/azure-pipelines-seissol-template.yml
@@ -18,7 +18,6 @@ jobs:
                         sudo apt-get install gcc-8 g++-8 gfortran-8
                         sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-8 100
                         sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-8 100
-                        sudo update-alternatives --install /usr/bin/gfortran gfortran /usr/bin/gfortran-8 100
                         gcc --version
                         sudo apt-get install -qq openmpi-bin openmpi-common libopenmpi-dev hdf5-tools libhdf5-openmpi-100 libhdf5-openmpi-dev python3 python3-pip libmetis-dev libparmetis-dev cxxtest
                         sudo pip3 install --upgrade pip

--- a/src/Geometry/MeshReaderCBinding.f90
+++ b/src/Geometry/MeshReaderCBinding.f90
@@ -188,7 +188,8 @@ contains
                   IntGaussW  = mesh%ELEM%BndGW_Tri,       &
                   M          = disc%Galerkin%nPoly+2,     &
                   IO         = io,                        &
-                  quiet      = .true.                     )
+                  quiet      = .true.,                    &
+                  MPI        = MPI                     )
 #endif
 
         call computeAdditionalMeshInfo()

--- a/src/Geometry/MeshReaderCBinding.f90
+++ b/src/Geometry/MeshReaderCBinding.f90
@@ -142,7 +142,7 @@ contains
                                     logical(EQN%Plasticity == 1, 1))
         else
             logError(*) 'Unknown mesh reader'
-            call exit(134)
+            call MPI_ABORT(m_mpi%commWorld, 134)
         endif
 
         ! Set additional SeisSol variables

--- a/src/Geometry/allocate_mesh.f90
+++ b/src/Geometry/allocate_mesh.f90
@@ -80,13 +80,14 @@ MODULE allocate_mesh_mod
 
 CONTAINS
 
-  SUBROUTINE allocate_mesh_level0_1(IO,MESH)
+  SUBROUTINE allocate_mesh_level0_1(IO,MESH, MPI)
     !--------------------------------------------------------------------------
     TYPE (tUnstructMesh)      :: MESH               
     TYPE (tInputOutput)       :: IO
+    TYPE (tMPI)               :: MPI
     INTEGER                   :: allocStat
     !--------------------------------------------------------------------------
-    INTENT(IN)                :: IO
+    INTENT(IN)                :: IO, MPI
     INTENT(INOUT)             :: MESH
     !--------------------------------------------------------------------------
     !
@@ -171,14 +172,15 @@ CONTAINS
   !END SUBROUTINE destruct_ncmesh_level0_1
 
 
-  SUBROUTINE allocate_mesh_level0_2(IO,EQN,MESH)
+  SUBROUTINE allocate_mesh_level0_2(IO,EQN,MESH,MPI)
     !--------------------------------------------------------------------------
     TYPE (tInputOutput)       :: IO
     TYPE (tEquations)         :: EQN
     TYPE (tUnstructMesh)      :: MESH
+    TYPE (tMPI)               :: MPI
     INTEGER                   :: allocStat
     !--------------------------------------------------------------------------
-    INTENT(IN)                :: IO, EQN
+    INTENT(IN)                :: IO, EQN, MPI
     INTENT(INOUT)             :: MESH
     !--------------------------------------------------------------------------
 

--- a/src/Geometry/allocate_mesh.f90
+++ b/src/Geometry/allocate_mesh.f90
@@ -106,7 +106,7 @@ CONTAINS
     
     IF (allocStat .NE. 0) THEN
         logError(*) 'allocate_mesh_level0_1: could not allocate the whole mesh!'
-        call exit(134)
+        call MPI_ABORT(MPI%commWorld, 134)
     END IF
     !
   END SUBROUTINE allocate_mesh_level0_1
@@ -151,7 +151,7 @@ CONTAINS
   !  
   !  IF (allocStat .NE. 0) THEN
   !      WRITE(IO%UNIT%errOut,*) 'ERROR allocate_mesh_level0_1: could not allocate the whole mesh!'
-  !      call exit(134)
+  !      call MPI_ABORT(MPI%commWorld, 134)
   !  END IF
   !  !
   !END SUBROUTINE allocate_ncmesh_level0_1
@@ -191,7 +191,7 @@ CONTAINS
 
     IF (allocStat .NE. 0) THEN
        logError(*) 'allocate_mesh_level0_2: could not allocate the whole mesh!'
-       call exit(134)
+       call MPI_ABORT(MPI%commWorld, 134)
     END IF
     
     MESH%VRTX%xyNode                = 0                                                !

--- a/src/Initializer/dg_setup.f90
+++ b/src/Initializer/dg_setup.f90
@@ -301,7 +301,7 @@ CONTAINS
     l_gts = minval( optionalFields%dt_convectiv(:) )
     if (l_gts .le. 0.0) then
       logError(*) 'Invalid timestep width'
-      call exit(134)
+      call MPI_ABORT(MPI%commWorld, 134)
     endif
 
 #ifdef PERIODIC_LTS_SCALING
@@ -385,7 +385,7 @@ CONTAINS
          STAT = allocstat                                                                       )
     IF(allocStat .NE. 0) THEN
        logError(*) 'could not allocate all variables!'
-       call exit(134)
+       call MPI_ABORT(MPI%commWorld, 134)
     END IF
     !
     IF(DISC%Galerkin%DGMethod.EQ.3) THEN
@@ -393,7 +393,7 @@ CONTAINS
                   STAT = allocstat )
         IF(allocStat .NE. 0) THEN
            logError(*) 'could not allocate DISC%Galerkin%DGTayl.'
-           call exit(134)
+           call MPI_ABORT(MPI%commWorld, 134)
         END IF
     ENDIF
 
@@ -480,12 +480,12 @@ CONTAINS
                                                      timeHistories     = SOURCE%RP%TimeHist       )
     case default
       logError(*) 'Generated Kernels: Unsupported source type: ', SOURCE%Type
-      call exit(134)
+      call MPI_ABORT(MPI%commWorld, 134)
   end select
 
   if (DISC%Galerkin%FluxMethod .ne. 0) then
     logError(*) 'Generated kernels currently supports Godunov fluxes only.'
-    call exit(134)
+    call MPI_ABORT(MPI%commWorld, 134)
   endif
 
   call c_interoperability_initializeEasiBoundaries(trim(EQN%BoundaryFileName) // c_null_char)
@@ -587,7 +587,7 @@ CONTAINS
     IF(DISC%Galerkin%CKMethod.EQ.1) THEN ! not yet done for hybrids
         print*,' ERROR in SUBROUTINE iniGalerkin3D_us_level2_new'
         PRINT*,' DISC%Galerkin%CKMethod.EQ.1 not implemented'
-        call exit(134)
+        call MPI_ABORT(MPI%commWorld, 134)
         !
     ENDIF
   END SUBROUTINE iniGalerkin3D_us_level2_new
@@ -682,12 +682,12 @@ CONTAINS
 
     IF(.NOT.DISC%Galerkin%init) THEN
        logError(*) 'iniGalerkin: SeisSol Interface not initialized!!'
-       call exit(134)
+       call MPI_ABORT(MPI%commWorld, 134)
     ENDIF
 
     IF(MESH%nElem_Tet.EQ.0 .AND. MESH%nElem_Hex.EQ.0) THEN
        logError(*) 'Quadraturefree ADER-DG is only implemented for tetrahedral and hexahedral.'
-       call exit(134)
+       call MPI_ABORT(MPI%commWorld, 134)
     ENDIF
 
     ! Reading polynomial coefficients and mass matrices
@@ -703,7 +703,7 @@ CONTAINS
                  STAT = allocstat                                                                                      )
         IF(allocStat .NE. 0) THEN
            logError(*) 'could not allocate all variables!'
-           call exit(134)
+           call MPI_ABORT(MPI%commWorld, 134)
         END IF
     ENDIF ! Tets
 
@@ -767,19 +767,19 @@ CONTAINS
         ! assert contant material parameters per element
         if ( disc%galerkin%nDegFrMat .ne. 1 ) then
           logError(*) 'iniGalerkin3D_us_intern_new, disc%galerkin%nDegFrMat not equal 1.', disc%galerkin%nDegFrMat
-          call exit(134)
+          call MPI_ABORT(MPI%commWorld, 134)
         endif
 
         ! assert 4 sides for tetrahedrons
         if ( mesh%nSides_tet .ne. 4 ) then
           logError(*) 'iniGalerkin3D_us_intern_new, mesh%nSides_tet not equal 4.', mesh%nSides_tet
-          call exit(134)
+          call MPI_ABORT(MPI%commWorld, 134)
         endif
 
         ! assert 3 vertices for triangles
          if ( mesh%nVertices_tri .ne. 3 ) then
           logError(*) 'iniGalerkin3D_us_intern_new, mesh%nVertices_tri not equal 3.', mesh%nVertices_tri
-          call exit(134)
+          call MPI_ABORT(MPI%commWorld, 134)
         endif
 #endif
     ENDIF ! Tetras
@@ -837,7 +837,7 @@ CONTAINS
     !
     IF(.NOT.DISC%Galerkin%init) THEN
        logError(*) 'icGalerkin: SeisSol Interface not initialized!!'
-       call exit(134)
+       call MPI_ABORT(MPI%commWorld, 134)
     ENDIF
     !
     ALLOCATE(EQN%Energy(3,1:MESH%nElem))
@@ -1035,7 +1035,7 @@ CONTAINS
               STAT=allocstat )
     IF (allocStat .NE. 0) THEN
        logError(*) 'Interface SeisSol: could not allocate all variables!'
-       call exit(134)
+       call MPI_ABORT(MPI%commWorld, 134)
     END IF
 
     ! Calculating boundary surfaces (3D)
@@ -1157,7 +1157,7 @@ CONTAINS
     IF(minv.LE.1e-15) THEN
         logError(*) 'Mesh contains a singular tetrahedron with radius ', minv
         logError(*) 'Element number and position : ', minl(1), MESH%ELEM%xyBary(:,minl(1))
-        call exit(134)
+        call MPI_ABORT(MPI%commWorld, 134)
     ENDIF
     DISC%DynRup%DynRup_out_elementwise%DR_pick_output = .FALSE.
     DISC%DynRup%DynRup_out_elementwise%nDR_pick       = 0
@@ -1287,7 +1287,7 @@ CONTAINS
                      END SELECT
                 ELSE
                    PRINT *, ' ERROR: local order must not be less or equal to zero! ', iLayer
-                   call exit(134)
+                   call MPI_ABORT(MPI%commWorld, 134)
                 ENDIF
             ELSE
                 !

--- a/src/Initializer/dg_setup.f90
+++ b/src/Initializer/dg_setup.f90
@@ -274,7 +274,7 @@ CONTAINS
     
     ! ------------------------------------------------------------------------!
     !
-    CALL iniGalerkin3D_us_intern_new(EQN, DISC, MESH, BND, IC, SOURCE, OptionalFields, IO)
+    CALL iniGalerkin3D_us_intern_new(EQN, DISC, MESH, BND, IC, SOURCE, OptionalFields, IO, MPI)
     !
     CALL BuildSpecialDGGeometry3D_new(OptionalFields%BackgroundValue,EQN,MESH,DISC,BND,MPI,IO)
 
@@ -288,14 +288,16 @@ CONTAINS
                           optionalFields, &
                           eqn,            &
                           mesh,           &
-                          io                )
+                          io,             &
+                          mpi                )
 
     ! get the time step width for every tet
     call cfl_step( optionalFields, &
                    eqn,            &
                    mesh,           &
                    disc,           &
-                   io                )
+                   io,             &
+                   mpi                )
 
     ! get gts time step width
     l_gts = minval( optionalFields%dt_convectiv(:) )
@@ -599,7 +601,7 @@ CONTAINS
   !!                                                                         !!
   !===========================================================================!
 
-  SUBROUTINE iniGalerkin3D_us_intern_new(EQN, DISC, MESH, BND, IC, SOURCE, OptionalFields, IO)
+  SUBROUTINE iniGalerkin3D_us_intern_new(EQN, DISC, MESH, BND, IC, SOURCE, OptionalFields, IO, MPI)
     !-------------------------------------------------------------------------!
 
     USE DGBasis_mod
@@ -619,6 +621,7 @@ CONTAINS
     TYPE(tSource)            :: SOURCE
     TYPE(tUnstructOptionalFields)   :: OptionalFields
     TYPE(tInputOutput)       :: IO
+    TYPE(tMPI)               :: MPI
     !-------------------------------------------------------------------------!
     ! Local variable declaration                                              !
     INTEGER :: allocstat                                  ! Allocation status !
@@ -760,7 +763,8 @@ CONTAINS
                  IntGaussW  = DISC%Galerkin%BndGaussW_Tet,     &
                  M          = DISC%Galerkin%nPoly+2,           &
                  IO         = IO,                              &
-                 quiet      = .TRUE.                           )
+                 quiet      = .TRUE.,                          &
+                 MPI        = MPI                              )
 #endif
 
 #ifndef NDEBUG
@@ -797,7 +801,7 @@ CONTAINS
   !===========================================================================!
 
 
-  SUBROUTINE icGalerkin3D_us_new(EQN, DISC, MESH, IC, SOURCE, IO)
+  SUBROUTINE icGalerkin3D_us_new(EQN, DISC, MESH, IC, SOURCE, IO, MPI)
     !-------------------------------------------------------------------------!
     use iso_c_binding, only: c_loc
     use f_ftoc_bind_interoperability
@@ -811,6 +815,7 @@ CONTAINS
     TYPE(tInitialCondition)  :: IC
     TYPE(tSource)            :: SOURCE
     TYPE(tInputOutput)       :: IO
+    TYPE(tMPI)               :: MPI
     !-------------------------------------------------------------------------!
     ! Local variable declaration                                              !
     INTEGER :: iElem                                                          ! Element number

--- a/src/Initializer/ini_optionalfields.f90
+++ b/src/Initializer/ini_optionalfields.f90
@@ -59,7 +59,7 @@ MODULE ini_OptionalFields_mod
 
 CONTAINS
   
-  SUBROUTINE ini_OptionalFields(OptionalFields,SOURCE,EQN,MESH,DISC,IO)
+  SUBROUTINE ini_OptionalFields(OptionalFields,SOURCE,EQN,MESH,DISC,IO,MPI)
     !--------------------------------------------------------------------------
     IMPLICIT NONE
     !--------------------------------------------------------------------------
@@ -69,11 +69,12 @@ CONTAINS
     TYPE (tUnstructMesh)               :: MESH
     TYPE (tDiscretization)             :: DISC
     TYPE (tInputOutput)                :: IO
+    TYPE (tMPI)                        :: MPI
     !local Variables
     INTEGER                            :: allocstat(20)
     INTEGER                            :: RK_size
     ! -------------------------------------------------------------------------
-    INTENT(IN)                         :: SOURCE,EQN,MESH,DISC,IO
+    INTENT(IN)                         :: SOURCE,EQN,MESH,DISC,IO,MPI
     INTENT(INOUT)                      :: OptionalFields
     ! -------------------------------------------------------------------------
     !                                                                          

--- a/src/Initializer/ini_optionalfields.f90
+++ b/src/Initializer/ini_optionalfields.f90
@@ -105,7 +105,7 @@ CONTAINS
     IF (SUM(ABS(allocStat(:))).NE.0) THEN                                       
        logError(*) 'Allocation error in ini_opt_fields. '
        logError(*) 'Status: ', allocstat(:)
-       call exit(134)                                                                    
+       call MPI_ABORT(MPI%commWorld, 134)                                                                    
     END IF                                                                              
     !
   END SUBROUTINE ini_OptionalFields

--- a/src/Initializer/ini_seissol.f90
+++ b/src/Initializer/ini_seissol.f90
@@ -249,7 +249,7 @@ CONTAINS
     !                                                                          !
     IF (allocStat .NE. 0) THEN                                                 ! Error Handling
        logError(*) 'could not allocate all variables!'      !
-       call exit(134)     
+       call MPI_ABORT(MPI%commWorld, 134)     
     END IF                                                                     !
     !                                                                          !
     pvar(:,:)  = 0.                                                            ! Initialize
@@ -299,7 +299,7 @@ CONTAINS
 
         IF(BND%periodic.NE.0)THEN
            logError(*) 'MetisWeights can only be computed for non-periodic boundary conditions!'
-           call exit(134)
+           call MPI_ABORT(MPI%commWorld, 134)
         ENDIF
 
         ALLOCATE(MetisWeight(MESH%nElem))
@@ -361,7 +361,7 @@ CONTAINS
         logInfo(*) 'Metis weights computed successfully!'
         logInfo(*) 'weighted graph file written to ',TRIM(IO%MetisFile) // '.dgraph.weighted'
         logInfo(*) 'Terminating Programm !'
-        call exit(134)
+        call MPI_ABORT(MPI%commWorld, 134)
     ENDIF
 #endif
 

--- a/src/Initializer/ini_seissol.f90
+++ b/src/Initializer/ini_seissol.f90
@@ -262,7 +262,8 @@ CONTAINS
          EQN            = EQN                           , &                    !            OptionalFields%Backgroundvalue
          MESH           = MESH                          , &                    !
          DISC           = DISC                          , &                    !
-         IO             = IO                              )                    !
+         IO             = IO                            , &                     !
+         MPI            = MPI                             )                    !
     !                                                                          !
     !
     IF (EQN%linearized) THEN                                                   !
@@ -366,7 +367,7 @@ CONTAINS
 #endif
 
     ! TODO do we need to call this function when we read a checkpoint?? (SR)
-    CALL icGalerkin3D_us_new(EQN, DISC, MESH, IC, SOURCE, IO)
+    CALL icGalerkin3D_us_new(EQN, DISC, MESH, IC, SOURCE, IO, MPI)
     ! Pre-compute basis functions at Gauss points of non-conforming boundaries
  !   CALL NonConformingGPEvaluation3D(DISC, MESH, IO, BND)
  !   CALL DGSponge(0., EQN, DISC, MESH, BND, IC, SOURCE, IO) ! not yet done for hybrids/unified version

--- a/src/Numerical_aux/dgbasis.f90
+++ b/src/Numerical_aux/dgbasis.f90
@@ -663,7 +663,7 @@ contains
         if(count>20) then
             write(*,*) ' | Error in QuadTrafoXY2XiEta. '
             write(*,*) ' |  Inverse of Jacobian not founded.'
-            call exit(134)
+            call MPI_ABORT(MPI%commWorld, 134)
         endif
     enddo
     

--- a/src/Numerical_aux/dgbasis.f90
+++ b/src/Numerical_aux/dgbasis.f90
@@ -43,6 +43,7 @@
 module DGBasis_mod
   !---------------------------------------------------------------------------!
   use TypesDef
+  use MPI_f08
   !---------------------------------------------------------------------------!
   implicit none
   private
@@ -663,7 +664,7 @@ contains
         if(count>20) then
             write(*,*) ' | Error in QuadTrafoXY2XiEta. '
             write(*,*) ' |  Inverse of Jacobian not founded.'
-            call MPI_ABORT(MPI%commWorld, 134)
+            call MPI_ABORT(MPI_COMM_WORLD, 134)
         endif
     enddo
     

--- a/src/Numerical_aux/operators.f90
+++ b/src/Numerical_aux/operators.f90
@@ -43,6 +43,7 @@
 MODULE COMMON_operators_mod
   !----------------------------------------------------------------------------
   USE typesDef
+  USE mpi_f08
   !----------------------------------------------------------------------------
   IMPLICIT NONE
   PRIVATE
@@ -607,7 +608,7 @@ CONTAINS
     IF(.NOT.fexist) THEN                                                     !
        logError(*) 'Error opening unit    : ',UnitNr              !
        logError(*) 'Unit is already open under the name:',TRIM(AllreadyOpenFileName)
-       call MPI_ABORT(MPI%commWorld, 134)                                                                  !
+       call MPI_ABORT(MPI_COMM_WORLD, 134)                                                                  !
     ENDIF                                                                    !
     !                                                                        !        
     IF (create) THEN                                                         !
@@ -623,7 +624,7 @@ CONTAINS
        IF(.NOT.fexist) THEN                                                  !
           logError(*) 'Error opening file    : ', Name            !
           logError(*) 'File does not exist.'                       !
-          call MPI_ABORT(MPI%commWorld, 134)                                                               !
+          call MPI_ABORT(MPI_COMM_WORLD, 134)                                                               !
        ENDIF                                                                 !
        !                                                                     !
     END IF                                                                   !
@@ -638,7 +639,7 @@ CONTAINS
        logError(*) 'could not open ',Name                   !
        logError(*) 'File does exist but cannot be opened.'         !
        logError(*) 'IOSTAT:',status                                !
-       call MPI_ABORT(MPI%commWorld, 134)                                                                  !
+       call MPI_ABORT(MPI_COMM_WORLD, 134)                                                                  !
     END IF                                                                   !
     !                                                                        !        
   END SUBROUTINE OpenFile
@@ -952,7 +953,7 @@ CONTAINS
     IF(d.LT.0.) THEN
         PRINT *, ' d negative in ZerosPolyO2. No real roots found! '
         PRINT *, d
-        call MPI_ABORT(MPI%commWorld, 134)
+        call MPI_ABORT(MPI_COMM_WORLD, 134)
     ENDIF
     !
     solution(1) = (-b-SQRT(d))/(2.*a)
@@ -1060,7 +1061,7 @@ CONTAINS
     IF(ABS(AIMAG(s)).GT.1e-6*ABS(y)) THEN
         PRINT *, ' Real root of aux. poly not real in ZerosPolyO4! '
         PRINT *, s
-        call MPI_ABORT(MPI%commWorld, 134)
+        call MPI_ABORT(MPI_COMM_WORLD, 134)
     ENDIF
     ! Aux. variables A+/-
     Ap = SQRT(8.*y+b*b-4*c) 
@@ -1077,7 +1078,7 @@ CONTAINS
     IF(d2.LT.0.) THEN
         PRINT *, ' d2 (using A+) negative in ZerosPolyO4. No real roots found! '
         PRINT *, d2
-        call MPI_ABORT(MPI%commWorld, 134)
+        call MPI_ABORT(MPI_COMM_WORLD, 134)
     ENDIF
     !
     solution(1) = (-b2-SQRT(d2))/(2.*a2)
@@ -1092,7 +1093,7 @@ CONTAINS
     IF(d2.LT.0.) THEN
         PRINT *, ' d2 (using A-) negative in ZerosPolyO4. No real roots found! '
         PRINT *, d2
-        call MPI_ABORT(MPI%commWorld, 134)
+        call MPI_ABORT(MPI_COMM_WORLD, 134)
     ENDIF
     !
     solution(3) = (-b2-SQRT(d2))/(2.*a2)

--- a/src/Numerical_aux/operators.f90
+++ b/src/Numerical_aux/operators.f90
@@ -607,7 +607,7 @@ CONTAINS
     IF(.NOT.fexist) THEN                                                     !
        logError(*) 'Error opening unit    : ',UnitNr              !
        logError(*) 'Unit is already open under the name:',TRIM(AllreadyOpenFileName)
-       call exit(134)                                                                  !
+       call MPI_ABORT(MPI%commWorld, 134)                                                                  !
     ENDIF                                                                    !
     !                                                                        !        
     IF (create) THEN                                                         !
@@ -623,7 +623,7 @@ CONTAINS
        IF(.NOT.fexist) THEN                                                  !
           logError(*) 'Error opening file    : ', Name            !
           logError(*) 'File does not exist.'                       !
-          call exit(134)                                                               !
+          call MPI_ABORT(MPI%commWorld, 134)                                                               !
        ENDIF                                                                 !
        !                                                                     !
     END IF                                                                   !
@@ -638,7 +638,7 @@ CONTAINS
        logError(*) 'could not open ',Name                   !
        logError(*) 'File does exist but cannot be opened.'         !
        logError(*) 'IOSTAT:',status                                !
-       call exit(134)                                                                  !
+       call MPI_ABORT(MPI%commWorld, 134)                                                                  !
     END IF                                                                   !
     !                                                                        !        
   END SUBROUTINE OpenFile
@@ -952,7 +952,7 @@ CONTAINS
     IF(d.LT.0.) THEN
         PRINT *, ' d negative in ZerosPolyO2. No real roots found! '
         PRINT *, d
-        call exit(134)
+        call MPI_ABORT(MPI%commWorld, 134)
     ENDIF
     !
     solution(1) = (-b-SQRT(d))/(2.*a)
@@ -1060,7 +1060,7 @@ CONTAINS
     IF(ABS(AIMAG(s)).GT.1e-6*ABS(y)) THEN
         PRINT *, ' Real root of aux. poly not real in ZerosPolyO4! '
         PRINT *, s
-        call exit(134)
+        call MPI_ABORT(MPI%commWorld, 134)
     ENDIF
     ! Aux. variables A+/-
     Ap = SQRT(8.*y+b*b-4*c) 
@@ -1077,7 +1077,7 @@ CONTAINS
     IF(d2.LT.0.) THEN
         PRINT *, ' d2 (using A+) negative in ZerosPolyO4. No real roots found! '
         PRINT *, d2
-        call exit(134)
+        call MPI_ABORT(MPI%commWorld, 134)
     ENDIF
     !
     solution(1) = (-b2-SQRT(d2))/(2.*a2)
@@ -1092,7 +1092,7 @@ CONTAINS
     IF(d2.LT.0.) THEN
         PRINT *, ' d2 (using A-) negative in ZerosPolyO4. No real roots found! '
         PRINT *, d2
-        call exit(134)
+        call MPI_ABORT(MPI%commWorld, 134)
     ENDIF
     !
     solution(3) = (-b2-SQRT(d2))/(2.*a2)

--- a/src/Numerical_aux/quadpoints.f90
+++ b/src/Numerical_aux/quadpoints.f90
@@ -127,7 +127,7 @@ CONTAINS
        ALLOCATE(IntGaussP(2,nIntGP),STAT=allocstat)
        IF (allocStat .NE. 0) THEN
           logError(*) 'TriangleQuadraturePoints: could not allocate all variables!'
-          call exit(134)
+          call MPI_ABORT(MPI%commWorld, 134)
        END IF
     ENDIF
     IF(.NOT.ASSOCIATED(IntGaussW)) THEN
@@ -139,14 +139,14 @@ CONTAINS
        ALLOCATE(IntGaussW(nIntGP),STAT=allocstat)
        IF (allocStat .NE. 0) THEN
           logError(*) 'TriangleQuadraturePoints: could not allocate all variables!'
-          call exit(134)
+          call MPI_ABORT(MPI%commWorld, 134)
        END IF
     ENDIF
 
     ALLOCATE(mu1(M), mu2(M), A1(M), A2(M), STAT = allocstat)
     IF (allocStat .NE. 0) THEN
        logError(*) 'TriangleQuadraturePoints: could not allocate all variables!'
-       call exit(134)
+       call MPI_ABORT(MPI%commWorld, 134)
     END IF
 
     !CALL gaujac(mu1,A1,M,1.,0.)     ! Get the Gauss-Jacobi positions and weights
@@ -233,7 +233,7 @@ CONTAINS
        ALLOCATE(IntGaussP(3,nIntGP),STAT=allocstat)
        IF (allocStat .NE. 0) THEN
           logError(*) 'TriangleQuadraturePoints: could not allocate all variables!'
-          call exit(134)
+          call MPI_ABORT(MPI%commWorld, 134)
        END IF
     ENDIF
     IF(.NOT.ASSOCIATED(IntGaussW)) THEN
@@ -243,14 +243,14 @@ CONTAINS
        ALLOCATE(IntGaussW(nIntGP),STAT=allocstat)
        IF (allocStat .NE. 0) THEN
           logError(*) 'TriangleQuadraturePoints: could not allocate all variables!'
-          call exit(134)
+          call MPI_ABORT(MPI%commWorld, 134)
        END IF
     ENDIF
 
     ALLOCATE(mu1(M), mu2(M), mu3(M), A1(M), A2(M), A3(M), STAT = allocstat)
     IF (allocStat .NE. 0) THEN
        logError(*) 'TriangleQuadraturePoints: could not allocate all variables!'
-       call exit(134)
+       call MPI_ABORT(MPI%commWorld, 134)
     END IF
 
     !CALL gaujac(mu1,A1,M,2.,0.)     ! Get the Gauss-Jacobi positions and weights
@@ -351,7 +351,7 @@ CONTAINS
           logError(*)                             &               !
                'Error in HypercubeQuadraturePoints: ',        &               !
                'could not allocate all variables!'                            !
-          call exit(134)                                                                !
+          call MPI_ABORT(MPI%commWorld, 134)                                                                !
        END IF                                                                 !
     ENDIF                                                                     !
     IF(.NOT.ASSOCIATED(IntGaussW)) THEN                                       !
@@ -365,7 +365,7 @@ CONTAINS
           logError(*)                             &               !
                'Error in HypercubeQuadraturePoints: ',        &               !
                'could not allocate all variables!'                            !
-          call exit(134)                                                                !
+          call MPI_ABORT(MPI%commWorld, 134)                                                                !
        END IF                                                                 !
     ENDIF                                                                     !
     !                                                                         !
@@ -375,7 +375,7 @@ CONTAINS
        logError(*)                               &                !
             'Error in HypercubeQuadraturePoints: ',          &                !
             'could not allocate all variables!'                               !
-       call exit(134)                                                                   !
+       call MPI_ABORT(MPI%commWorld, 134)                                                                   !
     END IF                                                                    !
     !                                                                         !
     DO iDim = 1, nDim                                                         !
@@ -440,7 +440,7 @@ CONTAINS
        ALLOCATE(Points(nPoints,2),STAT=allocstat)
        IF (allocStat .NE. 0) THEN
           logError(*) 'TriangleQuadraturePoints: could not allocate all variables!'
-          call exit(134)
+          call MPI_ABORT(MPI%commWorld, 134)
        END IF
     ENDIF
 
@@ -473,7 +473,7 @@ CONTAINS
        counter = counter  + 1
        IF(counter.GT.nPoints) THEN
           logError(*) 'Error in Divide. counter > nPoints', counter
-          call exit(134)
+          call MPI_ABORT(MPI%commWorld, 134)
        ENDIF
        Points(counter,:) = 1./3.*(XY(1,:)+XY(2,:)+XY(3,:))
        RETURN

--- a/src/Numerical_aux/quadpoints.f90
+++ b/src/Numerical_aux/quadpoints.f90
@@ -78,7 +78,7 @@ CONTAINS
 
   ! Quadrature formula of arbitrary accuracy on the reference triangle
   ! consisting of the nodes (0,0), (1,0), (0,1)
-  SUBROUTINE TriangleQuadraturePoints(nIntGP,IntGaussP,IntGaussW,M,IO,quiet)
+  SUBROUTINE TriangleQuadraturePoints(nIntGP,IntGaussP,IntGaussW,M,IO,quiet,MPI)
     !-------------------------------------------------------------------------!
     USE gauss_mod
     !-------------------------------------------------------------------------!
@@ -90,6 +90,7 @@ CONTAINS
     REAL, POINTER         :: IntGaussW(:)   ! Weights of 2D int. points       !
     INTEGER               :: M              ! Number of 1D Gausspoints        !
     TYPE(tInputOutput)    :: IO             ! IO structure                    !
+    TYPE (tMPI)           :: MPI
     LOGICAL, OPTIONAL     :: quiet          ! if quiet then less warnings     !
     !-------------------------------------------------------------------------!
     ! Local variable declaration                                              !
@@ -103,7 +104,7 @@ CONTAINS
     REAL, POINTER   :: A2(:)                ! 1D quadrature weights for y2    !
     LOGICAL         :: quiet_internal       ! map of OPTIONAL quiet           !
     !-------------------------------------------------------------------------!
-    INTENT(IN)      :: M, IO, quiet
+    INTENT(IN)      :: M, IO, quiet, MPI
     INTENT(OUT)     :: nIntGP
     !-------------------------------------------------------------------------!
     tol = 1.0 / (10.0**(PRECISION(1.0)-2) )                                   !
@@ -184,7 +185,7 @@ CONTAINS
   ! Quadrature formula of arbitrary accuracy on the reference tetrahedron
   ! consisting of the nodes (0,0,0), (1,0,0), (0,1,0), (0,0,1)
 
-  SUBROUTINE TetrahedronQuadraturePoints(nIntGP,IntGaussP,IntGaussW,M,IO,quiet)
+  SUBROUTINE TetrahedronQuadraturePoints(nIntGP,IntGaussP,IntGaussW,M,IO,quiet, MPI)
     !-------------------------------------------------------------------------!
     USE gauss_mod
     !-------------------------------------------------------------------------!
@@ -196,6 +197,7 @@ CONTAINS
     REAL, POINTER         :: IntGaussW(:)   ! Weights of 2D int. points       !
     INTEGER               :: M              ! Number of 1D Gausspoints        !
     TYPE(tInputOutput)    :: IO             ! IO structure                    !
+    TYPE (tMPI)           :: MPI
     LOGICAL, OPTIONAL     :: quiet          ! if quiet then less warnings     !
     !-------------------------------------------------------------------------!
     ! Local variable declaration                                              !
@@ -294,7 +296,7 @@ CONTAINS
 
   ! Quadrature formula of arbitrary accuracy on the physical hypercube 
   ! [x1_1, x2_1] x [x1_2, x2_2] x ... x [x1_n, x2_n]
-  SUBROUTINE HypercubeQuadraturePoints(nIntGP,IntGaussP,IntGaussW, M,nDim,X1,X2,IO,quiet )
+  SUBROUTINE HypercubeQuadraturePoints(nIntGP,IntGaussP,IntGaussW, M,nDim,X1,X2,IO,quiet,MPI)
     !-------------------------------------------------------------------------!
     use gauss_mod
     !-------------------------------------------------------------------------!
@@ -311,6 +313,7 @@ CONTAINS
     REAL                  :: X2(nDim)       ! Physical hypercube corner 2     !
     REAL                  :: tol            ! Tolerance of 0.0                !
     TYPE(tInputOutput)    :: IO             ! IO structure                    !
+    TYPE (tMPI)           :: MPI
     LOGICAL, OPTIONAL     :: quiet          ! if quiet then less warnings     !
     !-------------------------------------------------------------------------!
     ! Local variable declaration                                              !
@@ -323,7 +326,7 @@ CONTAINS
     REAL, POINTER   :: A(:,:)               ! 1D quadrature weights           !
     LOGICAL         :: quiet_internal       ! map of OPTIONAL quiet           !
     !-------------------------------------------------------------------------!
-    INTENT(IN)      :: M, X1, X2, IO, quiet
+    INTENT(IN)      :: M, X1, X2, IO, quiet, MPI
     INTENT(OUT)     :: nIntGP
     !-------------------------------------------------------------------------!
     tol = 1.0 / (10.0**(PRECISION(1.0)-2) )                                   !
@@ -415,12 +418,13 @@ CONTAINS
 
   ! Subroutine that subdivides a triangle with vertex coordinates X(:) and Y(:)
   ! regularly. Resulting number of points is 4^M
-  SUBROUTINE TriangleSubPoints(nPoints,Points,M,IO)
+  SUBROUTINE TriangleSubPoints(nPoints,Points,M,IO,MPI)
     !-------------------------------------------------------------------------!
     IMPLICIT NONE
     !-------------------------------------------------------------------------!
     ! Argument list declaration                                               !
     TYPE(tInputOutput)    :: IO             ! IO structure                    !
+    TYPE (tMPI)           :: MPI
     INTEGER               :: nPoints        ! Number of 2D points             !
     REAL, POINTER         :: Points(:,:)    ! Positions of 2D points          !
     INTEGER               :: M              ! Number of recursions            !
@@ -451,15 +455,16 @@ CONTAINS
     recdepth = 0
     counter  = 0
     !
-    CALL Divide(Points, counter, recdepth, M, nPoints, XY)
+    CALL Divide(Points, counter, recdepth, M, nPoints, XY, MPI)
     !
   END SUBROUTINE TriangleSubPoints
 
-  RECURSIVE SUBROUTINE Divide(Points, counter, recdepth, M, nPoints, XY)
+  RECURSIVE SUBROUTINE Divide(Points, counter, recdepth, M, nPoints, XY, MPI)
     !-------------------------------------------------------------------------!
     IMPLICIT NONE
     !-------------------------------------------------------------------------!
     ! Argument list declaration                                               !
+    TYPE (tMPI)           :: MPI
     INTEGER               :: counter,recdepth, M, nPoints
     REAL                  :: XY(3,2) 
     REAL                  :: Points(nPoints,2)
@@ -503,7 +508,7 @@ CONTAINS
     NewXY(4,3,:) = MidSide(3,:)
 
     DO i = 1, 4
-       CALL Divide(Points,counter,recdepth+1,M,nPoints,NewXY(i,:,:))
+       CALL Divide(Points,counter,recdepth+1,M,nPoints,NewXY(i,:,:), MPI)
     ENDDO
         
   END SUBROUTINE Divide

--- a/src/Physics/Evaluate_friction_law.f90
+++ b/src/Physics/Evaluate_friction_law.f90
@@ -180,7 +180,7 @@ MODULE Eval_friction_law_mod
 
         CASE DEFAULT
           logError(*) 'ERROR in friction.f90: friction law case',EQN%FL,' not implemented!'
-          call exit(134)
+          call MPI_ABORT(MPI%commWorld, 134)
     END SELECT    
 
   END SUBROUTINE Eval_friction_law
@@ -976,7 +976,7 @@ MODULE Eval_friction_law_mod
             !logError(*) 'nonConvergence RS Newton', time
             if (tmp(1).NE.tmp(1)) then
                logError(*) 'NaN detected', time
-               call exit(134)
+               call MPI_ABORT(MPI%commWorld, 134)
             endif
          ENDIF
          
@@ -1129,7 +1129,7 @@ MODULE Eval_friction_law_mod
 
     IF (ANY(IsNaN(LocSV)) .EQV. .TRUE.) THEN
        logError(*) 'NaN detected'
-       call exit(134)
+       call MPI_ABORT(MPI%commWorld, 134)
     ENDIF
 
 

--- a/src/Physics/Evaluate_friction_law.f90
+++ b/src/Physics/Evaluate_friction_law.f90
@@ -942,7 +942,7 @@ MODULE Eval_friction_law_mod
              !
              !fault strength using LocMu and P_f from previous timestep/iteration
              !1.update SV using Vold from the previous time step
-             CALL updateStateVariable (EQN, DISC, iFace, nBndGP, SV0, time_inc, SR_tmp, LocSV)
+             CALL updateStateVariable (EQN, DISC, iFace, nBndGP, SV0, time_inc, SR_tmp, LocSV, MPI)
              IF (DISC%DynRup%ThermalPress.EQ.1) THEN
                  S = -LocMu*(P - P_f)
                  DO iBndGP = 1, nBndGP
@@ -982,7 +982,7 @@ MODULE Eval_friction_law_mod
          
          ! 5. get final theta, mu, traction and slip
          ! SV from mean slip rate in tmp
-         CALL updateStateVariable (EQN, DISC, iFace, nBndGP, SV0, time_inc, SR_tmp, LocSV)
+         CALL updateStateVariable (EQN, DISC, iFace, nBndGP, SV0, time_inc, SR_tmp, LocSV, MPI)
 
          IF (DISC%DynRup%ThermalPress.EQ.1) THEN
              S = -LocMu*(P - P_f)
@@ -1083,12 +1083,13 @@ MODULE Eval_friction_law_mod
   !
  END SUBROUTINE rate_and_state
 
-   SUBROUTINE updateStateVariable (EQN, DISC, iFace, nBndGP, SV0, time_inc, SR_tmp, LocSV)
+   SUBROUTINE updateStateVariable (EQN, DISC, iFace, nBndGP, SV0, time_inc, SR_tmp, LocSV, MPI)
     !-------------------------------------------------------------------------!
     IMPLICIT NONE
     !-------------------------------------------------------------------------!
     TYPE(tEquations)               :: EQN
     TYPE(tDiscretization)          :: DISC
+    TYPE (tMPI)                    :: MPI
     ! Argument list declaration
     INTEGER                  :: iFace, nBndGP
     REAL                     :: RS_f0, RS_b, RS_a(nBndGP), RS_sr0, RS_fw, RS_srW(nBndGP), RS_sl0(nBndGP) !constant input parameters

--- a/src/Reader/read_backgroundstress.f90
+++ b/src/Reader/read_backgroundstress.f90
@@ -271,7 +271,7 @@ CONTAINS
 !~         posx_min.LT.xf_min .OR. posz_min.LT.zf_min)THEN
 !~         logError(*) 'Background stress field ',TRIM(IO%FileName_BackgroundStress),   &
 !~                     ' does not fully include the entire fault!'
-!~         call exit(134)
+!~         call MPI_ABORT(MPI%commWorld, 134)
 !~     ENDIF
 
     ! Interpolation of the background field onto the barycenter of the elements fault face
@@ -310,7 +310,7 @@ CONTAINS
 !            write(111,*) posx(i),posz(i),EQN%IniShearXY(i,1)
 !            enddo
 !            close(111)
-!            call exit(134)
+!            call MPI_ABORT(MPI%commWorld, 134)
         
     ELSEIF (GPwise == 1) THEN
         counter = 0
@@ -342,7 +342,7 @@ CONTAINS
 !            enddo
 !            enddo
 !            close(111)
-!            call exit(134)             
+!            call MPI_ABORT(MPI%commWorld, 134)             
     ENDIF ! GPwise
 
 

--- a/src/ResultWriter/energies.f90
+++ b/src/ResultWriter/energies.f90
@@ -139,7 +139,7 @@ CONTAINS
         IF(stat.NE.0) THEN                                                   !
            logError(*) 'cannot open ',ENERGY_FILE                            !
            logError(*) 'Error status: ', stat                                !
-           call exit(134)                                                              !
+           call MPI_ABORT(MPI%commWorld, 134)                                                              !
         ENDIF
     ELSE
         ! open file
@@ -152,7 +152,7 @@ CONTAINS
         IF(stat.NE.0) THEN                                                   !
            logError(*) 'cannot open ',ENERGY_FILE                            !
            logError(*) 'Error status: ', stat                                !
-           call exit(134)                                                              !
+           call MPI_ABORT(MPI%commWorld, 134)                                                              !
         ENDIF
         IF (EQN%Plasticity .EQ. 0) THEN
             WRITE(UNIT_ENERGY,*) '#time KineticEnergy '

--- a/src/ResultWriter/faultoutput.f90
+++ b/src/ResultWriter/faultoutput.f90
@@ -842,7 +842,7 @@ CONTAINS
             IF( stat.NE.0) THEN
                logError(*) 'cannot open ',ptsoutfile
                logError(*) 'Error status: ', stat
-               call exit(134)
+               call MPI_ABORT(MPI%commWorld, 134)
             END IF
             !
             DO k=1,DISC%DynRup%DynRup_out_atPickpoint%CurrentPick(iOutPoints)

--- a/src/ResultWriter/ini_faultoutput.f90
+++ b/src/ResultWriter/ini_faultoutput.f90
@@ -178,7 +178,7 @@ CONTAINS
         IF(stat.NE.0) THEN                                                   !
            logError(*) 'cannot open ',ptsoutfile          !
            logError(*) 'Error status: ', stat
-           call exit(134)                                                              !
+           call MPI_ABORT(MPI%commWorld, 134)                                                              !
         END IF                                                               !
         CLOSE( DISC%DynRup%DynRup_out_atPickpoint%VFILE(i) )
       ELSE
@@ -193,7 +193,7 @@ CONTAINS
         IF(stat.NE.0) THEN                                                   !
            logError(*) 'cannot open ',ptsoutfile           !
            logError(*) 'Error status: ', stat
-           call exit(134)                                                              !
+           call MPI_ABORT(MPI%commWorld, 134)                                                              !
         END IF                                                               !
         !
         ! Creating the header for the output File
@@ -261,7 +261,7 @@ CONTAINS
       IF( stat.NE.0) THEN
         logError(*) 'cannot open ',ptsoutfile
         logError(*) 'Error status: ', stat
-        call exit(134)
+        call MPI_ABORT(MPI%commWorld, 134)
       END IF
       !
       ! load stress values of nearest boundary GP: iBndGP

--- a/src/ResultWriter/output_rupturefront.f90
+++ b/src/ResultWriter/output_rupturefront.f90
@@ -127,7 +127,7 @@ CONTAINS
         IF(stat.NE.0) THEN                                              !
            logError(*) 'cannot open ',RF_FILE         !
            logError(*) 'Error status: ', stat                !
-           call exit(134)                                                          !
+           call MPI_ABORT(MPI%commWorld, 134)                                                          !
         ENDIF
     ELSE
         ! open file
@@ -140,7 +140,7 @@ CONTAINS
         IF(stat.NE.0) THEN                                              !
            logError(*) 'cannot open ',RF_FILE         !
            logError(*) 'Error status: ', stat                !
-           call exit(134)                                                          !
+           call MPI_ABORT(MPI%commWorld, 134)                                                          !
         ENDIF
         !
         ! add header with information of total nr of lines:

--- a/src/ResultWriter/receiver.f90
+++ b/src/ResultWriter/receiver.f90
@@ -92,7 +92,7 @@ CONTAINS
            IF (allocStat .NE. 0) THEN
                  logError(*) 'could not allocate',&
                  ' PGMarray for PGM output! '
-                 call exit(134)
+                 call MPI_ABORT(MPI%commWorld, 134)
            END IF
            MPI%PGMarray = 0.
         !ENDIF

--- a/src/ResultWriter/receiver_hdf.f90
+++ b/src/ResultWriter/receiver_hdf.f90
@@ -698,7 +698,7 @@ CONTAINS
            IF (allocStat .NE. 0) THEN
                  logError(*) 'could not allocate',&
                  ' PGMarray for PGM output! '
-                 call exit(134)
+                 call MPI_ABORT(MPI%commWorld, 134)
            END IF
            MPI%PGMarray = 0.
         !ENDIF

--- a/src/Solver/calc_deltat.f90
+++ b/src/Solver/calc_deltat.f90
@@ -68,7 +68,7 @@ MODULE calc_deltaT_mod
 
 CONTAINS
 
-  SUBROUTINE ini_calc_deltaT(EqType,OptionalFields,EQN,MESH,IO)
+  SUBROUTINE ini_calc_deltaT(EqType,OptionalFields,EQN,MESH,IO,MPI)
     !--------------------------------------------------------------------------
     IMPLICIT NONE     
     !--------------------------------------------------------------------------
@@ -76,11 +76,12 @@ CONTAINS
     TYPE (tUnstructMesh)          :: MESH
     TYPE (tUnstructOptionalFields):: OptionalFields
     TYPE (tInputOutput)           :: IO
+    TYPE (tMPI)                   :: MPI
     INTEGER                       :: EqType
     ! local Variables
     INTEGER                       :: allocStat
     !--------------------------------------------------------------------------
-    INTENT(IN)                    :: MESH,EqType,IO
+    INTENT(IN)                    :: MESH,EqType,IO, MPI
     INTENT(INOUT)                 :: OptionalFields
     !--------------------------------------------------------------------------
     !                                                                            !
@@ -130,7 +131,7 @@ CONTAINS
 !    END IF                                              !
   END SUBROUTINE close_calc_deltaT                      !
     
-  SUBROUTINE cfl_step(OptionalFields,EQN,MESH,DISC,IO)
+  SUBROUTINE cfl_step(OptionalFields,EQN,MESH,DISC,IO,MPI)
     !--------------------------------------------------------------------------
     IMPLICIT NONE
     !--------------------------------------------------------------------------
@@ -140,13 +141,14 @@ CONTAINS
     TYPE (tUnstructMesh)                  :: MESH
     TYPE (tDiscretization)                :: DISC
     TYPE (tInputOutput)                   :: IO
+    TYPE (tMPI)                           :: MPI
     ! local variable declaration
     REAL,POINTER                          :: MaterialVal(:,:)
     INTEGER                               :: iElem, iNeighbor, iSide
     INTEGER                               :: idxNeighbors(MESH%GlobalElemType)
     REAL                                  :: rho, C(6,6)
     !--------------------------------------------------------------------------
-    INTENT(IN)                            :: EQN, MESH, IO
+    INTENT(IN)                            :: EQN, MESH, IO, MPI
     INTENT(INOUT)                         :: OptionalFields
     INTENT(INOUT)                         :: DISC
     !--------------------------------------------------------------------------

--- a/src/Solver/calc_deltat.f90
+++ b/src/Solver/calc_deltat.f90
@@ -96,7 +96,7 @@ CONTAINS
     !                                                                            !
     IF (allocstat .NE. 0 ) THEN                                                  ! Error Handler
          logError(*) 'ALLOCATE ERROR in ini_calc_deltaT!'            ! Error Handler
-         call exit(134)                                                                    ! Error Handler
+         call MPI_ABORT(MPI%commWorld, 134)                                                                    ! Error Handler
     END IF                                                                       ! Error Handler
     !                                                   !
     !                                                   !
@@ -165,7 +165,7 @@ CONTAINS
            IF ((.NOT.ASSOCIATED(OptionalFields%BackgroundValue))) THEN              
               logError(*) 'OptionalFields%BackgroundValue not associated!'
               logError(*) 'although linearized Equations are specified. '
-              call exit(134)                                                                
+              call MPI_ABORT(MPI%commWorld, 134)                                                                
            END IF                                                                                                                              
            MaterialVal => OptionalFields%BackgroundValue           
            OptionalFields%vel(:) = SQRT( MaterialVal(:,4)**2 + MaterialVal(:,5)**2 + MaterialVal(:,6)**2 )

--- a/src/Solver/close_seissol.f90
+++ b/src/Solver/close_seissol.f90
@@ -105,7 +105,7 @@ CONTAINS
     DEALLOCATE (pvar,cvar,STAT=deallocStat)
     IF (deallocStat .NE. 0) THEN                                    ! Falls ein Fehler
        logError(*) 'cannot deallocate all arrays!'                  ! aufgetreten ist
-       call exit(134)                                                         ! Programmabbruch
+       call MPI_ABORT(MPI%commWorld, 134)                                                         ! Programmabbruch
     END IF                                                          !
 
     call c_interoperability_deallocateMemoryManager()

--- a/src/Solver/mpiexchangevalues.f90
+++ b/src/Solver/mpiexchangevalues.f90
@@ -122,7 +122,7 @@ CONTAINS
             counter = counter + 1
             IF(counter.GT.MsgLength) THEN
               PRINT *, 'Fatal error: Counter > MsgLength', counter, MsgLength, ' in CPU : ', MPI%myrank
-              call exit(134)
+              call MPI_ABORT(MPI%commWorld, 134)
             ENDIF
             send_message(iDomain)%Content(counter) = OptionalFields%BackgroundValue(iElem,iVar)
         ENDDO
@@ -163,7 +163,7 @@ CONTAINS
             counter = counter + 1
             IF(counter.GT.MsgLength) THEN
               PRINT *, 'Fatal error: Counter > MsgLength', counter, MsgLength, ' in CPU : ', MPI%myrank
-              call exit(134)
+              call MPI_ABORT(MPI%commWorld, 134)
             ENDIF
             BND%ObjMPI(iDomain)%NeighborBackground(iVar,i) = recv_message(iDomain)%Content(counter) 
         ENDDO

--- a/src/seissolxx.f90
+++ b/src/seissolxx.f90
@@ -113,7 +113,7 @@ open(FORTRAN_STDERR, recl=FORTRAN_LINE_SIZE)
      domain%MPI%MPI_AUTO_REAL = MPI_DOUBLE_PRECISION
    CASE DEFAULT
      logError(*) 'Unknown kind ', domain%MPI%real_kind
-     call exit(134)
+     call MPI_ABORT(MPI%commWorld, 134)
    END SELECT
    logInfo0(*) ' MPI_AUTO_REAL feature initialized. '
    domain%MPI%MPI_AUTO_INTEGER = 0

--- a/src/seissolxx.f90
+++ b/src/seissolxx.f90
@@ -113,7 +113,7 @@ open(FORTRAN_STDERR, recl=FORTRAN_LINE_SIZE)
      domain%MPI%MPI_AUTO_REAL = MPI_DOUBLE_PRECISION
    CASE DEFAULT
      logError(*) 'Unknown kind ', domain%MPI%real_kind
-     call MPI_ABORT(MPI%commWorld, 134)
+     call MPI_ABORT(domain%MPI%commWorld, 134)
    END SELECT
    logInfo0(*) ' MPI_AUTO_REAL feature initialized. '
    domain%MPI%MPI_AUTO_INTEGER = 0


### PR DESCRIPTION
I changed the `call exit(134)` to `call MPI_ABORT(MPI%commWorld, 134)`.
Same files as Sebastian previous PR.
Then I added the `USE mpi_f08` at the beginning of each file modified.
But, then I removed it in files where the compilation was complaining (because MPI_COMM_WORLD was already included in another module?).

(in the process of fixing the compilation, I changed some of the MPI_COMM_WORLD to MPI%commWorld, which should be equivalent, right?).