### PR TITLE
Fix flags for AMD Rome when using Intel compiler.

### DIFF
--- a/cmake/cpu_arch_flags.cmake
+++ b/cmake/cpu_arch_flags.cmake
@@ -49,7 +49,7 @@ function(get_arch_flags architecture compiler)
     # AMD Rome/ Epyc 2nd Gen
     elseif ("${HOST_ARCH}" STREQUAL "rome")
         if (compiler STREQUAL "Intel")
-
+            set(CPU_ARCH_FLAGS "-march=core-avx2" "-fma" PARENT_SCOPE)
         elseif(compiler MATCHES "GNU|Clang")
             set(CPU_ARCH_FLAGS "-march=znver2" "-mtune=znver2" PARENT_SCOPE)
     endif()


### PR DESCRIPTION
These are the flags that we used for our SC paper submission. They are tested.

We need to use Intel compiler currently because of #256.