### PR TITLE
Update xdmf writer.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -298,7 +298,7 @@ endif()
 # C++ compiler settings
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
   target_compile_options(SeisSol-lib PUBLIC -fopenmp -pedantic $<$<OR:$<COMPILE_LANGUAGE:CXX>,$<COMPILE_LANGUAGE:C>>:-Wall -Wextra -Wno-unused-parameter -Wno-unknown-pragmas>)
-  target_link_libraries(SeisSol-lib PUBLIC "-fopenmp")
+  target_link_libraries(SeisSol-lib PUBLIC "-fopenmp" "-lstdc++fs")
 
   # using GCC
 elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Intel")
@@ -309,10 +309,13 @@ elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Intel")
   # only if openmp
   set(CMAKE_EXE_LINKER_FLAGS  "${CMAKE_EXE_LINKER_FLAGS} -qopenmp")
 
+  target_link_libraries(SeisSol-lib PUBLIC "-lstdc++fs")
+
   # Activate interprocedual optimization.
   #set_property(TARGET SeisSol-lib PROPERTY INTERPROCEDURAL_OPTIMIZATION TRUE) 
 elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17 -fopenmp=libomp -Wall -Wextra -pedantic")
+  target_link_libraries(SeisSol-lib PUBLIC "lc++fs")
 endif()
 
 # Generated code does only work without red-zone.


### PR DESCRIPTION
As mentioned in #330, currently SeisSol fails with a very strange error, when an output file is not found. This PR should address that issue.
