### PR TITLE
Fix pinning for GCC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -199,6 +199,14 @@ if (COMMTHREAD)
   target_compile_definitions(SeisSol-lib PUBLIC USE_COMM_THREAD)
 endif()
 
+if (NUMA_AWARE_PINNING)
+  target_compile_definitions(SeisSol-lib PUBLIC USE_NUMA_AWARE_PINNING)
+  find_package(NUMA REQUIRED)
+
+  target_include_directories(SeisSol-lib SYSTEM PUBLIC ${NUMA_INCLUDE_DIR})
+  target_link_libraries(SeisSol-lib PUBLIC ${NUMA_LIBRARY})
+endif()
+
 #set(HDF5_PREFER_PARALLEL True)
 if (NETCDF)
   find_package(NetCDF REQUIRED)

--- a/Documentation/supermuc.rst
+++ b/Documentation/supermuc.rst
@@ -75,6 +75,7 @@ Supermuc-NG
   module load parmetis/4.0.3-intel-impi-i64-r64 metis/5.1.0-intel-i64-r64
   module load hdf5/1.8.21-impi-cxx-frt-threadsafe 
   module load netcdf/4.6.1-intel-impi-hdf5v1.8-parallel
+  module load numactl
 
   ####### for pspamm.py
   export PATH=~/bin:$PATH
@@ -130,7 +131,7 @@ set compiler options:
 ::
 
    mkdir build-release && cd build-release
-   CC=mpiicc CXX=mpiicpc FC=mpiifort  cmake -DCOMMTHREAD=ON -DASAGI=ON -DCMAKE_BUILD_TYPE=Release -DHOST_ARCH=skx -DPRECISION=single -DORDER=4 -DCMAKE_INSTALL_PREFIX=$(pwd)/build-release -DGEMM_TOOLS_LIST=LIBXSMM,PSpaMM -DPSpaMM_PROGRAM=~/bin/pspamm.py ..
+   CC=mpiicc CXX=mpiicpc FC=mpiifort  cmake -DCOMMTHREAD=ON -DNUMA_AWARE_PINNING=ON -DASAGI=ON -DCMAKE_BUILD_TYPE=Release -DHOST_ARCH=skx -DPRECISION=single -DORDER=4 -DCMAKE_INSTALL_PREFIX=$(pwd)/build-release -DGEMM_TOOLS_LIST=LIBXSMM,PSpaMM -DPSpaMM_PROGRAM=~/bin/pspamm.py ..
    make -j 48
 
 5. Submission file for SeisSol on NG:

--- a/cmake/FindNUMA.cmake
+++ b/cmake/FindNUMA.cmake
@@ -1,0 +1,43 @@
+# Module for locating libnuma
+#
+# Read-only variables:
+#   NUMA_FOUND
+#     Indicates that the library has been found.
+#
+#   NUMA_INCLUDE_DIR
+#     Points to the libnuma include directory.
+#
+#   NUMA_LIBRARY_DIR
+#     Points to the directory that contains the libraries.
+#     The content of this variable can be passed to link_directories.
+#
+#   NUMA_LIBRARY
+#     Points to the libnuma that can be passed to target_link_libararies.
+#
+# Copyright (c) 2015 Steve Borho
+
+include(FindPackageHandleStandardArgs)
+
+find_path(NUMA_ROOT_DIR
+        NAMES include/numa.h
+        PATHS ENV NUMA_ROOT
+        DOC "NUMA root directory")
+
+find_path(NUMA_INCLUDE_DIR
+        NAMES numa.h
+        HINTS ${NUMA_ROOT_DIR}
+        PATH_SUFFIXES include
+        DOC "NUMA include directory")
+
+find_library(NUMA_LIBRARY
+        NAMES numa
+        HINTS ${NUMA_ROOT_DIR}
+        DOC "NUMA library")
+
+if (NUMA_LIBRARY)
+    get_filename_component(NUMA_LIBRARY_DIR ${NUMA_LIBRARY} PATH)
+endif()
+
+mark_as_advanced(NUMA_INCLUDE_DIR NUMA_LIBRARY_DIR NUMA_LIBRARY)
+
+find_package_handle_standard_args(NUMA REQUIRED_VARS NUMA_ROOT_DIR NUMA_INCLUDE_DIR NUMA_LIBRARY)

--- a/cmake/process_users_input.cmake
+++ b/cmake/process_users_input.cmake
@@ -67,7 +67,7 @@ set(MEMORY_LAYOUT "auto" CACHE FILEPATH "A file with a specific memory layout or
 
 option(COMMTHREAD "Use a communication thread for MPI+MP." OFF)
 
-option(NUMA_AWARE_PINNING "Use libnuma to pin threads to correct NUMA nodes" OFF)
+option(NUMA_AWARE_PINNING "Use libnuma to pin threads to correct NUMA nodes" ON)
 
 
 set(LOG_LEVEL "warning" CACHE STRING "Log level for the code")

--- a/cmake/process_users_input.cmake
+++ b/cmake/process_users_input.cmake
@@ -65,8 +65,9 @@ set(NUMBER_OF_FUSED_SIMULATIONS 1 CACHE STRING "A number of fused simulations")
 
 set(MEMORY_LAYOUT "auto" CACHE FILEPATH "A file with a specific memory layout or auto")
 
-
 option(COMMTHREAD "Use a communication thread for MPI+MP." OFF)
+
+option(NUMA_AWARE_PINNING "Use libnuma to pin threads to correct NUMA nodes" OFF)
 
 
 set(LOG_LEVEL "warning" CACHE STRING "Log level for the code")

--- a/src/Parallel/Pin.cpp
+++ b/src/Parallel/Pin.cpp
@@ -43,6 +43,12 @@
 #include <sys/sysinfo.h>
 #include <sched.h>
 #include <sstream>
+#include <set>
+#include "Parallel/MPI.h"
+
+#ifdef USE_NUMA_AWARE_PINNING
+#include "numa.h"
+#endif
 
 seissol::parallel::Pinning::Pinning() {
   // Affinity mask of the entire process
@@ -74,9 +80,38 @@ cpu_set_t seissol::parallel::Pinning::getWorkerUnionMask() const {
 }
 
 cpu_set_t seissol::parallel::Pinning::getFreeCPUsMask() const {
-  // Affinity mask of the pthreads -> all free cores
+  const auto nodeOpenMpMask = getNodeMask();
+
   cpu_set_t freeMask{};
-  CPU_XOR(&freeMask, &processMask, &openmpMask);
+  CPU_ZERO(&freeMask);
+
+#ifdef USE_NUMA_AWARE_PINNING
+  // Find all numa nodes on which some OpenMP worker is pinned to
+  std::set<int> numaDomainsOfThisProcess{};
+  for (int cpu = 0; cpu < get_nprocs(); ++cpu) {
+    if (CPU_ISSET(cpu, &openmpMask)) {
+      numaDomainsOfThisProcess.insert(numa_node_of_cpu(cpu));
+    }
+  }
+
+  // Set free mask to all free threads which are on one of our numa nodes
+  for (int cpu = 0; cpu < get_nprocs(); ++cpu) {
+    const bool isFree = !CPU_ISSET(cpu, &nodeOpenMpMask);
+    if (isFree) {
+      const int numaNode = numa_node_of_cpu(cpu);
+      const bool isValidNumaNode = numaDomainsOfThisProcess.count(numaNode) != 0;
+      if (isValidNumaNode) {
+        CPU_SET(cpu, &freeMask);
+      }
+    }
+  }
+#else
+  // Set now contains all unused cores on the machine.
+  // Note that pinning of the communication thread is then not Numa-aware if there's more than one rank per node!
+  CPU_XOR(&freeMask, &nodeMask, &freeMask);
+#endif
+
+
   return freeMask;
 }
 
@@ -102,4 +137,29 @@ std::string seissol::parallel::Pinning::maskToString(cpu_set_t const& set) {
     }
   }
   return st.str();
+}
+
+cpu_set_t seissol::parallel::Pinning::getNodeMask() const {
+  const auto workerMask = getWorkerUnionMask();
+
+  // We have to use this due to the insanity of std::vector<bool>
+  auto workerMaskArray = std::vector<char>( get_nprocs(), 0);
+  for (int cpu = 0; cpu < get_nprocs(); ++cpu) {
+    workerMaskArray[cpu] = CPU_ISSET(cpu, &workerMask);
+  }
+
+  MPI_Comm commNode;
+  MPI_Comm_split_type(MPI::mpi.comm(), MPI_COMM_TYPE_SHARED, 0, MPI_INFO_NULL, &commNode);
+  MPI_Allreduce(MPI_IN_PLACE, workerMaskArray.data(), workerMaskArray.size(), MPI_CHAR, MPI_BOR, commNode);
+
+  cpu_set_t nodeMask;
+  CPU_ZERO(&nodeMask);
+  for (int cpu = 0; cpu < get_nprocs(); ++cpu) {
+    const auto isSet = workerMaskArray[cpu] != 0;
+    if (isSet) {
+      CPU_SET(cpu, &nodeMask);
+    }
+  }
+
+  return nodeMask;
 }

--- a/src/Parallel/Pin.cpp
+++ b/src/Parallel/Pin.cpp
@@ -108,7 +108,11 @@ cpu_set_t seissol::parallel::Pinning::getFreeCPUsMask() const {
 #else
   // Set now contains all unused cores on the machine.
   // Note that pinning of the communication thread is then not Numa-aware if there's more than one rank per node!
-  CPU_XOR(&freeMask, &nodeOpenMpMask, &freeMask);
+  for (int cpu = 0; cpu < get_nprocs(); ++cpu) {
+    if (!CPU_ISSET(cpu, &nodeOpenMpMask)) {
+      CPU_SET(cpu, &freeMask);
+    }
+  }
 #endif
 
 

--- a/src/Parallel/Pin.cpp
+++ b/src/Parallel/Pin.cpp
@@ -108,7 +108,7 @@ cpu_set_t seissol::parallel::Pinning::getFreeCPUsMask() const {
 #else
   // Set now contains all unused cores on the machine.
   // Note that pinning of the communication thread is then not Numa-aware if there's more than one rank per node!
-  CPU_XOR(&freeMask, &nodeMask, &freeMask);
+  CPU_XOR(&freeMask, &nodeOpenMpMask, &freeMask);
 #endif
 
 

--- a/src/Parallel/Pin.cpp
+++ b/src/Parallel/Pin.cpp
@@ -51,9 +51,6 @@
 #endif
 
 seissol::parallel::Pinning::Pinning() {
-  // Affinity mask of the entire process
-  sched_getaffinity(0, sizeof(cpu_set_t), &processMask);
-
   // Affinity mask for the OpenMP workers
   openmpMask = getWorkerUnionMask();
 }

--- a/src/Parallel/Pin.h
+++ b/src/Parallel/Pin.h
@@ -58,6 +58,7 @@ public:
   static bool freeCPUsMaskEmpty(cpu_set_t const& set);
   void pinToFreeCPUs() const;
   static std::string maskToString(cpu_set_t const& set);
+  cpu_set_t getNodeMask() const;
 };
   }
 }

--- a/src/Parallel/Pin.h
+++ b/src/Parallel/Pin.h
@@ -47,12 +47,10 @@ namespace seissol {
   namespace parallel {
 class Pinning {
 private:
-  cpu_set_t processMask{};
   cpu_set_t openmpMask{};
 public:
   Pinning();
 
-  cpu_set_t getProcessMask() const { return processMask; };
   cpu_set_t getWorkerUnionMask() const;
   cpu_set_t getFreeCPUsMask() const;
   static bool freeCPUsMaskEmpty(cpu_set_t const& set);

--- a/src/SeisSol.cpp
+++ b/src/SeisSol.cpp
@@ -108,8 +108,6 @@ bool seissol::SeisSol::init(int argc, char* argv[])
 
 #ifdef _OPENMP
   logInfo(rank) << "Using OMP with #threads/rank:" << omp_get_max_threads();
-  logInfo(rank) << "Overall affinity (this process)      :" << parallel::Pinning::maskToString(
-      pinning.getProcessMask());
   logInfo(rank) << "OpenMP worker affinity (this process):" << parallel::Pinning::maskToString(
       pinning.getWorkerUnionMask());
   logInfo(rank) << "OpenMP worker affinity (this node)   :" << parallel::Pinning::maskToString(

--- a/src/SeisSol.cpp
+++ b/src/SeisSol.cpp
@@ -95,7 +95,7 @@ bool seissol::SeisSol::init(int argc, char* argv[])
 
   // Print welcome message
   logInfo(rank) << "Welcome to SeisSol";
-  logInfo(rank) << "Copyright (c) 2012-2020, SeisSol Group";
+  logInfo(rank) << "Copyright (c) 2012-2021, SeisSol Group";
   logInfo(rank) << "Built on:" << __DATE__ << __TIME__ ;
   logInfo(rank) << "Version:" << VERSION_STRING;
 
@@ -108,10 +108,13 @@ bool seissol::SeisSol::init(int argc, char* argv[])
 
 #ifdef _OPENMP
   logInfo(rank) << "Using OMP with #threads/rank:" << omp_get_max_threads();
-  logInfo(rank) << "Overall affinity            :" << parallel::Pinning::maskToString(
+  logInfo(rank) << "Overall affinity (this process)      :" << parallel::Pinning::maskToString(
       pinning.getProcessMask());
-  logInfo(rank) << "OpenMP worker affinity       :" << parallel::Pinning::maskToString(
+  logInfo(rank) << "OpenMP worker affinity (this process):" << parallel::Pinning::maskToString(
       pinning.getWorkerUnionMask());
+  logInfo(rank) << "OpenMP worker affinity (this node)   :" << parallel::Pinning::maskToString(
+      pinning.getNodeMask());
+  std::cout << "My mask:" << parallel::Pinning::maskToString(pinning.getWorkerUnionMask()) << std::endl;
 #ifdef USE_MPI
   logInfo(rank) << "Using MPI with #ranks:" << MPI::mpi.size();
 #ifdef USE_COMM_THREAD

--- a/src/SeisSol.cpp
+++ b/src/SeisSol.cpp
@@ -114,7 +114,6 @@ bool seissol::SeisSol::init(int argc, char* argv[])
       pinning.getWorkerUnionMask());
   logInfo(rank) << "OpenMP worker affinity (this node)   :" << parallel::Pinning::maskToString(
       pinning.getNodeMask());
-  std::cout << "My mask:" << parallel::Pinning::maskToString(pinning.getWorkerUnionMask()) << std::endl;
 #ifdef USE_MPI
   logInfo(rank) << "Using MPI with #ranks:" << MPI::mpi.size();
 #ifdef USE_COMM_THREAD


### PR DESCRIPTION
Our current pinning method does not work for the GCC compiler.
Or rather, with its standard OpenMP runtime. It sets the affinity mask for the entire process from the OpenMP pinning mask at the beginning of the process. For intel/clang compiler, this only happens after the first OpenMP call.

This PR implements a different strategy:

- Find affinity mask for all OpenMP threads on every process
- Find affinity mask for all OpenMP threads on every *node*
- Pin communication thread to all cores that are not used by OpenMP.

Furthermore, if the option NUMA_AWARE_PINNING is used, we only pin the communication thread to the cores that are not used by OpenMP and that are in on of the numa domains used by OpenMP.
This option needs libnuma which is available basically everywhere (module numactl most often).

Note that the pinning should still work without NUMA_AWARE_PINNING but might be not optimal, depending on how the MPI runtime pins the threads. 