### PR TITLE
Ravil/dr gpu

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -398,6 +398,8 @@ if (TESTING)
           ${CMAKE_CURRENT_SOURCE_DIR}/src/tests/Geometry/TriangleRefiner.t.h
           ${CMAKE_CURRENT_SOURCE_DIR}/src/tests/Initializer/time_stepping/LTSWeights.t.h
           ${CMAKE_CURRENT_SOURCE_DIR}/src/tests/Initializer/PointMapper.t.h
+          ${CMAKE_CURRENT_SOURCE_DIR}/src/tests/Pipeline/PipelineTest.t.h
+          ${CMAKE_CURRENT_SOURCE_DIR}/src/tests/Pipeline/DrTunerTest.t.h
   )
   target_link_libraries(test_serial_test_suite PRIVATE SeisSol-lib)
   target_include_directories(test_serial_test_suite PRIVATE ${CXXTEST_INCLUDE_DIR})

--- a/auto_tuning/proxy/src/proxy_seissol.cpp
+++ b/auto_tuning/proxy/src/proxy_seissol.cpp
@@ -131,13 +131,9 @@ void testKernel(unsigned kernel, unsigned timesteps) {
       }
       break;    
     case godunov_dr:
-#ifdef ACL_DEVICE
-      logError() << "godunov_dr has not been implemented for acl. device";
-#else
       for (; t < timesteps; ++t) {
         computeDynRupGodunovState();
       }
-#endif
       break;
     default:
       break;
@@ -196,7 +192,7 @@ int main(int argc, char* argv[]) {
   initGlobalData();
   cells = initDataStructures(cells, enableDynamicRupture);
 #ifdef ACL_DEVICE
-  initDataStructuresOnDevice();
+  initDataStructuresOnDevice(enableDynamicRupture);
 #endif // ACL_DEVICE
   printf("...done\n\n");
 

--- a/auto_tuning/proxy/src/proxy_seissol_device_integrators.hpp
+++ b/auto_tuning/proxy/src/proxy_seissol_device_integrators.hpp
@@ -97,6 +97,10 @@ namespace proxy::device {
   }
 
   void computeDynRupGodunovState() {
+    auto& layer = m_dynRupTree->child(0).child<Interior>();
+
+    ConditionalBatchTableT &table = layer.getCondBatchTable();
+    m_dynRupKernel.batchedSpaceTimeInterpolation(table);
   }
 } // namespace proxy::device
 

--- a/src/Initializer/BatchRecorders/DataTypes/EncodedConstants.hpp
+++ b/src/Initializer/BatchRecorders/DataTypes/EncodedConstants.hpp
@@ -23,6 +23,13 @@ enum struct EntityId : size_t {
   Pstrains,
   ElementsIds,
   InitialLoad,
+  DrDerivativesPlus,
+  DrDerivativesMinus,
+  DrIdofsPlus,
+  DrIdofsMinus,
+  DrQInterpolatedPlus,
+  DrQInterpolatedMinus,
+  DrTinvT,
   Count
 };
 
@@ -38,7 +45,9 @@ enum struct KernelNames : size_t {
   NeighborFlux = 1 << 3,
   Displacements = 1 << 4,
   Plasticity = 1 << 5,
-  Count = 6,
+  DrTime = 1 << 6,
+  DrSpaceMap = 1 << 7,
+  Count = 8,
   Any = encodeAny(Count)
 };
 

--- a/src/Initializer/BatchRecorders/DynamicRuptureRecorder.cpp
+++ b/src/Initializer/BatchRecorders/DynamicRuptureRecorder.cpp
@@ -1,0 +1,104 @@
+#include "Recorders.h"
+#include <Kernels/Interface.hpp>
+#include <yateto.h>
+
+using namespace device;
+using namespace seissol::initializers;
+using namespace seissol::initializers::recording;
+
+
+void DynamicRuptureRecorder::record(DynamicRupture &handler, Layer &layer) {
+  setUpContext(handler, layer);
+  recordDofsTimeEvaluation();
+  recordSpaceInterpolation();
+}
+
+
+void DynamicRuptureRecorder::recordDofsTimeEvaluation() {
+  real** timeDerivativePlus = currentLayer->var(currentHandler->timeDerivativePlus);
+  real** timeDerivativeMinus = currentLayer->var(currentHandler->timeDerivativeMinus);
+  real* idofsPlus = static_cast<real *>(currentLayer->getScratchpadMemory(currentHandler->idofsPlusOnDevice));
+  real* idofsMinus = static_cast<real *>(currentLayer->getScratchpadMemory(currentHandler->idofsMinusOnDevice));
+
+  if (currentLayer->getNumberOfCells()) {
+    std::vector<real *> timeDerivativePlusPtrs{};
+    std::vector<real *> timeDerivativeMinusPtrs{};
+    std::vector<real *> idofsPlusPtrs{};
+    std::vector<real *> idofsMinusPtrs{};
+
+    const size_t idofsSize = tensor::Q::size();
+    for (unsigned face = 0; face < currentLayer->getNumberOfCells(); ++face) {
+      timeDerivativePlusPtrs.push_back(timeDerivativePlus[face]);
+      timeDerivativeMinusPtrs.push_back(timeDerivativeMinus[face]);
+      idofsPlusPtrs.push_back(&idofsPlus[face * idofsSize]);
+      idofsMinusPtrs.push_back(&idofsMinus[face * idofsSize]);
+    }
+
+    if (!idofsPlusPtrs.empty()) {
+      ConditionalKey key(*KernelNames::DrTime);
+      checkKey(key);
+
+      (*currentTable)[key].content[*EntityId::DrDerivativesPlus] = new BatchPointers(timeDerivativePlusPtrs);
+      (*currentTable)[key].content[*EntityId::DrDerivativesMinus] = new BatchPointers(timeDerivativeMinusPtrs);
+      (*currentTable)[key].content[*EntityId::DrIdofsPlus] = new BatchPointers(idofsPlusPtrs);
+      (*currentTable)[key].content[*EntityId::DrIdofsMinus] = new BatchPointers(idofsMinusPtrs);
+    }
+  }
+}
+
+
+void DynamicRuptureRecorder::recordSpaceInterpolation() {
+  real* QInterpolatedPlus =
+      static_cast<real *>(currentLayer->getScratchpadMemory(currentHandler->QInterpolatedPlusOnDevice));
+  real* QInterpolatedMinus =
+      static_cast<real *>(currentLayer->getScratchpadMemory(currentHandler->QInterpolatedMinusOnDevice));
+
+  real* idofsPlus = static_cast<real *>(currentLayer->getScratchpadMemory(currentHandler->idofsPlusOnDevice));
+  real* idofsMinus = static_cast<real *>(currentLayer->getScratchpadMemory(currentHandler->idofsMinusOnDevice));
+
+  DRGodunovData* godunovData = currentLayer->var(currentHandler->godunovData);
+  DRFaceInformation* faceInfo = currentLayer->var(currentHandler->faceInformation);
+
+  if (currentLayer->getNumberOfCells()) {
+    std::array<std::vector<real *>, *FaceId::Count> QInterpolatedPlusPtr {};
+    std::array<std::vector<real *>, *FaceId::Count> idofsPlusPtr {};
+    std::array<std::vector<real *>, *FaceId::Count> TinvTPlusPtr {};
+
+    std::array<std::vector<real *>[*FaceId::Count], *FaceId::Count> QInterpolatedMinusPtr {};
+    std::array<std::vector<real *>[*FaceId::Count], *FaceId::Count> idofsMinusPtr {};
+    std::array<std::vector<real *>[*FaceId::Count], *FaceId::Count> TinvTMinusPtr {};
+
+    const size_t QInterpolatedSize = CONVERGENCE_ORDER * tensor::QInterpolated::size();
+    const size_t idofsSize = tensor::Q::size();
+
+    for (unsigned face = 0; face < currentLayer->getNumberOfCells(); ++face) {
+      const auto plusSide = faceInfo[face].plusSide;
+      QInterpolatedPlusPtr[plusSide].push_back(&QInterpolatedPlus[face * QInterpolatedSize]);
+      idofsPlusPtr[plusSide].push_back(&idofsPlus[face * idofsSize]);
+      TinvTPlusPtr[plusSide].push_back((&godunovData[face])->TinvT);
+
+      const auto minusSide = faceInfo[face].minusSide;
+      const auto faceRelation = faceInfo[face].faceRelation;
+      QInterpolatedMinusPtr[minusSide][faceRelation].push_back(&QInterpolatedMinus[face * QInterpolatedSize]);
+      idofsMinusPtr[minusSide][faceRelation].push_back(&idofsMinus[face * idofsSize]);
+      TinvTMinusPtr[minusSide][faceRelation].push_back((&godunovData[face])->TinvT);
+    }
+
+    for (unsigned side = 0; side < 4; ++side) {
+      if (!QInterpolatedPlusPtr[side].empty()) {
+        ConditionalKey key(*KernelNames::DrSpaceMap, side);
+        (*currentTable)[key].content[*EntityId::DrQInterpolatedPlus] = new BatchPointers(QInterpolatedPlusPtr[side]);
+        (*currentTable)[key].content[*EntityId::DrIdofsPlus] = new BatchPointers(idofsPlusPtr[side]);
+        (*currentTable)[key].content[*EntityId::DrTinvT] = new BatchPointers(TinvTPlusPtr[side]);
+      }
+      for (unsigned faceRelation = 0; faceRelation < 4; ++faceRelation) {
+        if (!QInterpolatedMinusPtr[side][faceRelation].empty()) {
+          ConditionalKey key(*KernelNames::DrSpaceMap, side, faceRelation);
+          (*currentTable)[key].content[*EntityId::DrQInterpolatedMinus] = new BatchPointers(QInterpolatedMinusPtr[side][faceRelation]);
+          (*currentTable)[key].content[*EntityId::DrIdofsMinus] = new BatchPointers(idofsMinusPtr[side][faceRelation]);
+          (*currentTable)[key].content[*EntityId::DrTinvT] = new BatchPointers(TinvTMinusPtr[side][faceRelation]);
+        }
+      }
+    }
+  }
+}

--- a/src/Initializer/BatchRecorders/DynamicRuptureRecorder.cpp
+++ b/src/Initializer/BatchRecorders/DynamicRuptureRecorder.cpp
@@ -20,29 +20,28 @@ void DynamicRuptureRecorder::recordDofsTimeEvaluation() {
   real* idofsPlus = static_cast<real *>(currentLayer->getScratchpadMemory(currentHandler->idofsPlusOnDevice));
   real* idofsMinus = static_cast<real *>(currentLayer->getScratchpadMemory(currentHandler->idofsMinusOnDevice));
 
-  if (currentLayer->getNumberOfCells()) {
-    std::vector<real *> timeDerivativePlusPtrs{};
-    std::vector<real *> timeDerivativeMinusPtrs{};
-    std::vector<real *> idofsPlusPtrs{};
-    std::vector<real *> idofsMinusPtrs{};
+  const auto size = currentLayer->getNumberOfCells();
+  if (size > 0) {
+    std::vector<real *> timeDerivativePlusPtrs(size, nullptr);
+    std::vector<real *> timeDerivativeMinusPtrs(size, nullptr);
+    std::vector<real *> idofsPlusPtrs(size, nullptr);
+    std::vector<real *> idofsMinusPtrs(size, nullptr);
 
     const size_t idofsSize = tensor::Q::size();
-    for (unsigned face = 0; face < currentLayer->getNumberOfCells(); ++face) {
-      timeDerivativePlusPtrs.push_back(timeDerivativePlus[face]);
-      timeDerivativeMinusPtrs.push_back(timeDerivativeMinus[face]);
-      idofsPlusPtrs.push_back(&idofsPlus[face * idofsSize]);
-      idofsMinusPtrs.push_back(&idofsMinus[face * idofsSize]);
+    for (unsigned faceId = 0; faceId < size; ++faceId) {
+      timeDerivativePlusPtrs[faceId] = timeDerivativePlus[faceId];
+      timeDerivativeMinusPtrs[faceId] = timeDerivativeMinus[faceId];
+      idofsPlusPtrs[faceId] = &idofsPlus[faceId * idofsSize];
+      idofsMinusPtrs[faceId] = &idofsMinus[faceId * idofsSize];
     }
 
-    if (!idofsPlusPtrs.empty()) {
-      ConditionalKey key(*KernelNames::DrTime);
-      checkKey(key);
+    ConditionalKey key(*KernelNames::DrTime);
+    checkKey(key);
 
-      (*currentTable)[key].content[*EntityId::DrDerivativesPlus] = new BatchPointers(timeDerivativePlusPtrs);
-      (*currentTable)[key].content[*EntityId::DrDerivativesMinus] = new BatchPointers(timeDerivativeMinusPtrs);
-      (*currentTable)[key].content[*EntityId::DrIdofsPlus] = new BatchPointers(idofsPlusPtrs);
-      (*currentTable)[key].content[*EntityId::DrIdofsMinus] = new BatchPointers(idofsMinusPtrs);
-    }
+    (*currentTable)[key].content[*EntityId::DrDerivativesPlus] = new BatchPointers(timeDerivativePlusPtrs);
+    (*currentTable)[key].content[*EntityId::DrDerivativesMinus] = new BatchPointers(timeDerivativeMinusPtrs);
+    (*currentTable)[key].content[*EntityId::DrIdofsPlus] = new BatchPointers(idofsPlusPtrs);
+    (*currentTable)[key].content[*EntityId::DrIdofsMinus] = new BatchPointers(idofsMinusPtrs);
   }
 }
 
@@ -59,7 +58,8 @@ void DynamicRuptureRecorder::recordSpaceInterpolation() {
   DRGodunovData* godunovData = currentLayer->var(currentHandler->godunovData);
   DRFaceInformation* faceInfo = currentLayer->var(currentHandler->faceInformation);
 
-  if (currentLayer->getNumberOfCells()) {
+  const auto size = currentLayer->getNumberOfCells();
+  if (size > 0) {
     std::array<std::vector<real *>, *FaceId::Count> QInterpolatedPlusPtr {};
     std::array<std::vector<real *>, *FaceId::Count> idofsPlusPtr {};
     std::array<std::vector<real *>, *FaceId::Count> TinvTPlusPtr {};
@@ -71,17 +71,17 @@ void DynamicRuptureRecorder::recordSpaceInterpolation() {
     const size_t QInterpolatedSize = CONVERGENCE_ORDER * tensor::QInterpolated::size();
     const size_t idofsSize = tensor::Q::size();
 
-    for (unsigned face = 0; face < currentLayer->getNumberOfCells(); ++face) {
-      const auto plusSide = faceInfo[face].plusSide;
-      QInterpolatedPlusPtr[plusSide].push_back(&QInterpolatedPlus[face * QInterpolatedSize]);
-      idofsPlusPtr[plusSide].push_back(&idofsPlus[face * idofsSize]);
-      TinvTPlusPtr[plusSide].push_back((&godunovData[face])->TinvT);
+    for (unsigned faceId = 0; faceId < size; ++faceId) {
+      const auto plusSide = faceInfo[faceId].plusSide;
+      QInterpolatedPlusPtr[plusSide].push_back(&QInterpolatedPlus[faceId * QInterpolatedSize]);
+      idofsPlusPtr[plusSide].push_back(&idofsPlus[faceId * idofsSize]);
+      TinvTPlusPtr[plusSide].push_back((&godunovData[faceId])->TinvT);
 
-      const auto minusSide = faceInfo[face].minusSide;
-      const auto faceRelation = faceInfo[face].faceRelation;
-      QInterpolatedMinusPtr[minusSide][faceRelation].push_back(&QInterpolatedMinus[face * QInterpolatedSize]);
-      idofsMinusPtr[minusSide][faceRelation].push_back(&idofsMinus[face * idofsSize]);
-      TinvTMinusPtr[minusSide][faceRelation].push_back((&godunovData[face])->TinvT);
+      const auto minusSide = faceInfo[faceId].minusSide;
+      const auto faceRelation = faceInfo[faceId].faceRelation;
+      QInterpolatedMinusPtr[minusSide][faceRelation].push_back(&QInterpolatedMinus[faceId * QInterpolatedSize]);
+      idofsMinusPtr[minusSide][faceRelation].push_back(&idofsMinus[faceId * idofsSize]);
+      TinvTMinusPtr[minusSide][faceRelation].push_back((&godunovData[faceId])->TinvT);
     }
 
     for (unsigned side = 0; side < 4; ++side) {

--- a/src/Initializer/BatchRecorders/NeighIntegrationRecorder.cpp
+++ b/src/Initializer/BatchRecorders/NeighIntegrationRecorder.cpp
@@ -95,10 +95,6 @@ void NeighIntegrationRecorder::recordNeighbourFluxIntegrals() {
   std::array<std::vector<real *>[*FaceRelations::Count], *FaceId::Count> regularPeriodicIDofs {};
   std::array<std::vector<real *>[*FaceRelations::Count], *FaceId::Count> regularPeriodicAminusT {};
 
-  std::vector<real *> freeSurfaceDofs[*FaceId::Count];
-  std::vector<real *> freeSurfaceIDofs[*FaceId::Count];
-  std::vector<real *> freeSurfaceAminusT[*FaceId::Count];
-
   std::array<std::vector<real *>[*DrFaceRelations::Count], *FaceId::Count> drDofs {};
   std::array<std::vector<real *>[*DrFaceRelations::Count], *FaceId::Count> drGodunov {};
   std::array<std::vector<real *>[*DrFaceRelations::Count], *FaceId::Count> drFluxSolver {};

--- a/src/Initializer/BatchRecorders/NeighIntegrationRecorder.cpp
+++ b/src/Initializer/BatchRecorders/NeighIntegrationRecorder.cpp
@@ -23,13 +23,14 @@ void NeighIntegrationRecorder::recordDofsTimeEvaluation() {
   real *(*faceNeighbors)[4] = currentLayer->var(currentHandler->faceNeighbors);
   real *idofsScratch = static_cast<real *>(currentLayer->getScratchpadMemory(currentHandler->idofsScratch));
 
-  if (currentLayer->getNumberOfCells()) {
+  const auto size = currentLayer->getNumberOfCells();
+  if (size > 0) {
     std::vector<real *> ltsIDofsPtrs{};
     std::vector<real *> ltsDerivativesPtrs{};
     std::vector<real *> gtsDerivativesPtrs{};
     std::vector<real *> gtsIDofsPtrs{};
 
-    for (unsigned cell = 0; cell < currentLayer->getNumberOfCells(); ++cell) {
+    for (unsigned cell = 0; cell < size; ++cell) {
       auto data = currentLoader->entry(cell);
 
       for (unsigned face = 0; face < 4; ++face) {
@@ -47,7 +48,7 @@ void NeighIntegrationRecorder::recordDofsTimeEvaluation() {
               bool isNeighbProvidesDerivatives = ((data.cellInformation.ltsSetup >> face) % 2) == 1;
 
               if (isNeighbProvidesDerivatives) {
-                real *NextTempIDofsPtr = &idofsScratch[idofsAddressCounter];
+                real *NextTempIDofsPtr = &idofsScratch[integratedDofsAddressCounter];
 
                 bool isGtsNeigbour = ((data.cellInformation.ltsSetup >> (face + 4)) % 2) == 1;
                 if (isGtsNeigbour) {
@@ -61,7 +62,7 @@ void NeighIntegrationRecorder::recordDofsTimeEvaluation() {
                   ltsIDofsPtrs.push_back(NextTempIDofsPtr);
                   ltsDerivativesPtrs.push_back(neighbourBuffer);
                 }
-                idofsAddressCounter += tensor::I::size();
+                integratedDofsAddressCounter += tensor::I::size();
               } else {
                 idofsAddressRegistry[neighbourBuffer] = neighbourBuffer;
               }
@@ -101,12 +102,13 @@ void NeighIntegrationRecorder::recordNeighbourFluxIntegrals() {
 
   CellDRMapping(*drMapping)[4] = currentLayer->var(currentHandler->drMapping);
 
-  for (unsigned cell = 0; cell < currentLayer->getNumberOfCells(); ++cell) {
+  const auto size = currentLayer->getNumberOfCells();
+  for (unsigned cell = 0; cell < size; ++cell) {
     auto data = currentLoader->entry(cell);
     for (unsigned int face = 0; face < 4; face++) {
       switch (data.cellInformation.faceTypes[face]) {
         case FaceType::regular:
-          // Fallthrough intended
+          [[fallthrough]];
         case FaceType::periodic: {
           // compute face type relation
 

--- a/src/Initializer/BatchRecorders/PlasticityRecorder.cpp
+++ b/src/Initializer/BatchRecorders/PlasticityRecorder.cpp
@@ -14,27 +14,27 @@ void PlasticityRecorder::record(LTS &handler, Layer &layer) {
   real(*pstrains)[7] = currentLayer->var(currentHandler->pstrain);
   size_t nodalStressTensorCounter = 0;
   real *scratchMem = static_cast<real *>(currentLayer->getScratchpadMemory(currentHandler->idofsScratch));
-  if (currentLayer->getNumberOfCells()) {
-    std::vector<real *> dofsPtrs{};
-    std::vector<real *> qstressNodalPtrs{};
-    std::vector<real *> pstransPtrs{};
-    std::vector<real *> initialLoadPtrs{};
+  const auto size = currentLayer->getNumberOfCells();
+  if (size > 0) {
+    std::vector<real *> dofsPtrs(size, nullptr);
+    std::vector<real *> qstressNodalPtrs(size, nullptr);
+    std::vector<real *> pstransPtrs(size, nullptr);
+    std::vector<real *> initialLoadPtrs(size, nullptr);
 
-    for (unsigned cell = 0; cell < currentLayer->getNumberOfCells(); ++cell) {
+    for (unsigned cell = 0; cell < size; ++cell) {
       auto data = currentLoader->entry(cell);
-      dofsPtrs.push_back(static_cast<real *>(data.dofs));
-      qstressNodalPtrs.push_back(&scratchMem[nodalStressTensorCounter]);
+      dofsPtrs[cell] = static_cast<real *>(data.dofs);
+      qstressNodalPtrs[cell] = &scratchMem[nodalStressTensorCounter];
       nodalStressTensorCounter += tensor::QStressNodal::size();
-      pstransPtrs.push_back(static_cast<real *>(pstrains[cell]));
-      initialLoadPtrs.push_back(static_cast<real *>(data.plasticity.initialLoading));
+      pstransPtrs[cell] = static_cast<real *>(pstrains[cell]);
+      initialLoadPtrs[cell] = static_cast<real *>(data.plasticity.initialLoading);
     }
-    if (!dofsPtrs.empty()) {
-      ConditionalKey key(*KernelNames::Plasticity);
-      checkKey(key);
-      (*currentTable)[key].content[*EntityId::Dofs] = new BatchPointers(dofsPtrs);
-      (*currentTable)[key].content[*EntityId::NodalStressTensor] = new BatchPointers(qstressNodalPtrs);
-      (*currentTable)[key].content[*EntityId::Pstrains] = new BatchPointers(pstransPtrs);
-      (*currentTable)[key].content[*EntityId::InitialLoad] = new BatchPointers(initialLoadPtrs);
-    }
+
+    ConditionalKey key(*KernelNames::Plasticity);
+    checkKey(key);
+    (*currentTable)[key].content[*EntityId::Dofs] = new BatchPointers(dofsPtrs);
+    (*currentTable)[key].content[*EntityId::NodalStressTensor] = new BatchPointers(qstressNodalPtrs);
+    (*currentTable)[key].content[*EntityId::Pstrains] = new BatchPointers(pstransPtrs);
+    (*currentTable)[key].content[*EntityId::InitialLoad] = new BatchPointers(initialLoadPtrs);
   }
 }

--- a/src/Initializer/BatchRecorders/Recorders.h
+++ b/src/Initializer/BatchRecorders/Recorders.h
@@ -4,6 +4,7 @@
 #include "DataTypes/ConditionalTable.hpp"
 #include "utils/logger.h"
 #include <Initializer/LTS.h>
+#include <Initializer/DynamicRupture.h>
 #include <Initializer/tree/Layer.hpp>
 #include <Kernels/Interface.hpp>
 #include <vector>
@@ -13,11 +14,12 @@ namespace initializers {
 namespace recording {
 
 
+template<typename LtsT>
 class AbstractRecorder {
 public:
   virtual ~AbstractRecorder() = default;
 
-  virtual void record(LTS &handler, Layer &layer) = 0;
+  virtual void record(LtsT &handler, Layer &layer) = 0;
 
 protected:
   void checkKey(const ConditionalKey &key) {
@@ -27,38 +29,32 @@ protected:
     }
   }
 
-  void setUpContext(LTS &handler, Layer &layer) {
+  void setUpContext(LtsT &handler, Layer &layer) {
     currentTable = &(layer.getCondBatchTable());
     currentHandler = &(handler);
     currentLayer = &(layer);
-
-    idofsAddressCounter = 0;
-    derivativesAddressCounter = 0;
   }
 
   ConditionalBatchTableT *currentTable{nullptr};
-  LTS *currentHandler{nullptr};
+  LtsT *currentHandler{nullptr};
   Layer *currentLayer{nullptr};
-
-  size_t idofsAddressCounter{0};
-  size_t derivativesAddressCounter{0};
 };
 
-
-class CompositeRecorder : public AbstractRecorder {
+template<typename LtsT>
+class CompositeRecorder : public AbstractRecorder<LtsT> {
 public:
   ~CompositeRecorder() override {
     for (auto recorder : concreteRecorders)
       delete recorder;
   }
 
-  void record(LTS &handler, Layer &layer) override {
+  void record(LtsT &handler, Layer &layer) override {
     for (auto recorder : concreteRecorders) {
       recorder->record(handler, layer);
     }
   }
 
-  void addRecorder(AbstractRecorder *recorder) {
+  void addRecorder(AbstractRecorder<LtsT> *recorder) {
     concreteRecorders.push_back(recorder);
   }
 
@@ -69,17 +65,19 @@ public:
   }
 
 private:
-  std::vector<AbstractRecorder *> concreteRecorders{};
+  std::vector<AbstractRecorder<LtsT> *> concreteRecorders{};
 };
 
 
-class LocalIntegrationRecorder : public AbstractRecorder {
+class LocalIntegrationRecorder : public AbstractRecorder<seissol::initializers::LTS> {
 public:
   void record(LTS &handler, Layer &layer) override;
 
 private:
   void setUpContext(LTS &handler, Layer &layer, kernels::LocalData::Loader &loader) {
     currentLoader = &loader;
+    idofsAddressCounter = 0;
+    derivativesAddressCounter = 0;
     AbstractRecorder::setUpContext(handler, layer);
   }
 
@@ -88,25 +86,29 @@ private:
   void recordLocalFluxIntegral();
   void recordDisplacements();
   std::unordered_map<size_t, real *> idofsAddressRegistry{};
+  size_t idofsAddressCounter{0};
+  size_t derivativesAddressCounter{0};
 };
 
 
-class NeighIntegrationRecorder : public AbstractRecorder {
+class NeighIntegrationRecorder : public AbstractRecorder<seissol::initializers::LTS> {
 public:
   void record(LTS &handler, Layer &layer) override;
 private:
   void setUpContext(LTS &handler, Layer &layer, kernels::NeighborData::Loader &loader) {
     currentLoader = &loader;
+    idofsAddressCounter = 0;
     AbstractRecorder::setUpContext(handler, layer);
   }
   void recordDofsTimeEvaluation();
   void recordNeighbourFluxIntegrals();
   kernels::NeighborData::Loader *currentLoader{nullptr};
   std::unordered_map<real *, real *> idofsAddressRegistry{};
+  size_t idofsAddressCounter{0};
 };
 
 
-class PlasticityRecorder : public AbstractRecorder {
+class PlasticityRecorder : public AbstractRecorder<seissol::initializers::LTS> {
 public:
   void setUpContext(LTS &handler, Layer &layer, kernels::LocalData::Loader &loader) {
     currentLoader = &loader;
@@ -115,6 +117,18 @@ public:
 
   void record(LTS &handler, Layer &layer) override;
   kernels::LocalData::Loader *currentLoader{nullptr};
+};
+
+class DynamicRuptureRecorder : public AbstractRecorder<seissol::initializers::DynamicRupture> {
+public:
+  void record(DynamicRupture &handler, Layer &layer) override;
+private:
+  void setUpContext(DynamicRupture &handler, Layer &layer) {
+    AbstractRecorder::setUpContext(handler, layer);
+  }
+  void recordDofsTimeEvaluation();
+  void recordSpaceInterpolation();
+  std::unordered_map<real *, real *> idofsAddressRegistry{};
 };
 
 } // namespace recording

--- a/src/Initializer/BatchRecorders/Recorders.h
+++ b/src/Initializer/BatchRecorders/Recorders.h
@@ -76,7 +76,7 @@ public:
 private:
   void setUpContext(LTS &handler, Layer &layer, kernels::LocalData::Loader &loader) {
     currentLoader = &loader;
-    idofsAddressCounter = 0;
+    integratedDofsAddressCounter = 0;
     derivativesAddressCounter = 0;
     AbstractRecorder::setUpContext(handler, layer);
   }
@@ -86,7 +86,7 @@ private:
   void recordLocalFluxIntegral();
   void recordDisplacements();
   std::unordered_map<size_t, real *> idofsAddressRegistry{};
-  size_t idofsAddressCounter{0};
+  size_t integratedDofsAddressCounter{0};
   size_t derivativesAddressCounter{0};
 };
 
@@ -97,14 +97,14 @@ public:
 private:
   void setUpContext(LTS &handler, Layer &layer, kernels::NeighborData::Loader &loader) {
     currentLoader = &loader;
-    idofsAddressCounter = 0;
+    integratedDofsAddressCounter = 0;
     AbstractRecorder::setUpContext(handler, layer);
   }
   void recordDofsTimeEvaluation();
   void recordNeighbourFluxIntegrals();
   kernels::NeighborData::Loader *currentLoader{nullptr};
   std::unordered_map<real *, real *> idofsAddressRegistry{};
-  size_t idofsAddressCounter{0};
+  size_t integratedDofsAddressCounter{0};
 };
 
 

--- a/src/Kernels/DeviceAux/PlasticityAux.h
+++ b/src/Kernels/DeviceAux/PlasticityAux.h
@@ -17,7 +17,7 @@ void saveFirstModes(real *firstModes,
 void adjustDeviatoricTensors(real **nodalStressTensors,
                              int *isAdjustableVector,
                              const PlasticityData *plasticity,
-                             double one_minus_integrating_factor,
+                             double oneMinusIntegratingFactor,
                              size_t numElements);
 
 void adjustModalStresses(real **modalStressTensors,
@@ -31,7 +31,7 @@ void computePstrains(real **pstrains,
                      const real **modalStressTensors,
                      const real *firsModes,
                      const PlasticityData *plasticity,
-                     double one_minus_integrating_factor,
+                     double oneMinusIntegratingFactor,
                      double timeStepWidth,
                      double T_v,
                      size_t numElements);

--- a/src/Kernels/DeviceAux/cuda/PlasticityAux.cu
+++ b/src/Kernels/DeviceAux/cuda/PlasticityAux.cu
@@ -36,7 +36,7 @@ void saveFirstModes(real *firstModes,
 __global__ void kernel_adjustDeviatoricTensors(real **nodalStressTensors,
                                                int *isAdjustableVector,
                                                const PlasticityData *plasticity,
-                                               const double one_minus_integrating_factor) {
+                                               const double oneMinusIntegratingFactor) {
   real *elementTensors = nodalStressTensors[blockIdx.x];
   real localStresses[NUM_STREESS_COMPONENTS];
 
@@ -80,7 +80,7 @@ __global__ void kernel_adjustDeviatoricTensors(real **nodalStressTensors,
   real factor = 0.0;
   if (tau > taulim) {
     isAdjusted = static_cast<int>(true);
-    factor = ((taulim / tau) - 1.0) * one_minus_integrating_factor;
+    factor = ((taulim / tau) - 1.0) * oneMinusIntegratingFactor;
   }
 
   // 7. Adjust deviatoric stress tensor if a node within a node exceeds the elasticity region
@@ -100,7 +100,7 @@ __global__ void kernel_adjustDeviatoricTensors(real **nodalStressTensors,
 void adjustDeviatoricTensors(real **nodalStressTensors,
                              int *isAdjustableVector,
                              const PlasticityData *plasticity,
-                             const double one_minus_integrating_factor,
+                             const double oneMinusIntegratingFactor,
                              const size_t numElements) {
   constexpr unsigned numNodesPerElement = tensor::QStressNodal::Shape[0];
   dim3 block(numNodesPerElement, 1, 1);
@@ -108,7 +108,7 @@ void adjustDeviatoricTensors(real **nodalStressTensors,
   kernel_adjustDeviatoricTensors<<<grid, block>>>(nodalStressTensors,
                                                   isAdjustableVector,
                                                   plasticity,
-                                                  one_minus_integrating_factor);
+                                                  oneMinusIntegratingFactor);
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -173,7 +173,7 @@ __global__ void kernel_computePstrains(real **pstrains,
                                        const real** modalStressTensors,
                                        const real* firsModes,
                                        const PlasticityData* plasticity,
-                                       const double one_minus_integrating_factor,
+                                       const double oneMinusIntegratingFactor,
                                        const double timeStepWidth,
                                        const double T_v,
                                        const size_t numElements) {
@@ -189,7 +189,7 @@ __global__ void kernel_computePstrains(real **pstrains,
     const PlasticityData *localData = &plasticity[index];
 
     constexpr unsigned numModesPerElement = init::Q::Shape[0];
-    real factor = localData->mufactor / (T_v * one_minus_integrating_factor);
+    real factor = localData->mufactor / (T_v * oneMinusIntegratingFactor);
     real duDtPstrain = factor * (localFirstMode[threadIdx.x] - localModalTensor[threadIdx.x * numModesPerElement]);
     localPstrains[threadIdx.x] += timeStepWidth * duDtPstrain;
 
@@ -216,7 +216,7 @@ void computePstrains(real **pstrains,
                      const real **modalStressTensors,
                      const real *firsModes,
                      const PlasticityData *plasticity,
-                     const double one_minus_integrating_factor,
+                     const double oneMinusIntegratingFactor,
                      const double timeStepWidth,
                      const double T_v,
                      const size_t numElements) {
@@ -228,7 +228,7 @@ void computePstrains(real **pstrains,
                                           modalStressTensors,
                                           firsModes,
                                           plasticity,
-                                          one_minus_integrating_factor,
+                                          oneMinusIntegratingFactor,
                                           timeStepWidth,
                                           T_v,
                                           numElements);

--- a/src/Kernels/Plasticity.cpp
+++ b/src/Kernels/Plasticity.cpp
@@ -55,7 +55,7 @@ using namespace device;
 #endif
 
 namespace seissol::kernels {
-  unsigned Plasticity::computePlasticity(double one_minus_integrating_factor,
+  unsigned Plasticity::computePlasticity(double oneMinusIntegratingFactor,
                                          double timeStepWidth,
                                          double T_v,
                                          GlobalData const *global,
@@ -137,7 +137,7 @@ namespace seissol::kernels {
       // where r = 1 - exp(-timeStepWidth / T_v)
       if (tau[ip] > taulim[ip]) {
         adjust = true;
-        yieldFactor[ip] = (taulim[ip] / tau[ip] - 1.0) * one_minus_integrating_factor;
+        yieldFactor[ip] = (taulim[ip] / tau[ip] - 1.0) * oneMinusIntegratingFactor;
       } else {
         yieldFactor[ip] = 0.0;
       }
@@ -192,7 +192,7 @@ namespace seissol::kernels {
          *
          * If tau < taulim, then sigma_{ij} - sigmaNew_{ij} = 0.
          */
-        real factor = plasticityData->mufactor / (T_v * one_minus_integrating_factor);
+        real factor = plasticityData->mufactor / (T_v * oneMinusIntegratingFactor);
         dudt_pstrain[q] = factor *
             (prev_degreesOfFreedom[q] - degreesOfFreedom[q * NUMBER_OF_ALIGNED_BASIS_FUNCTIONS]);
         // Integrate with explicit Euler
@@ -211,7 +211,7 @@ namespace seissol::kernels {
     return 0;
   }
 
-  unsigned Plasticity::computePlasticityBatched(double one_minus_integrating_factor,
+  unsigned Plasticity::computePlasticityBatched(double oneMinusIntegratingFactor,
                                                 double timeStepWidth,
                                                 double T_v,
                                                 GlobalData const *global,
@@ -266,7 +266,7 @@ namespace seissol::kernels {
       device::aux::plasticity::adjustDeviatoricTensors(nodalStressTensors,
                                                        isAdjustableVector,
                                                        plasticity,
-                                                       one_minus_integrating_factor,
+                                                       oneMinusIntegratingFactor,
                                                        numElements);
 
       unsigned numAdjustedDofs = device.algorithms.reduceVector(isAdjustableVector,
@@ -287,7 +287,7 @@ namespace seissol::kernels {
                                                const_cast<const real **>(modalStressTensors),
                                                firsModes,
                                                plasticity,
-                                               one_minus_integrating_factor,
+                                               oneMinusIntegratingFactor,
                                                timeStepWidth,
                                                T_v,
                                                numElements);

--- a/src/Kernels/Plasticity.h
+++ b/src/Kernels/Plasticity.h
@@ -57,7 +57,7 @@ class seissol::kernels::Plasticity {
 public:
   /** Returns 1 if there was plastic yielding otherwise 0.
    */
-  static unsigned computePlasticity( double                      relaxTime,
+  static unsigned computePlasticity( double                      oneMinusIntegratingFactor,
                                      double                      timeStepWidth,
                                      double                      T_v,
                                      GlobalData const*           global,

--- a/src/Kernels/Time.h
+++ b/src/Kernels/Time.h
@@ -123,6 +123,12 @@ class seissol::kernels::Time : public TimeBase {
                                  real const*  timeDerivatives,
                                  real         timeEvaluated[tensor::Q::size()] );
 
+  void computeBatchedTaylorExpansion(real time,
+                                     real expansionPoint,
+                                     real** timeDerivatives,
+                                     real** timeEvaluated,
+                                     size_t numElements);
+
     void flopsTaylorExpansion(long long& nonZeroFlops, long long& hardwareFlops);
 };
 

--- a/src/Solver/Pipeline/DrPipeline.h
+++ b/src/Solver/Pipeline/DrPipeline.h
@@ -5,7 +5,7 @@
  * @author Ravil Dorozhinskii (ravil.dorozhinskii AT tum.de)
  *
  * @section LICENSE
- * Copyright (c) 2015-2017, SeisSol Group
+ * Copyright (c) 2020-2021, SeisSol Group
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Solver/Pipeline/DrPipeline.h
+++ b/src/Solver/Pipeline/DrPipeline.h
@@ -1,0 +1,90 @@
+/**
+ * @file
+ * This file is part of SeisSol.
+ *
+ * @author Ravil Dorozhinskii (ravil.dorozhinskii AT tum.de)
+ *
+ * @section LICENSE
+ * Copyright (c) 2015-2017, SeisSol Group
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @section DESCRIPTION
+ * An implementation of a pipeline.
+ *
+ * Specification of Dynamic Rupture pipeline.
+ **/
+
+#ifndef DR_PIPELINE_H
+#define DR_PIPELINE_H
+
+#include <Solver/Pipeline/GenericPipeline.h>
+#include <Solver/Pipeline/DrTuner.h>
+#include <generated_code/tensor.h>
+#ifdef ACL_DEVICE
+#include <device.h>
+#endif
+
+namespace seissol::time_stepping {
+  class TimeCluster;
+}
+
+namespace seissol::dr::pipeline {
+  using DrPipeline = seissol::GenericPipeline<3, 1024, DrPipelineTuner>;
+
+  struct DrContext {
+    using QInterpolatedPtrT = real (*)[CONVERGENCE_ORDER][tensor::QInterpolated::size()];
+    using imposedStatePlusT = real (*)[tensor::QInterpolated::size()];
+
+    real* QInterpolatedPlusOnDevice{nullptr};
+    real* QInterpolatedMinusOnDevice{nullptr};
+    QInterpolatedPtrT QInterpolatedPlusOnHost{nullptr};
+    QInterpolatedPtrT QInterpolatedMinusOnHost{nullptr};
+    imposedStatePlusT imposedStatePlusOnHost{nullptr};
+    imposedStatePlusT imposedStateMinusOnHost{nullptr};
+    DRFaceInformation* faceInformation{nullptr};
+    real (*devImposedStatePlus)[tensor::QInterpolated::size()]{nullptr};
+    real (*devImposedStateMinus)[tensor::QInterpolated::size()]{nullptr};
+    model::IsotropicWaveSpeeds* waveSpeedsPlus{nullptr};
+    model::IsotropicWaveSpeeds* waveSpeedsMinus{nullptr};
+  };
+
+  struct DrBaseCallBack : public DrPipeline::PipelineCallBack {
+    explicit DrBaseCallBack(DrContext userContext, time_stepping::TimeCluster *cluster)
+        : context(userContext), cluster(cluster) {}
+  protected:
+    DrContext context{};
+    time_stepping::TimeCluster *cluster{nullptr};
+#ifdef ACL_DEVICE
+    device::DeviceInstance &device = device::DeviceInstance::getInstance();
+#endif
+  };
+}
+
+
+#endif //DR_PIPELINE_H

--- a/src/Solver/Pipeline/DrTuner.cpp
+++ b/src/Solver/Pipeline/DrTuner.cpp
@@ -1,0 +1,125 @@
+/**
+ * @file
+ * This file is part of SeisSol.
+ *
+ * @author Ravil Dorozhinskii (ravil.dorozhinskii AT tum.de)
+ *
+ * @section LICENSE
+ * Copyright (c) 2015-2017, SeisSol Group
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @section DESCRIPTION
+ * A custom pipeline tuner of DR pipeline which is based on the golden bisection method
+ *
+ * The objective function is given as million DR cells updates per second which is
+ * supposed to get maximized
+ **/
+
+#include "DrTuner.h"
+#include <cmath>
+#include <iostream>
+
+namespace seissol::dr::pipeline {
+
+  DrPipelineTuner::DrPipelineTuner() {
+    assert(minBatchSize > 1.0 && "min batch size must be at least 1");
+
+    invPhi = 0.5 * (std::sqrt(5.0) - 1);
+    invPhiSquared = invPhi * invPhi;
+
+    stepSize = maxBatchSize - minBatchSize;
+    leftPoint = minBatchSize + invPhiSquared * stepSize;
+    rightPoint = minBatchSize + invPhi * stepSize;
+
+    currBatchSize = rightPoint;
+    action = Action::BeginRecordingRightEvaluation;
+  }
+
+  void DrPipelineTuner::tune(const std::array<double, NumStages>& stageTiming) {
+    constexpr size_t ComputeStageId{1};
+    double currPerformance = 1e6 * currBatchSize / (stageTiming[ComputeStageId] + 1e-12);
+
+    switch (action) {
+      case Action::SkipAction: {
+        return;
+      }
+      case Action::BeginRecordingRightEvaluation : {
+        rightValue = currPerformance;
+
+        // set next action to take (i.e. to evaluate and record left value)
+        action = Action::BeginRecordingLeftEvaluation;
+        currBatchSize = leftPoint;
+        return;
+      }
+      case Action::BeginRecordingLeftEvaluation : {
+        leftValue = currPerformance;
+        break;
+      }
+      case Action::RecordRightEvaluation : {
+        rightValue = currPerformance;
+        break;
+      }
+      case Action::RecordLeftEvaluation : {
+        leftValue = currPerformance;
+        break;
+      }
+      default: {
+        break;
+      }
+    }
+
+    const auto diff = std::abs(leftPoint - rightPoint);
+    if (eps > diff) {
+      // convergence achieved
+      action = Action::SkipAction;
+      isConverged = true;
+      return;
+    }
+
+    // Golden-section search
+    if (leftValue > rightValue) {
+      maxBatchSize = rightPoint;
+      rightPoint = leftPoint;
+      rightValue = leftValue;
+      stepSize = invPhi * stepSize;
+      leftPoint = minBatchSize + invPhiSquared * stepSize;
+      action = Action::RecordLeftEvaluation;
+      currBatchSize = leftPoint;
+    }
+    else {
+      minBatchSize = leftPoint;
+      leftPoint = rightPoint;
+      leftValue = rightValue;
+      stepSize = invPhi * stepSize;
+      rightPoint = minBatchSize + invPhi * stepSize;
+      action = Action::RecordRightEvaluation;
+      currBatchSize = rightPoint;
+    }
+  }
+}

--- a/src/Solver/Pipeline/DrTuner.h
+++ b/src/Solver/Pipeline/DrTuner.h
@@ -1,0 +1,87 @@
+/**
+ * @file
+ * This file is part of SeisSol.
+ *
+ * @author Ravil Dorozhinskii (ravil.dorozhinskii AT tum.de)
+ *
+ * @section LICENSE
+ * Copyright (c) 2015-2017, SeisSol Group
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @section DESCRIPTION
+ * A custom pipeline tuner of DR pipeline which is based on the golden bisection method
+ *
+ * The objective function is given as million DR cells updates per second which is
+ * supposed to get maximized
+ **/
+
+#ifndef DR_TUNER_H
+#define DR_TUNER_H
+
+#include <Solver/Pipeline/GenericPipeline.h>
+
+namespace seissol::unit_test {
+class DrTunerTest;
+}
+
+namespace seissol::dr::pipeline {
+  class DrPipelineTuner: public PipelineTuner<3, 1024> {
+  public:
+    DrPipelineTuner();
+    ~DrPipelineTuner() override = default;
+    void tune(const std::array<double, NumStages>& stageTiming) override;
+
+  private:
+    enum class Action {
+      BeginRecordingLeftEvaluation,
+      BeginRecordingRightEvaluation,
+      RecordLeftEvaluation,
+      RecordRightEvaluation,
+      SkipAction,
+    };
+    Action action;
+
+    double maxBatchSize{DefaultBatchSize};
+    double minBatchSize{0.1 * DefaultBatchSize};
+
+    double stepSize{};
+    double leftPoint{};
+    double rightPoint{};
+    double leftValue{0.0};
+    double rightValue{0.0};
+    double invPhi{};
+    double invPhiSquared{};
+    double eps{5e-2};
+    bool isConverged{false};
+
+    friend class seissol::unit_test::DrTunerTest;
+  };
+}
+
+#endif //DR_TUNER_H

--- a/src/Solver/Pipeline/DrTuner.h
+++ b/src/Solver/Pipeline/DrTuner.h
@@ -5,7 +5,7 @@
  * @author Ravil Dorozhinskii (ravil.dorozhinskii AT tum.de)
  *
  * @section LICENSE
- * Copyright (c) 2015-2017, SeisSol Group
+ * Copyright (c) 2020-2021, SeisSol Group
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -37,8 +37,7 @@
  * @section DESCRIPTION
  * A custom pipeline tuner of DR pipeline which is based on the golden bisection method
  *
- * The objective function is given as million DR cells updates per second which is
- * supposed to get maximized
+ * Note, this can be deprecated once friction solvers are adapted for GPU computing
  **/
 
 #ifndef DR_TUNER_H
@@ -46,9 +45,6 @@
 
 #include <Solver/Pipeline/GenericPipeline.h>
 
-namespace seissol::unit_test {
-class DrTunerTest;
-}
 
 namespace seissol::dr::pipeline {
   class DrPipelineTuner: public PipelineTuner<3, 1024> {
@@ -56,7 +52,9 @@ namespace seissol::dr::pipeline {
     DrPipelineTuner();
     ~DrPipelineTuner() override = default;
     void tune(const std::array<double, NumStages>& stageTiming) override;
-
+    [[nodiscard]] bool isTunerConverged() const {return isConverged;}
+    [[nodiscard]] double getMaxBatchSize() const {return maxBatchSize;}
+    [[nodiscard]] double getMinBatchSize() const {return minBatchSize;}
   private:
     enum class Action {
       BeginRecordingLeftEvaluation,
@@ -65,7 +63,7 @@ namespace seissol::dr::pipeline {
       RecordRightEvaluation,
       SkipAction,
     };
-    Action action;
+    Action action{Action::BeginRecordingRightEvaluation};
 
     double maxBatchSize{DefaultBatchSize};
     double minBatchSize{0.1 * DefaultBatchSize};
@@ -79,8 +77,6 @@ namespace seissol::dr::pipeline {
     double invPhiSquared{};
     double eps{5e-2};
     bool isConverged{false};
-
-    friend class seissol::unit_test::DrTunerTest;
   };
 }
 

--- a/src/Solver/Pipeline/GenericPipeline.h
+++ b/src/Solver/Pipeline/GenericPipeline.h
@@ -1,0 +1,233 @@
+/**
+ * @file
+ * This file is part of SeisSol.
+ *
+ * @author Ravil Dorozhinskii (ravil.dorozhinskii AT tum.de)
+ *
+ * @section LICENSE
+ * Copyright (c) 2015-2017, SeisSol Group
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @section DESCRIPTION
+ * An implementation of a pipeline.
+ *
+ * A user sets up a num. of stages, default batch size and callbacks. A instance of
+ * a pipeline is going to automatically handle corner cases, namely: filling
+ * and draining pipeline. A user defines callbacks as instance of classes derived
+ * from PipelineCallBack inner class. This approach allows one to customize a
+ * pipeline for her/his needs.
+ **/
+
+#ifndef GENERIC_PIPELINE_H
+#define GENERIC_PIPELINE_H
+
+#include <Monitoring/Stopwatch.h>
+#include <limits>
+#include <array>
+#include <cassert>
+
+
+namespace seissol::unit_test {
+  class PipelineTest;
+}
+
+namespace seissol {
+
+  template<unsigned NumStagesP, unsigned DefaultBatchSizeP>
+  class PipelineTuner {
+  public:
+    virtual ~PipelineTuner() = default;
+    constexpr static decltype(NumStagesP) NumStages{NumStagesP};
+    constexpr static decltype(DefaultBatchSizeP) DefaultBatchSize{DefaultBatchSizeP};
+
+    virtual void tune(const std::array<double, NumStages>& stageTiming) {
+      /**no default implementation provided**/
+    };
+    size_t getBatchSize() {
+      const auto batchSize = static_cast<size_t>(currBatchSize);
+      assert(batchSize != 0 && "error: autotuner derived zero-length batched size");
+      return batchSize;
+    }
+
+  protected:
+    double currBatchSize{static_cast<double>(DefaultBatchSize)};
+  };
+
+
+  template<unsigned NumStagesP, unsigned DefaultBatchSizeP, typename TunerT = PipelineTuner<NumStagesP, DefaultBatchSizeP>>
+  class GenericPipeline {
+  private:
+  public:
+    struct PipelineCallBack {
+      virtual ~PipelineCallBack() = default;
+      virtual void operator()(size_t begin, size_t end, size_t callCounter) = 0;
+      virtual void finalize() = 0;
+    };
+
+    GenericPipeline(bool resetAfterRun = true) : resetAfterRun(resetAfterRun) {
+      using BaseTunerT = PipelineTuner<NumStagesP, DefaultBatchSizeP>;
+      static_assert(std::is_base_of_v<BaseTunerT, TunerT>,
+                    "ConcreteTunerT must be derived from PipelineTuner");
+    }
+    ~GenericPipeline() = default;
+    constexpr static decltype(NumStagesP) NumStages{NumStagesP};
+    static constexpr decltype(NumStagesP) TailSize{NumStagesP - 1};
+    constexpr static decltype(DefaultBatchSizeP) DefaultBatchSize{DefaultBatchSizeP};
+
+    void registerCallBack(unsigned id, PipelineCallBack* callBack) {
+      assert(id < NumStages);
+      callBacks[id] = callBack;
+    }
+
+    void run(size_t size) {
+      init(size);
+      fill();
+      run();
+      drain();
+      clean();
+
+      for (auto& time: stageTiming)
+        time /= numTotalIterations;
+      tuner.tune(stageTiming);
+    }
+
+  private:
+    struct Range {
+      Range() = default;
+      Range(const Range& other) = default;
+      explicit Range(size_t step, size_t limit) :  begin(0), end(step), stepSize(step), limit(limit) {
+        clamp();
+      }
+      size_t begin{0};
+      size_t end{0};
+      size_t stepSize{0};
+      size_t limit{std::numeric_limits<size_t>::max()};
+      size_t currentIteration{0};
+      size_t size() {
+        assert(end > begin);
+        return (end - begin);
+      }
+      Range& operator++(int) {
+        this->begin += stepSize;
+        this->end += stepSize;
+        ++currentIteration;
+        clamp();
+        return *this;
+      }
+
+    private:
+      void clamp() {
+        begin = (begin > limit) ? limit : begin;
+        end = (end > limit) ? limit : end;
+      }
+    };
+
+    void init(size_t size) {
+      const auto currBatchSize = tuner.getBatchSize();
+      for (auto& range: ranges) {
+        range = Range(currBatchSize, size);
+      }
+      numTotalIterations = (size + currBatchSize - 1) / currBatchSize;
+      numFullPipeIterations = (numTotalIterations > TailSize) ? numTotalIterations - TailSize : 0;
+      stageTiming = decltype(stageTiming){};
+    }
+
+    void fill() {
+      for (unsigned i = 0; i < TailSize; ++i) {
+        for (unsigned stage = 0; stage < (i + 1); ++stage) {
+          if (ranges[stage].currentIteration < numTotalIterations) {
+            execute(stage, ranges[stage]);
+            ranges[stage]++;
+            checkToFinalize(stage, ranges[stage].currentIteration);
+          }
+        }
+      }
+    }
+
+    void run() {
+      // reduce numFullPipeIterations by 1 to handle a corner case in the `drain` stage
+      const size_t length = (numFullPipeIterations > 0) ? numFullPipeIterations - 1 : 0;
+      for (size_t i = 0; i < length; ++i) {
+        for (unsigned stage = 0; stage < NumStages; ++stage) {
+          execute(stage, ranges[stage]);
+          ranges[stage]++;
+        }
+      }
+    }
+
+    void drain() {
+      for (unsigned i = 0; i < TailSize + 1; ++i) {
+        for (unsigned stage = 0; stage < NumStages; ++stage) {
+          if (ranges[stage].currentIteration < numTotalIterations) {
+            execute(stage, ranges[stage]);
+            ranges[stage]++;
+            checkToFinalize(stage, ranges[stage].currentIteration);
+          }
+        }
+      }
+    }
+
+    void clean() {
+      if (resetAfterRun) {
+        for (auto& callBack: callBacks) {
+          callBack = nullptr;
+        }
+      }
+    }
+
+    void execute(unsigned stage, Range range) {
+      assert(callBacks[stage] != nullptr && "call back has not been setup");
+      stopwatch.start();
+      (*callBacks[stage])(range.begin, range.size(), range.currentIteration);
+      stageTiming[stage] += stopwatch.stop();
+    }
+
+    void checkToFinalize(unsigned stage, size_t currentIteration) {
+      assert(callBacks[stage] != nullptr && "call back has not been setup");
+      if (currentIteration == numTotalIterations) {
+        stopwatch.start();
+        callBacks[stage]->finalize();
+        stageTiming[stage] += stopwatch.stop();
+      }
+    }
+
+    size_t numTotalIterations{0};
+    size_t numFullPipeIterations{0};
+    std::array<Range, NumStages> ranges;
+    std::array<double, NumStages> stageTiming{};
+    std::array<PipelineCallBack*, NumStages> callBacks{nullptr};
+    bool resetAfterRun{true};
+    TunerT tuner;
+    Stopwatch stopwatch{};
+
+    friend class seissol::unit_test::PipelineTest;
+  };
+}
+
+#endif //GENERIC_PIPELINE_H

--- a/src/Solver/Pipeline/GenericPipeline.h
+++ b/src/Solver/Pipeline/GenericPipeline.h
@@ -5,7 +5,7 @@
  * @author Ravil Dorozhinskii (ravil.dorozhinskii AT tum.de)
  *
  * @section LICENSE
- * Copyright (c) 2015-2017, SeisSol Group
+ * Copyright (c) 2020-2021, SeisSol Group
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -53,10 +53,6 @@
 #include <cassert>
 
 
-namespace seissol::unit_test {
-  class PipelineTest;
-}
-
 namespace seissol {
 
   template<unsigned NumStagesP, unsigned DefaultBatchSizeP>
@@ -82,11 +78,10 @@ namespace seissol {
 
   template<unsigned NumStagesP, unsigned DefaultBatchSizeP, typename TunerT = PipelineTuner<NumStagesP, DefaultBatchSizeP>>
   class GenericPipeline {
-  private:
   public:
     struct PipelineCallBack {
       virtual ~PipelineCallBack() = default;
-      virtual void operator()(size_t begin, size_t end, size_t callCounter) = 0;
+      virtual void operator()(size_t begin, size_t batchSize, size_t callCounter) = 0;
       virtual void finalize() = 0;
     };
 
@@ -97,7 +92,7 @@ namespace seissol {
     }
     ~GenericPipeline() = default;
     constexpr static decltype(NumStagesP) NumStages{NumStagesP};
-    static constexpr decltype(NumStagesP) TailSize{NumStagesP - 1};
+    constexpr static decltype(NumStagesP) TailSize{NumStagesP - 1};
     constexpr static decltype(DefaultBatchSizeP) DefaultBatchSize{DefaultBatchSizeP};
 
     void registerCallBack(unsigned id, PipelineCallBack* callBack) {
@@ -141,7 +136,6 @@ namespace seissol {
         return *this;
       }
 
-    private:
       void clamp() {
         begin = (begin > limit) ? limit : begin;
         end = (end > limit) ? limit : end;
@@ -225,8 +219,6 @@ namespace seissol {
     bool resetAfterRun{true};
     TunerT tuner;
     Stopwatch stopwatch{};
-
-    friend class seissol::unit_test::PipelineTest;
   };
 }
 

--- a/src/Solver/time_stepping/TimeCluster.cpp
+++ b/src/Solver/time_stepping/TimeCluster.cpp
@@ -768,7 +768,7 @@ void seissol::time_stepping::TimeCluster::computeNeighboringIntegration( seissol
                                                );
 
 #ifdef USE_PLASTICITY
-  numberOTetsWithPlasticYielding += seissol::kernels::Plasticity::computePlasticity( m_relaxTime,
+  numberOTetsWithPlasticYielding += seissol::kernels::Plasticity::computePlasticity( m_oneMinusIntegratingFactor,
                                                                                      m_timeStepWidth,
                                                                                      m_tv,
                                                                                      m_globalDataOnHost,
@@ -807,7 +807,7 @@ void seissol::time_stepping::TimeCluster::computeNeighboringIntegration( seissol
 
 #ifdef USE_PLASTICITY
   PlasticityData* plasticity = i_layerData.var(m_lts->plasticity);
-  unsigned numAdjustedDofs = seissol::kernels::Plasticity::computePlasticityBatched(m_relaxTime,
+  unsigned numAdjustedDofs = seissol::kernels::Plasticity::computePlasticityBatched(m_oneMinusIntegratingFactor,
                                                                                     m_timeStepWidth,
                                                                                     m_tv,
                                                                                     m_globalDataOnDevice,

--- a/src/Solver/time_stepping/TimeCluster.cpp
+++ b/src/Solver/time_stepping/TimeCluster.cpp
@@ -158,7 +158,7 @@ seissol::time_stepping::TimeCluster::TimeCluster( unsigned int                  
   m_localKernel.setGlobalData(i_globalData);
   m_localKernel.setInitConds(&e_interoperability.getInitialConditions());
   m_neighborKernel.setGlobalData(i_globalData);
-  m_dynamicRuptureKernel.setGlobalData(m_globalDataOnHost);
+  m_dynamicRuptureKernel.setGlobalData(i_globalData);
 
   computeFlops();
 
@@ -233,10 +233,8 @@ void seissol::time_stepping::TimeCluster::computeSources() {
 #endif
 }
 
+#ifndef ACL_DEVICE
 void seissol::time_stepping::TimeCluster::computeDynamicRupture( seissol::initializers::Layer&  layerData ) {
-#ifdef ACL_DEVICE
-  device.api->putProfilingMark("computeDynamicRupture", device::ProfilingColors::Cyan);
-#endif
   SCOREP_USER_REGION( "computeDynamicRupture", SCOREP_USER_REGION_TYPE_FUNCTION )
 
   m_loopStatistics->begin(m_regionComputeDynamicRupture);
@@ -281,10 +279,143 @@ void seissol::time_stepping::TimeCluster::computeDynamicRupture( seissol::initia
   }
 
   m_loopStatistics->end(m_regionComputeDynamicRupture, layerData.getNumberOfCells());
-#ifdef ACL_DEVICE
-  device.api->popLastProfilingMark();
-#endif
 }
+#else
+
+void seissol::time_stepping::TimeCluster::computeDynamicRupture( seissol::initializers::Layer&  layerData ) {
+  device.api->putProfilingMark("computeDynamicRupture", device::ProfilingColors::Cyan);
+  SCOREP_USER_REGION( "computeDynamicRupture", SCOREP_USER_REGION_TYPE_FUNCTION )
+
+  m_loopStatistics->begin(m_regionComputeDynamicRupture);
+
+  if (layerData.getNumberOfCells() > 0) {
+    // compute space time interpolation part
+    ConditionalBatchTableT &table = layerData.getCondBatchTable();
+    m_dynamicRuptureKernel.batchedSpaceTimeInterpolation(table);
+
+    // compute friction part
+    using namespace dr::pipeline;
+    DrContext context;
+    context.QInterpolatedPlusOnDevice = static_cast<real *>(layerData.getScratchpadMemory(m_dynRup->QInterpolatedPlusOnDevice));
+    context.QInterpolatedMinusOnDevice = static_cast<real *>(layerData.getScratchpadMemory(m_dynRup->QInterpolatedMinusOnDevice));
+    context.QInterpolatedPlusOnHost = static_cast<DrContext::QInterpolatedPtrT>(layerData.getScratchpadMemory(m_dynRup->QInterpolatedPlusOnHost));
+    context.QInterpolatedMinusOnHost = static_cast<DrContext::QInterpolatedPtrT>(layerData.getScratchpadMemory(m_dynRup->QInterpolatedMinusOnHost));
+
+    context.faceInformation = layerData.var(m_dynRup->faceInformation);
+    context.devImposedStatePlus = layerData.var(m_dynRup->imposedStatePlus);
+    context.devImposedStateMinus = layerData.var(m_dynRup->imposedStateMinus);
+    context.waveSpeedsPlus = layerData.var(m_dynRup->waveSpeedsPlus);
+    context.waveSpeedsMinus = layerData.var(m_dynRup->waveSpeedsMinus);
+
+    context.imposedStatePlusOnHost = static_cast<DrContext::imposedStatePlusT>(layerData.getScratchpadMemory(m_dynRup->imposedStatePlusOnHost));
+    context.imposedStateMinusOnHost = static_cast<DrContext::imposedStatePlusT>(layerData.getScratchpadMemory(m_dynRup->imposedStateMinusOnHost));
+
+    struct AsyncCopyFrom : public DrBaseCallBack {
+      explicit AsyncCopyFrom(DrContext userContext, TimeCluster *cluster) : DrBaseCallBack(userContext, cluster) {
+        assert(context.QInterpolatedPlusOnDevice != nullptr);
+        assert(context.QInterpolatedMinusOnDevice != nullptr);
+        assert(context.QInterpolatedPlusOnHost != nullptr);
+        assert(context.QInterpolatedMinusOnHost != nullptr);
+        copyFromStream = device.api->getNextCircularStream();
+      }
+
+      void operator()(size_t begin, size_t batchSize, size_t callCounter) override {
+        constexpr size_t QInterpolatedSize = CONVERGENCE_ORDER * tensor::QInterpolated::size();
+        const size_t upperStageOffset = (callCounter % DrPipeline::TailSize) * DrPipeline::DefaultBatchSize;
+
+        device.api->syncStreamFromCircularBuffer(copyFromStream);
+        device.api->copyFromAsync(reinterpret_cast<real *>(&context.QInterpolatedPlusOnHost[upperStageOffset]),
+                                  reinterpret_cast<real *>(&context.QInterpolatedPlusOnDevice[begin * QInterpolatedSize]),
+                                  batchSize * QInterpolatedSize * sizeof(real),
+                                  copyFromStream);
+
+        device.api->copyFromAsync(reinterpret_cast<real *>(&context.QInterpolatedMinusOnHost[upperStageOffset]),
+                                  reinterpret_cast<real *>(&context.QInterpolatedMinusOnDevice[begin * QInterpolatedSize]),
+                                  batchSize * QInterpolatedSize * sizeof(real),
+                                  copyFromStream);
+      }
+
+      void finalize() override {
+        device.api->syncStreamFromCircularBuffer(copyFromStream);
+      }
+    private:
+      void *copyFromStream{nullptr};
+    } asyncCopyFrom(context, this);
+
+    struct ComputeFriction : public DrBaseCallBack {
+      explicit ComputeFriction(DrContext userContext, TimeCluster *cluster) : DrBaseCallBack(userContext, cluster) {
+        assert(context.faceInformation != nullptr);
+        assert(context.imposedStatePlusOnHost != nullptr);
+        assert(context.imposedStateMinusOnHost != nullptr);
+        assert(context.waveSpeedsPlus != nullptr);
+        assert(context.waveSpeedsMinus != nullptr);
+      }
+
+      void operator()(size_t begin, size_t batchSize, size_t callCounter) override {
+        const size_t upperStageOffset = (callCounter % DrPipeline::TailSize) * DrPipeline::DefaultBatchSize;
+        const size_t lowerStageOffset = (callCounter % DrPipeline::NumStages) * DrPipeline::DefaultBatchSize;
+
+#ifdef _OPENMP
+#pragma omp parallel for schedule(static)
+#endif
+        for (unsigned face = 0; face < batchSize; ++face) {
+          e_interoperability.evaluateFrictionLaw(static_cast<int>(context.faceInformation[begin + face].meshFace),
+                                                 context.QInterpolatedPlusOnHost[upperStageOffset + face],
+                                                 context.QInterpolatedMinusOnHost[upperStageOffset + face],
+                                                 context.imposedStatePlusOnHost[lowerStageOffset + face],
+                                                 context.imposedStateMinusOnHost[lowerStageOffset + face],
+                                                 cluster->m_fullUpdateTime,
+                                                 cluster->m_dynamicRuptureKernel.timePoints,
+                                                 cluster->m_dynamicRuptureKernel.timeWeights,
+                                                 context.waveSpeedsPlus[begin + face],
+                                                 context.waveSpeedsMinus[begin + face]);
+        }
+      }
+      void finalize() override {}
+    } computeFriction(context, this);
+
+
+    struct AsyncCopyBack : public DrBaseCallBack {
+      explicit AsyncCopyBack(DrContext userContext, TimeCluster *cluster) : DrBaseCallBack(userContext, cluster) {
+        assert(context.devImposedStatePlus != nullptr);
+        assert(context.devImposedStateMinus != nullptr);
+        copyBackStream = device.api->getNextCircularStream();
+      }
+
+      void operator()(size_t begin, size_t batchSize, size_t callCounter) override {
+        const size_t lowerStageOffset = (callCounter % DrPipeline::NumStages) * DrPipeline::DefaultBatchSize;
+        const size_t imposedStateSize = tensor::QInterpolated::size() * batchSize * sizeof(real);
+
+        device.api->syncStreamFromCircularBuffer(copyBackStream);
+        device.api->copyToAsync(reinterpret_cast<real *>(&context.devImposedStatePlus[begin]),
+                                reinterpret_cast<real *>(&context.imposedStatePlusOnHost[lowerStageOffset]),
+                                imposedStateSize,
+                                copyBackStream);
+
+        device.api->copyToAsync(reinterpret_cast<real *>(&context.devImposedStateMinus[begin]),
+                                reinterpret_cast<real *>(&context.imposedStateMinusOnHost[lowerStageOffset]),
+                                imposedStateSize,
+                                copyBackStream);
+      }
+
+      void finalize() override {
+        device.api->syncStreamFromCircularBuffer(copyBackStream);
+      }
+    private:
+      void *copyBackStream{nullptr};
+    } asyncCopyBack(context, this);
+
+    drPipeline.registerCallBack(0, &asyncCopyFrom);
+    drPipeline.registerCallBack(1, &computeFriction);
+    drPipeline.registerCallBack(2, &asyncCopyBack);
+    drPipeline.run(layerData.getNumberOfCells());
+
+    device.api->resetCircularStreamCounter();
+  }
+  m_loopStatistics->end(m_regionComputeDynamicRupture, layerData.getNumberOfCells());
+  device.api->popLastProfilingMark();
+}
+#endif
 
 
 void seissol::time_stepping::TimeCluster::computeDynamicRuptureFlops( seissol::initializers::Layer& layerData,

--- a/src/Solver/time_stepping/TimeCluster.h
+++ b/src/Solver/time_stepping/TimeCluster.h
@@ -203,7 +203,7 @@ private:
     double m_tv;
     
     //! Relax time for plasticity
-    double m_one_minus_integrating_factor;
+    double m_oneMinusIntegratingFactor;
     
     //! Stopwatch of TimeManager
     LoopStatistics* m_loopStatistics;
@@ -322,7 +322,7 @@ private:
     
     //! Update relax time for plasticity
     void updateRelaxTime() {
-      m_one_minus_integrating_factor = (m_tv > 0.0) ? 1.0 - exp(-m_timeStepWidth / m_tv) : 1.0;
+      m_oneMinusIntegratingFactor = (m_tv > 0.0) ? 1.0 - exp(-m_timeStepWidth / m_tv) : 1.0;
     }
 
   public:

--- a/src/Solver/time_stepping/TimeCluster.h
+++ b/src/Solver/time_stepping/TimeCluster.h
@@ -89,6 +89,10 @@
 #include <Kernels/Plasticity.h>
 #include <Solver/FreeSurfaceIntegrator.h>
 #include <Monitoring/LoopStatistics.h>
+#ifdef ACL_DEVICE
+#include <device.h>
+#include <Solver/Pipeline/DrPipeline.h>
+#endif
 
 namespace seissol {
   namespace time_stepping {
@@ -143,6 +147,7 @@ private:
     GlobalData *m_globalDataOnDevice{nullptr};
 #ifdef ACL_DEVICE
     device::DeviceInstance& device = device::DeviceInstance::getInstance();
+    dr::pipeline::DrPipeline drPipeline;
 #endif
 
     /*

--- a/src/sources.cmake
+++ b/src/sources.cmake
@@ -33,6 +33,7 @@ src/Solver/Interoperability.cpp
 src/Solver/time_stepping/MiniSeisSol.cpp
 src/Solver/time_stepping/TimeCluster.cpp
 src/Solver/time_stepping/TimeManager.cpp
+src/Solver/Pipeline/DrTuner.cpp
 src/Kernels/DynamicRupture.cpp
 src/Kernels/Plasticity.cpp
 src/Kernels/TimeCommon.cpp
@@ -201,7 +202,8 @@ if ("${DEVICE_BACKEND}" STREQUAL "CUDA")
   target_sources(SeisSol-lib PUBLIC
           ${CMAKE_CURRENT_SOURCE_DIR}/src/Initializer/BatchRecorders/LocalIntegrationRecorder.cpp
           ${CMAKE_CURRENT_SOURCE_DIR}/src/Initializer/BatchRecorders/NeighIntegrationRecorder.cpp
-          ${CMAKE_CURRENT_SOURCE_DIR}/src/Initializer/BatchRecorders/PlasticityRecorder.cpp)
+          ${CMAKE_CURRENT_SOURCE_DIR}/src/Initializer/BatchRecorders/PlasticityRecorder.cpp
+          ${CMAKE_CURRENT_SOURCE_DIR}/src/Initializer/BatchRecorders/DynamicRuptureRecorder.cpp)
 
   find_package(CUDA REQUIRED)
   set(CUDA_NVCC_FLAGS -std=c++14;

--- a/src/tests/Pipeline/DrTunerTest.t.h
+++ b/src/tests/Pipeline/DrTunerTest.t.h
@@ -1,0 +1,61 @@
+#include <cxxtest/TestSuite.h>
+#include "Solver/Pipeline/DrTuner.h"
+#include <array>
+
+
+namespace seissol {
+  namespace unit_test {
+    class DrTunerTest;
+  }
+}
+
+
+class seissol::unit_test::DrTunerTest : public CxxTest::TestSuite {
+public:
+  void testGoesToLeft() {
+    dr::pipeline::DrPipelineTuner tuner;
+    // this is going to results in: Performance ~ 1 / batchSize
+    auto squareFunction = [] (size_t x) {return static_cast<double>(x * x);};
+
+    while (!tuner.isConverged) {
+      batchSize = tuner.getBatchSize();
+      timing[ComputeStageId] = squareFunction(batchSize);
+      tuner.tune(timing);
+    }
+    TS_ASSERT_DELTA(batchSize, tuner.minBatchSize, eps);
+  }
+
+  void testGoesToRight() {
+    dr::pipeline::DrPipelineTuner tuner;
+    auto hyperbolicTime = [](size_t x) {return 1.0 / (static_cast<double>(x + 1.0));};
+
+    while (!tuner.isConverged) {
+      batchSize = tuner.getBatchSize();
+      timing[ComputeStageId] = hyperbolicTime(batchSize);
+      tuner.tune(timing);
+    }
+    TS_ASSERT_DELTA(batchSize, tuner.maxBatchSize, eps);
+  }
+
+  void testMaxWithinRange() {
+    dr::pipeline::DrPipelineTuner tuner;
+    const auto midPoint = 0.5 * (tuner.maxBatchSize + tuner.minBatchSize);
+
+    auto hatFunction = [midPoint] (size_t x) {
+      return std::abs(midPoint - x);
+    };
+
+    while (!tuner.isConverged) {
+      batchSize = tuner.getBatchSize();
+      timing[ComputeStageId] = hatFunction(batchSize);
+      tuner.tune(timing);
+    }
+    TS_ASSERT_DELTA(batchSize, midPoint, eps);
+  }
+
+private:
+  constexpr static size_t ComputeStageId{1};
+  std::array<double, 3> timing{};
+  constexpr static double eps{2.0};
+  size_t batchSize{0};
+};

--- a/src/tests/Pipeline/DrTunerTest.t.h
+++ b/src/tests/Pipeline/DrTunerTest.t.h
@@ -17,35 +17,35 @@ public:
     // this is going to results in: Performance ~ 1 / batchSize
     auto squareFunction = [] (size_t x) {return static_cast<double>(x * x);};
 
-    while (!tuner.isConverged) {
+    while (!tuner.isTunerConverged()) {
       batchSize = tuner.getBatchSize();
       timing[ComputeStageId] = squareFunction(batchSize);
       tuner.tune(timing);
     }
-    TS_ASSERT_DELTA(batchSize, tuner.minBatchSize, eps);
+    TS_ASSERT_DELTA(batchSize, tuner.getMinBatchSize(), eps);
   }
 
   void testGoesToRight() {
     dr::pipeline::DrPipelineTuner tuner;
     auto hyperbolicTime = [](size_t x) {return 1.0 / (static_cast<double>(x + 1.0));};
 
-    while (!tuner.isConverged) {
+    while (!tuner.isTunerConverged()) {
       batchSize = tuner.getBatchSize();
       timing[ComputeStageId] = hyperbolicTime(batchSize);
       tuner.tune(timing);
     }
-    TS_ASSERT_DELTA(batchSize, tuner.maxBatchSize, eps);
+    TS_ASSERT_DELTA(batchSize, tuner.getMaxBatchSize(), eps);
   }
 
   void testMaxWithinRange() {
     dr::pipeline::DrPipelineTuner tuner;
-    const auto midPoint = 0.5 * (tuner.maxBatchSize + tuner.minBatchSize);
+    const auto midPoint = 0.5 * (tuner.getMaxBatchSize() + tuner.getMinBatchSize());
 
     auto hatFunction = [midPoint] (size_t x) {
       return std::abs(midPoint - x);
     };
 
-    while (!tuner.isConverged) {
+    while (!tuner.isTunerConverged()) {
       batchSize = tuner.getBatchSize();
       timing[ComputeStageId] = hatFunction(batchSize);
       tuner.tune(timing);

--- a/src/tests/Pipeline/PipelineTest.t.h
+++ b/src/tests/Pipeline/PipelineTest.t.h
@@ -1,0 +1,165 @@
+#include <cxxtest/TestSuite.h>
+#include "Solver/Pipeline/GenericPipeline.h"
+#include <string>
+#include <memory>
+#include <algorithm>
+#include <iterator>
+#include <iostream>
+
+namespace seissol {
+  namespace unit_test {
+    class PipelineTest;
+  }
+}
+
+class seissol::unit_test::PipelineTest : public CxxTest::TestSuite
+{
+private:
+  using TestPipeline = seissol::GenericPipeline<4, 1024>;
+  struct TestStageCallBack : public TestPipeline::PipelineCallBack {
+    explicit TestStageCallBack(std::string& buffer) : buffer(buffer) {}
+    void finalize() override {
+      buffer.push_back('F');
+    }
+  protected:
+    std::string& buffer;
+  };
+
+  struct FirstStage : public TestStageCallBack {
+    explicit FirstStage(std::string& buffer) : TestStageCallBack(buffer) {}
+    void operator()(size_t, size_t, size_t) override {
+      buffer.push_back('A');
+    }
+  };
+
+  struct SecondStage : public TestStageCallBack {
+    explicit SecondStage(std::string& buffer) : TestStageCallBack(buffer) {}
+    void operator()(size_t, size_t, size_t) override {
+      buffer.push_back('B');
+    }
+  };
+
+  struct ThirdStage : public TestStageCallBack {
+    explicit ThirdStage(std::string& buffer) : TestStageCallBack(buffer) {}
+    void operator()(size_t, size_t, size_t) override {
+      buffer.push_back('C');
+    }
+  };
+
+  struct FourthStage : public TestStageCallBack {
+    explicit FourthStage(std::string& buffer) : TestStageCallBack(buffer) {}
+    void operator()(size_t, size_t, size_t) override {
+      buffer.push_back('D');
+    }
+  };
+
+  static std::string format(std::string&& stringWithSpaces) {
+    static auto notSpace = [](unsigned char x){return std::isspace(x) == 0;};
+
+    std::string stringWoSpaces{};
+    std::copy_if(stringWithSpaces.begin(),
+                 stringWithSpaces.end(),
+                 std::back_inserter(stringWoSpaces),
+                 notSpace);
+    return stringWoSpaces;
+  }
+
+public:
+  void testGeneral() {
+    TestPipeline pipeline{};
+    TS_ASSERT_EQUALS(TestPipeline::NumStages, 4);
+    TS_ASSERT_EQUALS(TestPipeline::TailSize, 3);
+  }
+
+  void testSuperShortPipeline()
+  {
+    std::string testBuffer{};
+    std::array<std::shared_ptr<TestPipeline::PipelineCallBack>, 4> callBacks = {
+        std::make_shared<FirstStage>(testBuffer),
+        std::make_shared<SecondStage>(testBuffer),
+        std::make_shared<ThirdStage>(testBuffer),
+        std::make_shared<FourthStage>(testBuffer),
+    };
+    TestPipeline pipeline{};
+    for (unsigned i = 0; i < callBacks.size(); ++i) {
+      pipeline.registerCallBack(i, callBacks[i].get());
+    }
+
+    pipeline.run(TestPipeline::DefaultBatchSize - 3);
+    std::string expectedResults{PipelineTest::format("AF BF CF DF")};
+
+    TS_ASSERT_EQUALS(testBuffer.size(), expectedResults.size());
+    TS_ASSERT_EQUALS(pipeline.numFullPipeIterations, 0);
+    TS_ASSERT_EQUALS(pipeline.numTotalIterations, 1);
+    TS_ASSERT_SAME_DATA(testBuffer.data(), expectedResults.data(), expectedResults.size());
+  }
+
+  void testShortPipeline()
+  {
+    std::string testBuffer{};
+    std::array<std::shared_ptr<TestPipeline::PipelineCallBack>, 4> callBacks = {
+        std::make_shared<FirstStage>(testBuffer),
+        std::make_shared<SecondStage>(testBuffer),
+        std::make_shared<ThirdStage>(testBuffer),
+        std::make_shared<FourthStage>(testBuffer),
+    };
+    TestPipeline pipeline{};
+    for (unsigned i = 0; i < callBacks.size(); ++i) {
+      pipeline.registerCallBack(i, callBacks[i].get());
+    }
+
+    pipeline.run(2 * TestPipeline::DefaultBatchSize - 3);
+    std::string expectedResults{PipelineTest::format("A AFB BFC CFD DF")};
+
+    TS_ASSERT_EQUALS(testBuffer.size(), expectedResults.size());
+    TS_ASSERT_EQUALS(pipeline.numFullPipeIterations, 0);
+    TS_ASSERT_EQUALS(pipeline.numTotalIterations, 2);
+    TS_ASSERT_SAME_DATA(testBuffer.data(), expectedResults.data(), expectedResults.size());
+  }
+
+  void testWithOneFullPipelineIteration()
+  {
+    std::string testBuffer{};
+    std::array<std::shared_ptr<TestPipeline::PipelineCallBack>, 4> callBacks = {
+        std::make_shared<FirstStage>(testBuffer),
+        std::make_shared<SecondStage>(testBuffer),
+        std::make_shared<ThirdStage>(testBuffer),
+        std::make_shared<FourthStage>(testBuffer),
+    };
+    TestPipeline pipeline{};
+    for (unsigned i = 0; i < callBacks.size(); ++i) {
+      pipeline.registerCallBack(i, callBacks[i].get());
+    }
+
+    pipeline.run(4 * TestPipeline::DefaultBatchSize - 3);
+    std::string expectedResults{PipelineTest::format("A AB ABC AFBCD BFCD CFD DF")};
+
+    TS_ASSERT_EQUALS(testBuffer.size(), expectedResults.size());
+    TS_ASSERT_EQUALS(pipeline.numFullPipeIterations, 1);
+    TS_ASSERT_EQUALS(pipeline.numTotalIterations, 4);
+    TS_ASSERT_SAME_DATA(testBuffer.data(), expectedResults.data(), expectedResults.size());
+  }
+
+  void testLongPipeline()
+  {
+    std::string testBuffer{};
+    std::array<std::shared_ptr<TestPipeline::PipelineCallBack>, 4> callBacks = {
+        std::make_shared<FirstStage>(testBuffer),
+        std::make_shared<SecondStage>(testBuffer),
+        std::make_shared<ThirdStage>(testBuffer),
+        std::make_shared<FourthStage>(testBuffer),
+    };
+    TestPipeline pipeline{};
+    for (unsigned i = 0; i < callBacks.size(); ++i) {
+      pipeline.registerCallBack(i, callBacks[i].get());
+    }
+
+    pipeline.run(4 * TestPipeline::DefaultBatchSize + 3);
+    std::string expectedResults{PipelineTest::format("A AB ABC ABCD AFBCD BFCD CFD DF")};
+
+    TS_ASSERT_EQUALS(testBuffer.size(), expectedResults.size());
+    TS_ASSERT_EQUALS(pipeline.numFullPipeIterations, 2);
+    TS_ASSERT_EQUALS(pipeline.numTotalIterations, 5);
+    TS_ASSERT_SAME_DATA(testBuffer.data(), expectedResults.data(), expectedResults.size());
+  }
+};


### PR DESCRIPTION
This PR contains GPU implementation of space time interpolation which is required by DR cells. Additionally, pipelining has been utilized to hide CPU-to-GPU memory transfers which happens due to the DR part is still computed with CPUs. A DR layer is split into batches which forms a work-load for each stage. The first stage moves asynchronously data from device to host, the second stage runs a friction solver, the third stage asynchronously copies results computed by the second stage in its previous iteration. Because it is difficult to find a good batch size, a simple tuner has been implemented which takes into account estimated performance of the second stage.  (The DR pipeline is meant to be deprecated once DR is fully adapted for GPU.)

Pipelining was implemented in a generic way which allows to customize it for different kinds of computations if it is needed. Tests are included.

Additionally, changes were tested with 2 GPUs on an LRZ ARM+NVIDIA node. Numerical results are correct