### PR TITLE
Fix crash in viewrec

### DIFF
--- a/postprocessing/visualization/receiver/src/View.py
+++ b/postprocessing/visualization/receiver/src/View.py
@@ -206,7 +206,10 @@ class View(QWidget):
           p.set_ylabel(name)
           #print L2 difference
           if nWf > 0 and not self.diff.isChecked():
-            time_union = numpy.union1d(wf.time, wf_ref.time)
+            t_min = max(wf.time.min(), wf_ref.time.min())
+            t_max = min(wf.time.max(), wf_ref.time.max())
+            truncate = lambda a: a[(a >= t_min) & (a <= t_max)]
+            time_union = numpy.union1d(truncate(wf.time), truncate(wf_ref.time))
             wf_interp = scipy.interpolate.interp1d(wf.time, waveform)
             ref_interp = scipy.interpolate.interp1d(wf_ref.time, wf_ref.waveforms[name])
             wf_union = wf_interp(time_union)


### PR DESCRIPTION
The receiver viewer crashes in the computation of the L2 error if the waveforms don't have the same length (due to forbidden extrapolation in scipy). This PR ensures that the time union is bounded w.r.t. to the waveforms' time interval.