### PR TITLE
Remove compile option for plasticity

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,11 +108,6 @@ add_custom_command(
        COMMENT "Codegen for tensor stuff."
        )
 
-if (PLASTICITY)
-  target_compile_definitions(SeisSol-lib PUBLIC USE_PLASTICITY)
-  set(PLASTICITY_NAME_SUFFIX "_plasticity")
-endif()
-
 if (PLASTICITY_METHOD STREQUAL "ip")
   target_compile_definitions(SeisSol-lib PUBLIC USE_PLASTICITY_IP)
 elseif (PLASTICITY_METHOD STREQUAL "nb")
@@ -359,6 +354,8 @@ add_executable(SeisSol-proxy auto_tuning/proxy/src/proxy_main.cpp)
 target_link_libraries(SeisSol-proxy PUBLIC SeisSol-proxy-core SeisSol-lib)
 set_target_properties(SeisSol-proxy PROPERTIES OUTPUT_NAME "SeisSol_proxy_${EXE_NAME_PREFIX}")
 
+set (CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -fno-omit-frame-pointer -fsanitize=address -fsanitize-recover=all")
+set (CMAKE_LINKER_FLAGS_DEBUG "${CMAKE_LINKER_FLAGS_DEBUG} -fno-omit-frame-pointer -fsanitize=address -fsanitize-recover=all")
 
 if (TESTING)
   include(cmake/testing.cmake)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ project(SeisSol LANGUAGES C CXX Fortran)
 #       user's input: HOST_ARCH, DEVICE_ARCH, DEVICE_SUB_ARCH,
 #                     ORDER, NUMBER_OF_MECHANISMS, EQUATIONS,
 #                     PRECISION, DYNAMIC_RUPTURE_METHOD,
-#                     PLASTICITY, NUMBER_OF_FUSED_SIMULATIONS,
+#                     NUMBER_OF_FUSED_SIMULATIONS,
 #                     MEMORY_LAYOUT, COMMTHREAD,
 #                     LOG_LEVEL, LOG_LEVEL_MASTER,
 #                     GEMM_TOOLS_LIST, EXTRA_CXX_FLAGS
@@ -330,7 +330,7 @@ endif()
 
 add_executable(SeisSol-bin src/main.cpp)
 target_link_libraries(SeisSol-bin PUBLIC SeisSol-lib)
-set_target_properties(SeisSol-bin PROPERTIES OUTPUT_NAME "SeisSol_${EXE_NAME_PREFIX}${PLASTICITY_NAME_SUFFIX}")
+set_target_properties(SeisSol-bin PROPERTIES OUTPUT_NAME "SeisSol_${EXE_NAME_PREFIX}")
 
 # SeisSol proxy-core
 add_library(SeisSol-proxy-core auto_tuning/proxy/src/proxy_seissol.cpp
@@ -353,9 +353,6 @@ endif()
 add_executable(SeisSol-proxy auto_tuning/proxy/src/proxy_main.cpp)
 target_link_libraries(SeisSol-proxy PUBLIC SeisSol-proxy-core SeisSol-lib)
 set_target_properties(SeisSol-proxy PROPERTIES OUTPUT_NAME "SeisSol_proxy_${EXE_NAME_PREFIX}")
-
-set (CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -fno-omit-frame-pointer -fsanitize=address -fsanitize-recover=all")
-set (CMAKE_LINKER_FLAGS_DEBUG "${CMAKE_LINKER_FLAGS_DEBUG} -fno-omit-frame-pointer -fsanitize=address -fsanitize-recover=all")
 
 if (TESTING)
   include(cmake/testing.cmake)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -312,7 +312,7 @@ elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Intel")
   #set_property(TARGET SeisSol-lib PROPERTY INTERPROCEDURAL_OPTIMIZATION TRUE) 
 elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17 -fopenmp=libomp -Wall -Wextra -pedantic")
-  target_link_libraries(SeisSol-lib PUBLIC "lc++fs")
+  target_link_libraries(SeisSol-lib PUBLIC "-lstdc++fs")
 endif()
 
 # Generated code does only work without red-zone.

--- a/auto_tuning/proxy/src/proxy_seissol_allocator.hpp
+++ b/auto_tuning/proxy/src/proxy_seissol_allocator.hpp
@@ -254,9 +254,7 @@ void initDataStructuresOnDevice(bool enableDynamicRupture) {
   recorder.addRecorder(new seissol::initializers::recording::LocalIntegrationRecorder);
   recorder.addRecorder(new seissol::initializers::recording::NeighIntegrationRecorder);
 
-#ifdef USE_PLASTICITY
   recorder.addRecorder(new seissol::initializers::recording::PlasticityRecorder);
-#endif
   recorder.record(m_lts, layer);
   if (enableDynamicRupture) {
     auto &drLayer = m_dynRupTree->child(0).child<Interior>();

--- a/auto_tuning/proxy/src/proxy_seissol_allocator.hpp
+++ b/auto_tuning/proxy/src/proxy_seissol_allocator.hpp
@@ -115,7 +115,7 @@ void initGlobalData() {
 unsigned int initDataStructures(unsigned int i_cells, bool enableDynamicRupture) {
   // init RNG
   srand48(i_cells);
-  m_lts.addTo(*m_ltsTree);
+  m_lts.addTo(*m_ltsTree, false); // proxy does not use plasticity
   m_ltsTree->setNumberOfTimeClusters(1);
   m_ltsTree->fixate();
   

--- a/cmake/process_users_input.cmake
+++ b/cmake/process_users_input.cmake
@@ -54,7 +54,6 @@ set(RUPTURE_OPTIONS quadrature cellaverage)
 set_property(CACHE DYNAMIC_RUPTURE_METHOD PROPERTY STRINGS ${RUPTURE_OPTIONS})
 
 
-option(PLASTICITY "Use plasticity")
 set(PLASTICITY_METHOD "nb" CACHE STRING "Dynamic rupture method: nb (nodal basis) is faster, ip (interpolation points) possibly more accurate. Recommended: nb")
 set(PLASTICITY_OPTIONS nb ip)
 set_property(CACHE PLASTICITY_METHOD PROPERTY STRINGS ${PLASTICITY_OPTIONS})

--- a/src/Geometry/MeshReaderCBinding.f90
+++ b/src/Geometry/MeshReaderCBinding.f90
@@ -80,7 +80,7 @@ module MeshReaderCBinding
             real(kind=c_double), dimension(*), intent(in)      :: scalingMatrix
         end subroutine
 
-        subroutine read_mesh_puml_c(meshfile, checkPointFile, hasFault, displacement, scalingMatrix, easiVelocityModel, clusterRate) bind(C, name="read_mesh_puml_c")
+        subroutine read_mesh_puml_c(meshfile, checkPointFile, hasFault, displacement, scalingMatrix, easiVelocityModel, clusterRate, usePlasticity) bind(C, name="read_mesh_puml_c")
             use, intrinsic :: iso_c_binding
 
             character( kind=c_char ), dimension(*), intent(in) :: meshfile, easiVelocityModel, checkPointFile
@@ -88,6 +88,7 @@ module MeshReaderCBinding
             real(kind=c_double), dimension(*), intent(in)      :: displacement
             real(kind=c_double), dimension(*), intent(in)      :: scalingMatrix
             integer(kind=c_int), value, intent(in)                :: clusterRate
+            logical(kind=c_bool), value :: usePlasticity
         end subroutine
     end interface
 
@@ -137,7 +138,8 @@ contains
                                     MESH%Displacement(:),                       &
                                     m_mesh%ScalingMatrix(:,:),                  &
                                     trim(EQN%MaterialFileName) // c_null_char,  &
-                                    disc%galerkin%clusteredLts                  )
+                                    disc%galerkin%clusteredLts, &
+                                    logical(EQN%Plasticity == 1, 1))
         else
             logError(*) 'Unknown mesh reader'
             call exit(134)

--- a/src/Geometry/MeshReaderFBinding.cpp
+++ b/src/Geometry/MeshReaderFBinding.cpp
@@ -284,7 +284,14 @@ void read_mesh_netcdf_c(int rank, int nProcs, const char* meshfile, bool hasFaul
 }
 
 
-void read_mesh_puml_c(const char* meshfile, const char* checkPointFile, bool hasFault, double const displacement[3], double const scalingMatrix[3][3], char const* easiVelocityModel, int clusterRate)
+void read_mesh_puml_c(const char* meshfile,
+                      const char* checkPointFile,
+                      bool hasFault,
+                      double const displacement[3],
+                      double const scalingMatrix[3][3],
+                      char const* easiVelocityModel,
+                      int clusterRate,
+                      bool usePlasticity)
 {
 	SCOREP_USER_REGION("read_mesh", SCOREP_USER_REGION_TYPE_FUNCTION);
 
@@ -295,7 +302,8 @@ void read_mesh_puml_c(const char* meshfile, const char* checkPointFile, bool has
 	if constexpr (!seissol::isDeviceOn()) {
     if (seissol::MPI::mpi.size() > 1) {
       logInfo(rank) << "Running mini SeisSol to determine node weight";
-      tpwgt = 1.0 / seissol::miniSeisSol(seissol::SeisSol::main.getMemoryManager());
+      tpwgt = 1.0 / seissol::miniSeisSol(seissol::SeisSol::main.getMemoryManager(),
+                                         usePlasticity);
 
       const auto summary = seissol::statistics::parallelSummary(tpwgt);
       logInfo(rank) << "Node weights: mean =" << summary.mean

--- a/src/Initializer/LTS.h
+++ b/src/Initializer/LTS.h
@@ -111,12 +111,14 @@ struct seissol::initializers::LTS {
 #endif
   
   /// \todo Memkind
-  void addTo(LTSTree& tree) {
-#ifdef USE_PLASTICITY
-    LayerMask plasticityMask = LayerMask(Ghost);
-#else
-    LayerMask plasticityMask = LayerMask(Ghost) | LayerMask(Copy) | LayerMask(Interior);
-#endif
+  void addTo(LTSTree& tree, bool usePlasticity) {
+    LayerMask plasticityMask;
+    if (usePlasticity) {
+      plasticityMask = LayerMask(Ghost);
+    } else {
+      plasticityMask = LayerMask(Ghost) | LayerMask(Copy) | LayerMask(Interior);
+    }
+
     tree.addVar(                    dofs, LayerMask(Ghost),     PAGESIZE_HEAP,      MEMKIND_DOFS );
     if (kernels::size<tensor::Qane>() > 0) {
       tree.addVar(                 dofsAne, LayerMask(Ghost),     PAGESIZE_HEAP,      MEMKIND_DOFS );

--- a/src/Initializer/MemoryManager.cpp
+++ b/src/Initializer/MemoryManager.cpp
@@ -423,12 +423,13 @@ void seissol::initializers::MemoryManager::touchBuffersDerivatives( Layer& layer
 void seissol::initializers::MemoryManager::fixateLtsTree(struct TimeStepping& i_timeStepping,
                                                          struct MeshStructure*i_meshStructure,
                                                          unsigned* numberOfDRCopyFaces,
-                                                         unsigned* numberOfDRInteriorFaces) {
+                                                         unsigned* numberOfDRInteriorFaces,
+                                                         bool usePlasticity) {
   // store mesh structure and the number of time clusters
   m_meshStructure = i_meshStructure;
 
   // Setup tree variables
-  m_lts.addTo(m_ltsTree);
+  m_lts.addTo(m_ltsTree, usePlasticity);
   seissol::SeisSol::main.postProcessor().allocateMemory(&m_ltsTree);
   m_ltsTree.setNumberOfTimeClusters(i_timeStepping.numberOfLocalClusters);
 
@@ -759,9 +760,7 @@ void seissol::initializers::MemoryManager::recordExecutionPaths() {
   recorder.addRecorder(new recording::LocalIntegrationRecorder);
   recorder.addRecorder(new recording::NeighIntegrationRecorder);
 
-#ifdef USE_PLASTICITY
   recorder.addRecorder(new recording::PlasticityRecorder);
-#endif
 
   for (LTSTree::leaf_iterator it = m_ltsTree.beginLeaf(Ghost); it != m_ltsTree.endLeaf(); ++it) {
     recorder.record(m_lts, *it);

--- a/src/Initializer/MemoryManager.cpp
+++ b/src/Initializer/MemoryManager.cpp
@@ -755,12 +755,14 @@ void seissol::initializers::MemoryManager::initializeEasiBoundaryReader(const ch
 
 
 #ifdef ACL_DEVICE
-void seissol::initializers::MemoryManager::recordExecutionPaths() {
+void seissol::initializers::MemoryManager::recordExecutionPaths(bool usePlasticity) {
   recording::CompositeRecorder<seissol::initializers::LTS> recorder;
   recorder.addRecorder(new recording::LocalIntegrationRecorder);
   recorder.addRecorder(new recording::NeighIntegrationRecorder);
 
-  recorder.addRecorder(new recording::PlasticityRecorder);
+  if (usePlasticity) {
+    recorder.addRecorder(new recording::PlasticityRecorder);
+  }
 
   for (LTSTree::leaf_iterator it = m_ltsTree.beginLeaf(Ghost); it != m_ltsTree.endLeaf(); ++it) {
     recorder.record(m_lts, *it);

--- a/src/Initializer/MemoryManager.h
+++ b/src/Initializer/MemoryManager.h
@@ -321,7 +321,7 @@ class seissol::initializers::MemoryManager {
     }
 
 #ifdef ACL_DEVICE
-  void recordExecutionPaths();
+  void recordExecutionPaths(bool usePlasticity);
 #endif
 };
 

--- a/src/Initializer/MemoryManager.h
+++ b/src/Initializer/MemoryManager.h
@@ -240,7 +240,8 @@ class seissol::initializers::MemoryManager {
     void fixateLtsTree(struct TimeStepping& i_timeStepping,
                        struct MeshStructure*i_meshStructure,
                        unsigned* numberOfDRCopyFaces,
-                       unsigned* numberOfDRInteriorFaces);
+                       unsigned* numberOfDRInteriorFaces,
+                       bool usePlasticity);
 
     void fixateBoundaryLtsTree();
     /**

--- a/src/Initializer/dg_setup.f90
+++ b/src/Initializer/dg_setup.f90
@@ -491,9 +491,9 @@ CONTAINS
   call c_interoperability_initializeEasiBoundaries(trim(EQN%BoundaryFileName) // c_null_char)
 
   logInfo0(*) 'Initializing element local matrices.'
-  call c_interoperability_initializeCellLocalMatrices;
+  call c_interoperability_initializeCellLocalMatrices(logical(EQN%Plasticity == 1, 1))
 
-    IF(DISC%Galerkin%DGMethod.EQ.3) THEN
+  IF(DISC%Galerkin%DGMethod.EQ.3) THEN
         ALLOCATE( DISC%LocalIteration(MESH%nElem) )
         ALLOCATE( DISC%LocalTime(MESH%nElem)      )
         ALLOCATE( DISC%LocalDt(MESH%nElem)        )

--- a/src/Reader/readpar.f90
+++ b/src/Reader/readpar.f90
@@ -288,32 +288,19 @@ CONTAINS
 
     !
 
-#if defined(USE_PLASTICITY)
-    if (Plasticity .eq. 0) then
-      logError(*) 'Plasticity is disabled, but this version was compiled with Plasticity.'
-      call exit(134)
-    endif
-#endif
-
     SELECT CASE(Plasticity)
     CASE(0)
       logInfo0(*) 'No plasticity assumed. '
       EQN%Plasticity = Plasticity                                                     !
     CASE(1)
-#if !defined(USE_PLASTICITY)
-       logError(*) 'Plasticity is assumed, but this version was not compiled with Plasticity.'
-       call exit(134)
-#else
        logInfo0(*) '(Drucker-Prager) plasticity assumed .'
 
 #if defined(USE_PLASTIC_IP)
        logInfo0(*) 'Integration Points approach used for plasticity.'
 #elif defined(USE_PLASTIC_NB)
        logInfo0(*) 'Nodal Basis approach used for plasticity.'
-
 #endif
 
-#endif
         EQN%Plasticity = Plasticity
         !first constant, can be overwritten in ini_model
         EQN%Tv = Tv

--- a/src/Solver/Interoperability.cpp
+++ b/src/Solver/Interoperability.cpp
@@ -73,12 +73,12 @@ extern "C" {
                                          i_timeStepWidth );
   }
 
-  void c_interoperability_initializeClusteredLts( int i_clustering, bool enableFreeSurfaceIntegration ) {
-    e_interoperability.initializeClusteredLts( i_clustering, enableFreeSurfaceIntegration );
+  void c_interoperability_initializeClusteredLts( int i_clustering, bool enableFreeSurfaceIntegration, bool usePlasticity ) {
+    e_interoperability.initializeClusteredLts( i_clustering, enableFreeSurfaceIntegration, usePlasticity );
   }
 
-  void c_interoperability_initializeMemoryLayout(int clustering, bool enableFreeSurfaceIntegration) {
-    e_interoperability.initializeMemoryLayout(clustering, enableFreeSurfaceIntegration);
+  void c_interoperability_initializeMemoryLayout(int clustering, bool enableFreeSurfaceIntegration, bool usePlasticity) {
+    e_interoperability.initializeMemoryLayout(clustering, enableFreeSurfaceIntegration, usePlasticity);
   }
 
   void c_interoperability_initializeEasiBoundaries(char* fileName) {
@@ -180,7 +180,6 @@ extern "C" {
     e_interoperability.setMaterial(i_meshId, i_side, i_materialVal, i_numMaterialVals);
   }
       
-#ifdef USE_PLASTICITY
  void c_interoperability_setInitialLoading( int    i_meshId,
                                             double *i_initialLoading ) {
     e_interoperability.setInitialLoading( i_meshId, i_initialLoading );
@@ -194,14 +193,13 @@ extern "C" {
   void c_interoperability_setTv(double tv) {
     e_interoperability.setTv(tv);
   }
-#endif
 
   void c_interoperability_initializeCellLocalMatrices() {
     e_interoperability.initializeCellLocalMatrices();
   }
 
-  void c_interoperability_synchronizeCellLocalData() {
-    e_interoperability.synchronizeCellLocalData();
+  void c_interoperability_synchronizeCellLocalData(bool usePlasticity) {
+    e_interoperability.synchronizeCellLocalData(usePlasticity);
   }
 
   void c_interoperability_synchronizeCopyLayerDofs() {
@@ -387,16 +385,18 @@ void seissol::Interoperability::setTimeStepWidth( int    i_meshId,
   seissol::SeisSol::main.getLtsLayout().setTimeStepWidth( (i_meshId)-1, i_timeStepWidth );
 }
 
-void seissol::Interoperability::initializeClusteredLts( int i_clustering, bool enableFreeSurfaceIntegration ) {
+void seissol::Interoperability::initializeClusteredLts(int clustering,
+                                                       bool enableFreeSurfaceIntegration,
+                                                       bool usePlasticity) {
   // assert a valid clustering
-  assert( i_clustering > 0 );
+  assert(clustering > 0 );
 
   // either derive a GTS or LTS layout
-  if( i_clustering == 1 ) {
+  if(clustering == 1 ) {
     seissol::SeisSol::main.getLtsLayout().deriveLayout( single, 1);
   }
   else {
-    seissol::SeisSol::main.getLtsLayout().deriveLayout( multiRate, i_clustering );
+    seissol::SeisSol::main.getLtsLayout().deriveLayout(multiRate, clustering );
   }
 
   // get the mesh structure
@@ -416,7 +416,8 @@ void seissol::Interoperability::initializeClusteredLts( int i_clustering, bool e
   seissol::SeisSol::main.getMemoryManager().fixateLtsTree(m_timeStepping,
                                                           m_meshStructure,
                                                           numberOfDRCopyFaces,
-                                                          numberOfDRInteriorFaces);
+                                                          numberOfDRInteriorFaces,
+                                                          usePlasticity);
 
   delete[] numberOfDRCopyFaces;
   delete[] numberOfDRInteriorFaces;
@@ -445,14 +446,15 @@ void seissol::Interoperability::initializeClusteredLts( int i_clustering, bool e
 
 }
 
-void seissol::Interoperability::initializeMemoryLayout(int clustering, bool enableFreeSurfaceIntegration) {
+void seissol::Interoperability::initializeMemoryLayout(int clustering, bool enableFreeSurfaceIntegration, bool usePlasticity) {
   // initialize memory layout
   seissol::SeisSol::main.getMemoryManager().initializeMemoryLayout(enableFreeSurfaceIntegration);
 
   // add clusters
-  seissol::SeisSol::main.timeManager().addClusters( m_timeStepping,
-                                                    m_meshStructure,
-                                                    seissol::SeisSol::main.getMemoryManager() );
+  seissol::SeisSol::main.timeManager().addClusters(m_timeStepping,
+                                                   m_meshStructure,
+                                                   seissol::SeisSol::main.getMemoryManager(),
+                                                   usePlasticity);
 
   // get backward coupling
   m_globalData = seissol::SeisSol::main.getMemoryManager().getGlobalDataOnHost();
@@ -681,7 +683,6 @@ void seissol::Interoperability::setMaterial(int i_meshId, int i_side, double* i_
 #endif
 }
 
-#ifdef USE_PLASTICITY
 void seissol::Interoperability::setInitialLoading( int i_meshId, double *i_initialLoading ) {
   PlasticityData& plasticity = m_ltsLut.lookup(m_lts->plasticity, i_meshId - 1);
 
@@ -710,7 +711,6 @@ void seissol::Interoperability::setPlasticParameters( int i_meshId, double* i_pl
 void seissol::Interoperability::setTv(double tv) {
   seissol::SeisSol::main.timeManager().setTv(tv);
 }
-#endif
 
 void seissol::Interoperability::initializeCellLocalMatrices()
 {
@@ -769,11 +769,11 @@ void seissol::Interoperability::synchronize(seissol::initializers::Variable<T> c
   }
 }
 
-void seissol::Interoperability::synchronizeCellLocalData() {
+void seissol::Interoperability::synchronizeCellLocalData(bool usePlasticity) {
   synchronize(m_lts->material);
-#ifdef USE_PLASTICITY
-  synchronize(m_lts->plasticity);
-#endif
+  if (usePlasticity) {
+    synchronize(m_lts->plasticity);
+  }
 }
 
 void seissol::Interoperability::synchronizeCopyLayerDofs() {

--- a/src/Solver/Interoperability.cpp
+++ b/src/Solver/Interoperability.cpp
@@ -194,8 +194,8 @@ extern "C" {
     e_interoperability.setTv(tv);
   }
 
-  void c_interoperability_initializeCellLocalMatrices() {
-    e_interoperability.initializeCellLocalMatrices();
+  void c_interoperability_initializeCellLocalMatrices(bool usePlasticity) {
+    e_interoperability.initializeCellLocalMatrices(usePlasticity);
   }
 
   void c_interoperability_synchronizeCellLocalData(bool usePlasticity) {
@@ -712,7 +712,7 @@ void seissol::Interoperability::setTv(double tv) {
   seissol::SeisSol::main.timeManager().setTv(tv);
 }
 
-void seissol::Interoperability::initializeCellLocalMatrices()
+void seissol::Interoperability::initializeCellLocalMatrices(bool usePlasticity)
 {
   // \todo Move this to some common initialization place
   MeshReader& meshReader = seissol::SeisSol::main.meshReader();
@@ -746,7 +746,7 @@ void seissol::Interoperability::initializeCellLocalMatrices()
                                          memoryManager.getBoundaryTree(),
                                          memoryManager.getBoundary());
 
-  memoryManager.recordExecutionPaths();
+  memoryManager.recordExecutionPaths(usePlasticity);
 #endif
 }
 

--- a/src/Solver/Interoperability.h
+++ b/src/Solver/Interoperability.h
@@ -251,7 +251,7 @@ class seissol::Interoperability {
    /**
     * \todo Move this somewhere else when we have a C++ main loop.
     **/
-   void initializeCellLocalMatrices();
+   void initializeCellLocalMatrices(bool usePlasticity);
 
    template<typename T>
    void synchronize(seissol::initializers::Variable<T> const& handle);

--- a/src/Solver/Interoperability.h
+++ b/src/Solver/Interoperability.h
@@ -149,8 +149,8 @@ class seissol::Interoperability {
     * @param i_clustering clustering strategy
     * @param enableFreeSurfaceIntegration
     **/
-   void initializeClusteredLts( int i_clustering, bool enableFreeSurfaceIntegration );
-   void initializeMemoryLayout(int clustering, bool enableFreeSurfaceIntegration);
+   void initializeClusteredLts(int clustering, bool enableFreeSurfaceIntegration, bool usePlasticity);
+   void initializeMemoryLayout(int clustering, bool enableFreeSurfaceIntegration, bool usePlasticity);
 
 #if defined(USE_NETCDF) && !defined(NETCDF_PASSIVE)
    //! \todo Documentation
@@ -234,10 +234,8 @@ class seissol::Interoperability {
     * @param i_meshId mesh id.
     * @param i_initialLoading initial loading (stress tensor).
     **/
-#ifdef USE_PLASTICITY
    void setInitialLoading( int    i_meshId,
                            double *i_initialLoading );
-#endif
 
    /**
     * Sets the parameters for a cell (plasticity).
@@ -245,12 +243,10 @@ class seissol::Interoperability {
     * @param i_meshId mesh id.
     * @param i_plasticParameters cell dependent plastic Parameters (volume, cohesion...).
     **/
-#ifdef USE_PLASTICITY
    void setPlasticParameters( int    i_meshId,
                               double *i_plasticParameters );
 
    void setTv(double tv);
-#endif
 
    /**
     * \todo Move this somewhere else when we have a C++ main loop.
@@ -263,7 +259,7 @@ class seissol::Interoperability {
    /**
     * Synchronizes the cell local material data.
     **/
-   void synchronizeCellLocalData();
+   void synchronizeCellLocalData(bool usePlasticity);
 
    /**
     * Synchronizes the DOFs in the copy layer.

--- a/src/Solver/f_ftoc_bind_interoperability.f90
+++ b/src/Solver/f_ftoc_bind_interoperability.f90
@@ -227,8 +227,11 @@ module f_ftoc_bind_interoperability
   end interface
 
 
-  interface c_interoperability_initializeCellLocalMatrices
-    subroutine c_interoperability_initializeCellLocalMatrices() bind( C, name='c_interoperability_initializeCellLocalMatrices' )
+  interface
+    subroutine c_interoperability_initializeCellLocalMatrices(usePlasticity) bind( C, name='c_interoperability_initializeCellLocalMatrices' )
+      use iso_c_binding
+      implicit none
+      logical(kind=c_bool), value :: usePlasticity
     end subroutine
   end interface
 

--- a/src/Solver/f_ftoc_bind_interoperability.f90
+++ b/src/Solver/f_ftoc_bind_interoperability.f90
@@ -72,21 +72,23 @@ module f_ftoc_bind_interoperability
     end subroutine
   end interface
 
-  interface c_interoperability_initializeClusteredLts
-    subroutine c_interoperability_initializeClusteredLts( i_clustering, i_enableFreeSurfaceIntegration ) bind( C, name='c_interoperability_initializeClusteredLts' )
+  interface
+    subroutine c_interoperability_initializeClusteredLts( i_clustering, i_enableFreeSurfaceIntegration, usePlasticity ) bind( C, name='c_interoperability_initializeClusteredLts' )
       use iso_c_binding
       implicit none
       integer(kind=c_int), value  :: i_clustering
       logical(kind=c_bool), value :: i_enableFreeSurfaceIntegration
+      logical(kind=c_bool), value :: usePlasticity
     end subroutine
   end interface
 
-  interface c_interoperability_initializeMemoryLayout
-    subroutine c_interoperability_initializeMemoryLayout(clustering, enableFreeSurfaceIntegration ) bind( C, name='c_interoperability_initializeMemoryLayout' )
+  interface
+    subroutine c_interoperability_initializeMemoryLayout(clustering, enableFreeSurfaceIntegration, usePlasticity) bind( C, name='c_interoperability_initializeMemoryLayout' )
       use iso_c_binding
       implicit none
       integer(kind=c_int), value  :: clustering
       logical(kind=c_bool), value :: enableFreeSurfaceIntegration
+      logical(kind=c_bool), value :: usePlasticity
     end subroutine
   end interface
 
@@ -230,8 +232,11 @@ module f_ftoc_bind_interoperability
     end subroutine
   end interface
 
-  interface c_interoperability_synchronizeCellLocalData
-    subroutine c_interoperability_synchronizeCellLocalData() bind( C, name='c_interoperability_synchronizeCellLocalData' )
+  interface
+    subroutine c_interoperability_synchronizeCellLocalData( usePlasticity ) bind( C, name='c_interoperability_synchronizeCellLocalData' )
+      use iso_c_binding
+      implicit none
+      logical(kind=c_bool), value :: usePlasticity
     end subroutine
   end interface
 

--- a/src/Solver/time_stepping/MiniSeisSol.cpp
+++ b/src/Solver/time_stepping/MiniSeisSol.cpp
@@ -140,13 +140,13 @@ void seissol::fakeData(initializers::LTS& lts,
   fillWithStuff(reinterpret_cast<real*>(neighboringIntegration), sizeof(NeighboringIntegrationData)/sizeof(real) * layer.getNumberOfCells());
 }
 
-double seissol::miniSeisSol(initializers::MemoryManager& memoryManager) {
+double seissol::miniSeisSol(initializers::MemoryManager& memoryManager, bool usePlasticity) {
   struct GlobalData* globalData = memoryManager.getGlobalDataOnHost();
 
   initializers::LTSTree ltsTree;
   initializers::LTS     lts;
-  
-  lts.addTo(ltsTree);
+
+  lts.addTo(ltsTree, usePlasticity);
   ltsTree.setNumberOfTimeClusters(1);
   ltsTree.fixate();
   

--- a/src/Solver/time_stepping/MiniSeisSol.h
+++ b/src/Solver/time_stepping/MiniSeisSol.h
@@ -55,7 +55,7 @@ namespace seissol {
                   initializers::Layer& layer,
                   FaceType faceTp = FaceType::regular);
   
-  double miniSeisSol(initializers::MemoryManager& memoryManager);
+  double miniSeisSol(initializers::MemoryManager& memoryManager, bool usePlasticity);
 }
 
 

--- a/src/Solver/time_stepping/TimeCluster.cpp
+++ b/src/Solver/time_stepping/TimeCluster.cpp
@@ -697,93 +697,11 @@ void seissol::time_stepping::TimeCluster::computeLocalIntegration( seissol::init
 
 #ifndef ACL_DEVICE
 void seissol::time_stepping::TimeCluster::computeNeighboringIntegration( seissol::initializers::Layer&  i_layerData ) {
-  SCOREP_USER_REGION( "computeNeighboringIntegration", SCOREP_USER_REGION_TYPE_FUNCTION )
-
-  m_loopStatistics->begin(m_regionComputeNeighboringIntegration);
-
-  real* (*faceNeighbors)[4] = i_layerData.var(m_lts->faceNeighbors);
-  CellDRMapping (*drMapping)[4] = i_layerData.var(m_lts->drMapping);
-  CellLocalInformation* cellInformation = i_layerData.var(m_lts->cellInformation);
-  PlasticityData* plasticity = i_layerData.var(m_lts->plasticity);
-  real (*pstrain)[7] = i_layerData.var(m_lts->pstrain);
-  unsigned numberOTetsWithPlasticYielding = 0;
-
-  kernels::NeighborData::Loader loader;
-  loader.load(*m_lts, i_layerData);
-
-  real *l_timeIntegrated[4];
-  real *l_faceNeighbors_prefetch[4];
-
-#ifdef _OPENMP
-  #pragma omp parallel for schedule(static) private(l_timeIntegrated, l_faceNeighbors_prefetch) reduction(+:numberOTetsWithPlasticYielding)
-#endif
-  for( unsigned int l_cell = 0; l_cell < i_layerData.getNumberOfCells(); l_cell++ ) {
-    auto data = loader.entry(l_cell);
-    seissol::kernels::TimeCommon::computeIntegrals(m_timeKernel,
-                                                   data.cellInformation.ltsSetup,
-                                                   data.cellInformation.faceTypes,
-                                                   m_subTimeStart,
-                                                   m_timeStepWidth,
-                                                   faceNeighbors[l_cell],
-#ifdef _OPENMP
-                                                   *reinterpret_cast<real (*)[4][tensor::I::size()]>(&(m_globalDataOnHost->integrationBufferLTS[omp_get_thread_num()*4*tensor::I::size()])),
-#else
-                                                   *reinterpret_cast<real (*)[4][tensor::I::size()]>(m_globalData->integrationBufferLTS),
-#endif
-                                                   l_timeIntegrated);
-
-#ifdef ENABLE_MATRIX_PREFETCH
-#pragma message("the current prefetch structure (flux matrices and tDOFs is tuned for higher order and shouldn't be harmful for lower orders")
-    l_faceNeighbors_prefetch[0] = (cellInformation[l_cell].faceTypes[1] != FaceType::dynamicRupture) ?
-      faceNeighbors[l_cell][1] :
-      drMapping[l_cell][1].godunov;
-    l_faceNeighbors_prefetch[1] = (cellInformation[l_cell].faceTypes[2] != FaceType::dynamicRupture) ?
-      faceNeighbors[l_cell][2] :
-      drMapping[l_cell][2].godunov;
-    l_faceNeighbors_prefetch[2] = (cellInformation[l_cell].faceTypes[3] != FaceType::dynamicRupture) ?
-      faceNeighbors[l_cell][3] :
-      drMapping[l_cell][3].godunov;
-
-    // fourth face's prefetches
-    if (l_cell < (i_layerData.getNumberOfCells()-1) ) {
-      l_faceNeighbors_prefetch[3] = (cellInformation[l_cell+1].faceTypes[0] != FaceType::dynamicRupture) ?
-	faceNeighbors[l_cell+1][0] :
-	drMapping[l_cell+1][0].godunov;
-    } else {
-      l_faceNeighbors_prefetch[3] = faceNeighbors[l_cell][3];
-    }
-#endif
-
-    m_neighborKernel.computeNeighborsIntegral( data,
-                                               drMapping[l_cell],
-#ifdef ENABLE_MATRIX_PREFETCH
-                                               l_timeIntegrated, l_faceNeighbors_prefetch
-#else
-                                               l_timeIntegrated
-#endif
-                                               );
-
-    if (usePlasticity) {
-      numberOTetsWithPlasticYielding += seissol::kernels::Plasticity::computePlasticity( m_oneMinusIntegratingFactor,
-                                                                                         m_timeStepWidth,
-                                                                                         m_tv,
-                                                                                         m_globalDataOnHost,
-                                                                                         &plasticity[l_cell],
-                                                                                         data.dofs,
-                                                                                         pstrain[l_cell] );
-    }
-#ifdef INTEGRATE_QUANTITIES
-  seissol::SeisSol::main.postProcessor().integrateQuantities( m_timeStepWidth,
-                                                              i_layerData,
-                                                              l_cell,
-                                                              dofs[l_cell] );
-#endif // INTEGRATE_QUANTITIES
+  if (usePlasticity) {
+    computeNeighboringIntegrationImplementation<true>(i_layerData);
+  } else {
+    computeNeighboringIntegrationImplementation<false>(i_layerData);
   }
-
-  g_SeisSolNonZeroFlopsPlasticity += i_layerData.getNumberOfCells() * m_flops_nonZero[PlasticityCheck] + numberOTetsWithPlasticYielding * m_flops_nonZero[PlasticityYield];
-  g_SeisSolHardwareFlopsPlasticity += i_layerData.getNumberOfCells() * m_flops_hardware[PlasticityCheck] + numberOTetsWithPlasticYielding * m_flops_hardware[PlasticityYield];
-
-  m_loopStatistics->end(m_regionComputeNeighboringIntegration, i_layerData.getNumberOfCells());
 }
 #else // ACL_DEVICE
 void seissol::time_stepping::TimeCluster::computeNeighboringIntegration( seissol::initializers::Layer&  i_layerData ) {

--- a/src/Solver/time_stepping/TimeCluster.h
+++ b/src/Solver/time_stepping/TimeCluster.h
@@ -117,6 +117,8 @@ public:
     const unsigned int m_globalClusterId;
 
 private:
+    bool usePlasticity;
+
     //! number of time steps
     unsigned long m_numberOfTimeSteps;
 
@@ -380,6 +382,7 @@ private:
      *
      * @param i_clusterId id of this cluster with respect to the current rank.
      * @param i_globalClusterId global id of this cluster.
+     * @param usePlasticity true if using plasticity
      * @param i_timeKernel time integration kernel.
      * @param i_volumeKernel volume integration kernel.
      * @param i_boundaryKernel boundary integration kernel.
@@ -391,15 +394,16 @@ private:
      * @param i_interiorCellData cell data in the interior.
      * @param i_cells degrees of freedom, time buffers, time derivatives.
      **/
-    TimeCluster( unsigned int                   i_clusterId,
-                 unsigned int                   i_globalClusterId,
-                 MeshStructure                  *i_meshStructure,
-                 CompoundGlobalData             i_globalData,
-                 seissol::initializers::TimeCluster* i_clusterData,
-                 seissol::initializers::TimeCluster* i_dynRupClusterData,
-                 seissol::initializers::LTS*         i_lts,
-                 seissol::initializers::DynamicRupture* i_dynRup,
-                 LoopStatistics*                        i_loopStatistics );
+    TimeCluster(unsigned int i_clusterId,
+                unsigned int i_globalClusterId,
+                bool usePlasticity,
+                MeshStructure *i_meshStructure,
+                CompoundGlobalData i_globalData,
+                seissol::initializers::TimeCluster* i_clusterData,
+                seissol::initializers::TimeCluster* i_dynRupClusterData,
+                seissol::initializers::LTS* i_lts,
+                seissol::initializers::DynamicRupture* i_dynRup,
+                LoopStatistics* i_loopStatistics);
 
     /**
      * Destructor of a LTS cluster.

--- a/src/Solver/time_stepping/TimeCluster.h
+++ b/src/Solver/time_stepping/TimeCluster.h
@@ -89,6 +89,8 @@
 #include <Kernels/Plasticity.h>
 #include <Solver/FreeSurfaceIntegrator.h>
 #include <Monitoring/LoopStatistics.h>
+#include <Kernels/TimeCommon.h>
+
 #ifdef ACL_DEVICE
 #include <device.h>
 #include <Solver/Pipeline/DrPipeline.h>
@@ -303,6 +305,101 @@ private:
      **/
     void computeNeighboringIntegration( seissol::initializers::Layer&  i_layerData );
 
+#ifndef ACL_DEVICE
+    template<bool usePlasticity>
+    std::pair<long, long> computeNeighboringIntegrationImplementation(seissol::initializers::Layer& i_layerData) {
+      SCOREP_USER_REGION( "computeNeighboringIntegration", SCOREP_USER_REGION_TYPE_FUNCTION )
+
+      m_loopStatistics->begin(m_regionComputeNeighboringIntegration);
+
+      real* (*faceNeighbors)[4] = i_layerData.var(m_lts->faceNeighbors);
+      CellDRMapping (*drMapping)[4] = i_layerData.var(m_lts->drMapping);
+      CellLocalInformation* cellInformation = i_layerData.var(m_lts->cellInformation);
+      PlasticityData* plasticity = i_layerData.var(m_lts->plasticity);
+      real (*pstrain)[7] = i_layerData.var(m_lts->pstrain);
+      unsigned numberOTetsWithPlasticYielding = 0;
+
+      kernels::NeighborData::Loader loader;
+      loader.load(*m_lts, i_layerData);
+
+      real *l_timeIntegrated[4];
+      real *l_faceNeighbors_prefetch[4];
+
+#ifdef _OPENMP
+#pragma omp parallel for schedule(static) default(none) private(l_timeIntegrated, l_faceNeighbors_prefetch) shared(cellInformation, loader, faceNeighbors, pstrain, i_layerData, plasticity, drMapping) reduction(+:numberOTetsWithPlasticYielding)
+#endif
+      for( unsigned int l_cell = 0; l_cell < i_layerData.getNumberOfCells(); l_cell++ ) {
+        auto data = loader.entry(l_cell);
+        seissol::kernels::TimeCommon::computeIntegrals(m_timeKernel,
+                                                       data.cellInformation.ltsSetup,
+                                                       data.cellInformation.faceTypes,
+                                                       m_subTimeStart,
+                                                       m_timeStepWidth,
+                                                       faceNeighbors[l_cell],
+#ifdef _OPENMP
+                                                       *reinterpret_cast<real (*)[4][tensor::I::size()]>(&(m_globalDataOnHost->integrationBufferLTS[omp_get_thread_num()*4*tensor::I::size()])),
+#else
+            *reinterpret_cast<real (*)[4][tensor::I::size()]>(m_globalData->integrationBufferLTS),
+#endif
+                                                       l_timeIntegrated);
+
+#ifdef ENABLE_MATRIX_PREFETCH
+#pragma message("the current prefetch structure (flux matrices and tDOFs is tuned for higher order and shouldn't be harmful for lower orders")
+        l_faceNeighbors_prefetch[0] = (cellInformation[l_cell].faceTypes[1] != FaceType::dynamicRupture) ?
+                                      faceNeighbors[l_cell][1] :
+                                      drMapping[l_cell][1].godunov;
+        l_faceNeighbors_prefetch[1] = (cellInformation[l_cell].faceTypes[2] != FaceType::dynamicRupture) ?
+                                      faceNeighbors[l_cell][2] :
+                                      drMapping[l_cell][2].godunov;
+        l_faceNeighbors_prefetch[2] = (cellInformation[l_cell].faceTypes[3] != FaceType::dynamicRupture) ?
+                                      faceNeighbors[l_cell][3] :
+                                      drMapping[l_cell][3].godunov;
+
+        // fourth face's prefetches
+        if (l_cell < (i_layerData.getNumberOfCells()-1) ) {
+          l_faceNeighbors_prefetch[3] = (cellInformation[l_cell+1].faceTypes[0] != FaceType::dynamicRupture) ?
+                                        faceNeighbors[l_cell+1][0] :
+                                        drMapping[l_cell+1][0].godunov;
+        } else {
+          l_faceNeighbors_prefetch[3] = faceNeighbors[l_cell][3];
+        }
+#endif
+
+        m_neighborKernel.computeNeighborsIntegral( data,
+                                                   drMapping[l_cell],
+#ifdef ENABLE_MATRIX_PREFETCH
+                                                   l_timeIntegrated, l_faceNeighbors_prefetch
+#else
+            l_timeIntegrated
+#endif
+        );
+
+        if constexpr (usePlasticity) {
+          numberOTetsWithPlasticYielding += seissol::kernels::Plasticity::computePlasticity( m_oneMinusIntegratingFactor,
+                                                                                             m_timeStepWidth,
+                                                                                             m_tv,
+                                                                                             m_globalDataOnHost,
+                                                                                             &plasticity[l_cell],
+                                                                                             data.dofs,
+                                                                                             pstrain[l_cell] );
+        }
+#ifdef INTEGRATE_QUANTITIES
+        seissol::SeisSol::main.postProcessor().integrateQuantities( m_timeStepWidth,
+                                                              i_layerData,
+                                                              l_cell,
+                                                              dofs[l_cell] );
+#endif // INTEGRATE_QUANTITIES
+      }
+
+      const long long nonZeroFlopsPlasticity = i_layerData.getNumberOfCells() * m_flops_nonZero[PlasticityCheck] + numberOTetsWithPlasticYielding * m_flops_nonZero[PlasticityYield];
+      const long long hardwareFlopsPlasticity = i_layerData.getNumberOfCells() * m_flops_hardware[PlasticityCheck] + numberOTetsWithPlasticYielding * m_flops_hardware[PlasticityYield];
+
+      m_loopStatistics->end(m_regionComputeNeighboringIntegration, i_layerData.getNumberOfCells());
+
+      return {nonZeroFlopsPlasticity, hardwareFlopsPlasticity};
+    }
+#endif // ACL_DEVICE
+
     void computeLocalIntegrationFlops(  unsigned                    numberOfCells,
                                         CellLocalInformation const* cellInformation,
                                         long long&                  nonZeroFlops,
@@ -490,6 +587,7 @@ private:
      * Computes the neighboring contribution to the boundary integral for all cells in the interior.
      **/
     void computeNeighboringInterior();
+
 
 #if defined(_OPENMP) && defined(USE_MPI) && defined(USE_COMM_THREAD)
     /**

--- a/src/Solver/time_stepping/TimeManager.cpp
+++ b/src/Solver/time_stepping/TimeManager.cpp
@@ -69,9 +69,10 @@ seissol::time_stepping::TimeManager::~TimeManager() {
   }
 }
 
-void seissol::time_stepping::TimeManager::addClusters( struct TimeStepping&               i_timeStepping,
-                                                       struct MeshStructure*              i_meshStructure,
-                                                       initializers::MemoryManager&       i_memoryManager ) {
+void seissol::time_stepping::TimeManager::addClusters(TimeStepping& i_timeStepping,
+                                                      MeshStructure* i_meshStructure,
+                                                      initializers::MemoryManager& i_memoryManager,
+                                                      bool usePlasticity) {
   SCOREP_USER_REGION( "addClusters", SCOREP_USER_REGION_TYPE_FUNCTION );
 
   // assert non-zero pointers
@@ -91,6 +92,7 @@ void seissol::time_stepping::TimeManager::addClusters( struct TimeStepping&     
     // add this time cluster
     m_clusters.push_back( new TimeCluster( l_cluster,
                                            m_timeStepping.clusterIds[l_cluster],
+                                           usePlasticity,
                                            l_meshStructure,
                                            l_globalData,
                                            &i_memoryManager.getLtsTree()->child(l_cluster),

--- a/src/Solver/time_stepping/TimeManager.h
+++ b/src/Solver/time_stepping/TimeManager.h
@@ -141,9 +141,10 @@ class seissol::time_stepping::TimeManager {
      * @param i_memoryManager memory manager.
      * @param i_meshToClusters mapping from the mesh to the clusters.
      **/
-    void addClusters( struct TimeStepping&               i_timeStepping,
-                      struct MeshStructure*              i_meshStructure,
-                      initializers::MemoryManager&       i_memoryManager );
+    void addClusters(TimeStepping& i_timeStepping,
+                     MeshStructure* i_meshStructure,
+                     initializers::MemoryManager& i_memoryManager,
+                     bool usePlasticity);
 
     /**
      * Starts the communication thread.


### PR DESCRIPTION
Note: This PR is very much still in progress.

This PR removes the compile time option for plasticity and replaces it with a runtime option.
By using templates + constexpr if, we can create two optimized paths for the neighbor integration kernel: One with plasticity, one without.
In this way, this change comes without much (or any) performance cost.

This is very poorly tested.

@ravil-mobile Can you please have a look at the GPU version? I've just deleted the USE_PLASTICITY macros in your kernels/init. I think it should be fine to just do an i`f(usePlasticity)` in some places but I wasn't really sure. Also, I have currently no GPU, so I can't test this.