### PR TITLE
add filters to extractDataFromUnstructuredOutput.py

### DIFF
--- a/postprocessing/visualization/tools/extractDataFromUnstructuredOutput.py
+++ b/postprocessing/visualization/tools/extractDataFromUnstructuredOutput.py
@@ -36,8 +36,6 @@ parser.add_argument(
     help="output only cells with z center coordinate in range zmin zmax",
     type=float,
 )
-parser.add_argument("--no_ocean", dest="no_ocean", default=False, action="store_true", help="remove sea-surface cells")
-
 args = parser.parse_args()
 
 sx = seissolxdmf.seissolxdmf(args.xdmfFilename)
@@ -62,9 +60,6 @@ if args.yfilter:
     ids = np.intersect1d(ids, id0) if len(ids) else id0
 if args.zfilter:
     id0 = filter_cells(xyzc[:, 2], args.zfilter)
-    ids = np.intersect1d(ids, id0) if len(ids) else id0
-if args.no_ocean:
-    id0 = np.where(np.abs(xyzc[:, 2]) > 1e-3)[0]
     ids = np.intersect1d(ids, id0) if len(ids) else id0
 
 if len(ids):

--- a/postprocessing/visualization/tools/extractDataFromUnstructuredOutput.py
+++ b/postprocessing/visualization/tools/extractDataFromUnstructuredOutput.py
@@ -2,8 +2,8 @@ import os
 import os.path
 import seissolxdmf
 import shutil
-from recreateXdmf import *
-
+import recreateXdmf
+import numpy as np
 import argparse
 
 parser = argparse.ArgumentParser(description="resample output file and write as binary files")
@@ -15,23 +15,78 @@ parser.add_argument("--precision", type=str, choices=["float", "double"], defaul
 parser.add_argument("--backend", type=str, choices=["hdf5", "raw"], default="hdf5", help="backend used: raw (.bin file), hdf5 (.h5)")
 parser.add_argument("--last", dest="last", default=False, action="store_true", help="output last time step")
 parser.add_argument("--idt", nargs="+", help="list of time step to write (ex $(seq 7 3 28))", type=int)
+parser.add_argument(
+    "--xfilter",
+    nargs=2,
+    metavar=("xmin", "xmax"),
+    help="output only cells with x center coordinate in range xmin xmax",
+    type=float,
+)
+parser.add_argument(
+    "--yfilter",
+    nargs=2,
+    metavar=("ymin", "ymax"),
+    help="output only cells with y center coordinate in range ymin ymax",
+    type=float,
+)
+parser.add_argument(
+    "--zfilter",
+    nargs=2,
+    metavar=("zmin", "zmax"),
+    help="output only cells with z center coordinate in range zmin zmax",
+    type=float,
+)
+parser.add_argument("--no_ocean", dest="no_ocean", default=False, action="store_true", help="remove sea-surface cells")
+
 args = parser.parse_args()
 
 sx = seissolxdmf.seissolxdmf(args.xdmfFilename)
+xyz = sx.ReadGeometry()
 connect = sx.ReadConnect()
-nElements = sx.nElements
+
+xyzc = (xyz[connect[:, 0], :] + xyz[connect[:, 1], :] + xyz[connect[:, 2], :]) / 3.0
+
+
+def filter_cells(coords, filter_range):
+    m = 0.5 * (filter_range[0] + filter_range[1])
+    d = 0.5 * (filter_range[1] - filter_range[0])
+    return np.where(np.abs(coords[:] - m) < d)[0]
+
+
+ids = range(0, sx.nElements)
+if args.xfilter:
+    id0 = filter_cells(xyzc[:, 0], args.xfilter)
+    ids = np.intersect1d(ids, id0) if len(ids) else id0
+if args.yfilter:
+    id0 = filter_cells(xyzc[:, 1], args.yfilter)
+    ids = np.intersect1d(ids, id0) if len(ids) else id0
+if args.zfilter:
+    id0 = filter_cells(xyzc[:, 2], args.zfilter)
+    ids = np.intersect1d(ids, id0) if len(ids) else id0
+if args.no_ocean:
+    id0 = np.where(np.abs(xyzc[:, 2]) > 1e-3)[0]
+    ids = np.intersect1d(ids, id0) if len(ids) else id0
+
+if len(ids):
+    connect = connect[ids, :]
+    nElements = connect.shape[0]
+    if nElements != sx.nElements:
+        print(f"extracting {nElements} cells out of {sx.nElements}")
+else:
+    raise ValueError("all elements are outside filter range")
+
 ndt = sx.ndt
 
 if args.last:
     indices = [ndt - 1]
-    if (args.idt != None) or (args.downsample != None):
+    if args.idt or args.downsample:
         print("last option cannot be used together with idt and downsample options")
         exit()
 else:
-    if (args.idt != None) and (args.downsample != None):
+    if args.idt and args.downsample:
         print("idt and downsample options cannot be used together")
         exit()
-    elif args.downsample == None:
+    elif not args.downsample:
         indices = args.idt
     else:
         indices = range(0, ndt, args.downsample)
@@ -57,9 +112,9 @@ else:
     write2Binary = False
 
 prefix = os.path.splitext(args.xdmfFilename)[0]
-prefix_new = generate_new_prefix(prefix, args.add2prefix)
+prefix_new = recreateXdmf.generate_new_prefix(prefix, args.add2prefix)
 
-############Create folders if necessary#############
+# Create folders if necessary
 if write2Binary:
     if not os.path.exists(prefix_new + "_cell"):
         os.mkdir(prefix_new + "_cell")
@@ -71,7 +126,7 @@ if write2Binary:
         os.mkdir(prefix_new + "_vertex/mesh0/")
 
 
-#############write geometry and connect#############
+# Write geometry and connect
 if write2Binary:
     fn2 = prefix_new + "_cell/mesh0/connect.bin"
     if isHdf5:
@@ -83,10 +138,9 @@ if write2Binary:
         shutil.copy2(os.path.splitext(args.xdmfFilename)[0] + "_cell/mesh0/connect.bin", fn2)
     print("done writing " + fn2)
     # write geometry
-    geometry = sx.ReadGeometry()
     fn3 = prefix_new + "_vertex/mesh0/geometry.bin"
     output_file = open(fn3, "wb")
-    geometry.tofile(output_file)
+    xyz.tofile(output_file)
     output_file.close()
     print("done writing " + fn3)
 else:
@@ -94,8 +148,7 @@ else:
 
     # write geometry to hdf5 format
     h5fv = h5py.File(prefix_new + "_vertex.h5", "w")
-    geometry = sx.ReadGeometry()
-    h5fv.create_dataset("/mesh0/geometry", data=geometry)
+    h5fv.create_dataset("/mesh0/geometry", data=xyz)
     h5fv.close()
     print("done writing " + prefix_new + "_vertex.h5")
     # write connect to hdf5 format
@@ -103,7 +156,7 @@ else:
     h5fc.create_dataset("/mesh0/connect", data=connect)
 
 
-#############write data items#######################
+# Write data items
 for ida, sdata in enumerate(args.Data):
     if write2Binary:
         fname2 = prefix_new + "_cell/mesh0/" + args.Data[ida] + ".bin"
@@ -112,10 +165,11 @@ for ida, sdata in enumerate(args.Data):
         dset = h5fc.create_dataset("/mesh0/" + args.Data[ida], (len(indices), nElements), dtype=myDtype)
     # read only one row
     for kk, i in enumerate(indices):
+        print(kk, end=" ")
         if i >= ndt:
             print("ignoring index %d>=ndt=%d" % (i, ndt))
             continue
-        myData = sx.ReadData(args.Data[ida], idt=i)
+        myData = sx.ReadData(args.Data[ida], idt=i)[ids]
         if write2Binary:
             myData.astype(myDtype).tofile(output_file)
         else:
@@ -128,14 +182,13 @@ if not write2Binary:
     h5fc.close()
     print("done writing " + prefix_new + "_cell.h5")
 
-#####Now recrete the Xdmf ##################
+# Now recreate the Xdmf
 
 prefix = os.path.splitext(args.xdmfFilename)[0]
 
-### Read all parameters from the xdmf file of SeisSol (if any)
+# Read all parameters from the xdmf file of SeisSol (if any)
 
-ncells = ReadNcellsFromXdmf(args.xdmfFilename)
-dt = ReadDtFromXdmf(args.xdmfFilename)
-nvertex = ReadNvertexFromXdmf(args.xdmfFilename)
-ndt, nmem = ReadNdtNmemFromXdmf(args.xdmfFilename)
-recreateXdmf(prefix, prefix_new, nvertex, ncells, ncells, dt, indices, args.Data, not write2Binary, myprec, args.add2prefix)
+dt = recreateXdmf.ReadDtFromXdmf(args.xdmfFilename)
+nvertex = recreateXdmf.ReadNvertexFromXdmf(args.xdmfFilename)
+ndt, nmem = recreateXdmf.ReadNdtNmemFromXdmf(args.xdmfFilename)
+recreateXdmf.recreateXdmf(prefix, prefix_new, nvertex, nElements, nElements, dt, indices, args.Data, not write2Binary, myprec, args.add2prefix)


### PR DESCRIPTION
I just added some arguments to the script to extract a subset of the paraview output given coordinate ranges.
(was useful for processing the Palu surface output, might be useful for future setups).
I also changed a few things to fix errors identified by flake8.
Example of use:
```
python extractDataFromUnstructuredOutput.py /hppfs/work/pr45fi/ga24dib3/shared/2021-04-29_17-00_0/run_0/output/Sulawesi_WL_Batv1_CFL04b-surface.xdmf --Data U V W --do 100 --precision double --add resampled100s --xfilter -32000.0 24000.0 --yfilter -46000.0 58000.0 --no_ocean
```

Thomas. 