### PR TITLE
introduce MPI structure in operator and dgbasis

### DIFF
--- a/src/Numerical_aux/dgbasis.f90
+++ b/src/Numerical_aux/dgbasis.f90
@@ -43,7 +43,6 @@
 module DGBasis_mod
   !---------------------------------------------------------------------------!
   use TypesDef
-  use MPI_f08
   !---------------------------------------------------------------------------!
   implicit none
   private
@@ -160,7 +159,7 @@ contains
   ! *                                                               * !
   ! ***************************************************************** !
 
-  function XYInElement(xS,yS,iElem,epsilon,MESH)
+  function XYInElement(xS,yS,iElem,epsilon,MESH,MPI)
     !-------------------------------------------------------------------------!
     
     !-------------------------------------------------------------------------!
@@ -172,6 +171,7 @@ contains
     type(tUnstructMesh)      :: MESH
     type(tDiscretization)    :: DISC
     type(tInputOutput)       :: IO
+    TYPE (tMPI) :: MPI
     integer     :: iElem
     real        :: xS, yS
     real        :: epsilon
@@ -229,7 +229,7 @@ contains
 
       if(dist1<3*dist2) then
 
-          call QuadTrafoXY2XiEta(xi,eta,xS,yS,x,y)
+          call QuadTrafoXY2XiEta(xi,eta,xS,yS,x,y,MPI)
 
           if ((xi .lt. (0.-epsilon)).or.(eta .lt.(0.-epsilon)) .or.        &
               (xi .gt. (1.+epsilon)).or.(eta .gt.(1.+epsilon)))     then
@@ -255,7 +255,7 @@ contains
       !
 
       !
-      call TrafoXY2XiEta(xi,eta,xS,yS,x,y,4)
+      call TrafoXY2XiEta(xi,eta,xS,yS,x,y,4,MPI)
 
       if ((xi .lt. (0.-epsilon)).or.(eta .lt.(0.-epsilon)) .or.        &
           (xi .gt. (1.+epsilon)).or.(eta .gt.(1.+epsilon)))     then
@@ -429,11 +429,12 @@ contains
   ! *                                                               * !
   ! ***************************************************************** !
 
-  subroutine TrafoXY2XiEta(xi,eta,xP,yP,x,y,eType)
+  subroutine TrafoXY2XiEta(xi,eta,xP,yP,x,y,eType,MPI)
     !-------------------------------------------------------------------------!
     implicit none
     !-------------------------------------------------------------------------!
     ! Argument list declaration
+    TYPE (tMPI) :: MPI
     integer     :: eType                               ! Element type         !
     real        :: xP, yP                              ! Input:  xP, yP       !
     real        :: xi, eta, zeta                       ! Output: xi eta       !
@@ -446,7 +447,7 @@ contains
     if(eType.eq.3) then
       call TriTrafoXY2XiEta(xi,eta,xP,yP,x,y)
     elseif(eType.eq.4) then
-      call QuadTrafoXY2XiEta(xi,eta,xP,yP,x,y)
+      call QuadTrafoXY2XiEta(xi,eta,xP,yP,x,y,MPI)
     endif
     !
   end subroutine TrafoXY2XiEta
@@ -566,13 +567,14 @@ contains
   ! *                                                               * !
   ! ***************************************************************** !
 
-  subroutine QuadTrafoXY2XiEta(xi,eta,xP,yP,x,y)
+  subroutine QuadTrafoXY2XiEta(xi,eta,xP,yP,x,y,MPI)
 
     use COMMON_operators_mod
     !-------------------------------------------------------------------------!
     implicit none
     !-------------------------------------------------------------------------!
     ! Argument list declaration
+    TYPE (tMPI) :: MPI
     real        :: xP, yP                              ! Input:  xP, yP       !
     real        :: xi, eta                             ! Output: xi eta       !
     real        :: x(4)              !
@@ -664,7 +666,7 @@ contains
         if(count>20) then
             write(*,*) ' | Error in QuadTrafoXY2XiEta. '
             write(*,*) ' |  Inverse of Jacobian not founded.'
-            call MPI_ABORT(MPI_COMM_WORLD, 134)
+            call MPI_ABORT(mpi%commWorld, 134)
         endif
     enddo
     

--- a/src/Numerical_aux/operators.f90
+++ b/src/Numerical_aux/operators.f90
@@ -43,7 +43,6 @@
 MODULE COMMON_operators_mod
   !----------------------------------------------------------------------------
   USE typesDef
-  USE mpi_f08
   !----------------------------------------------------------------------------
   IMPLICIT NONE
   PRIVATE
@@ -584,13 +583,14 @@ CONTAINS
 
   END FUNCTION STRING_REAL
 
-  SUBROUTINE OpenFile(UnitNr,Name,create)
+  SUBROUTINE OpenFile(UnitNr,Name,create,MPI)
     !------------------------------------------------------------------------!
     IMPLICIT NONE
     !------------------------------------------------------------------------!
     INTEGER            :: UnitNr
     CHARACTER(LEN=*)   :: Name
     LOGICAL            :: create
+    TYPE (tMPI)        :: MPI
     ! local variables
     INTEGER            :: status
     LOGICAL            :: fexist
@@ -608,7 +608,7 @@ CONTAINS
     IF(.NOT.fexist) THEN                                                     !
        logError(*) 'Error opening unit    : ',UnitNr              !
        logError(*) 'Unit is already open under the name:',TRIM(AllreadyOpenFileName)
-       call MPI_ABORT(MPI_COMM_WORLD, 134)                                                                  !
+       call MPI_ABORT(mpi%commWorld, 134)                                                                  !
     ENDIF                                                                    !
     !                                                                        !        
     IF (create) THEN                                                         !
@@ -624,7 +624,7 @@ CONTAINS
        IF(.NOT.fexist) THEN                                                  !
           logError(*) 'Error opening file    : ', Name            !
           logError(*) 'File does not exist.'                       !
-          call MPI_ABORT(MPI_COMM_WORLD, 134)                                                               !
+          call MPI_ABORT(mpi%commWorld, 134)                                                               !
        ENDIF                                                                 !
        !                                                                     !
     END IF                                                                   !
@@ -639,7 +639,7 @@ CONTAINS
        logError(*) 'could not open ',Name                   !
        logError(*) 'File does exist but cannot be opened.'         !
        logError(*) 'IOSTAT:',status                                !
-       call MPI_ABORT(MPI_COMM_WORLD, 134)                                                                  !
+       call MPI_ABORT(mpi%commWorld, 134)                                                                  !
     END IF                                                                   !
     !                                                                        !        
   END SUBROUTINE OpenFile
@@ -929,11 +929,12 @@ CONTAINS
   ! Analytically compute all the roots of a non-degenerate second order polynomial
   ! a=coefficient(1) must be non-zero.
   ! 
-  SUBROUTINE ZerosPolyO2(solution,coefficients)
+  SUBROUTINE ZerosPolyO2(solution,coefficients,MPI)
     !--------------------------------------------------------------------------
     IMPLICIT NONE
     !--------------------------------------------------------------------------
     ! Argument list declaration
+    TYPE (tMPI)               :: MPI
     REAL                      :: coefficients(3)
     REAL                      :: solution(2)
     ! Local variable declaration
@@ -953,7 +954,7 @@ CONTAINS
     IF(d.LT.0.) THEN
         PRINT *, ' d negative in ZerosPolyO2. No real roots found! '
         PRINT *, d
-        call MPI_ABORT(MPI_COMM_WORLD, 134)
+        call MPI_ABORT(mpi%commWorld, 134)
     ENDIF
     !
     solution(1) = (-b-SQRT(d))/(2.*a)
@@ -1017,11 +1018,12 @@ CONTAINS
   ! Analytically compute all the roots of a non-degenerate fourth order polynomial
   ! a=coefficient(1) must be non-zero.
   ! 
-  SUBROUTINE ZerosPolyO4(solution,coefficients)
+  SUBROUTINE ZerosPolyO4(solution,coefficients,MPI)
     !--------------------------------------------------------------------------
     IMPLICIT NONE
     !--------------------------------------------------------------------------
     ! Argument list declaration
+    TYPE (tMPI)               :: MPI
     REAL                      :: coefficients(5)
     REAL                      :: solution(4)
     ! Local variable declaration
@@ -1061,7 +1063,7 @@ CONTAINS
     IF(ABS(AIMAG(s)).GT.1e-6*ABS(y)) THEN
         PRINT *, ' Real root of aux. poly not real in ZerosPolyO4! '
         PRINT *, s
-        call MPI_ABORT(MPI_COMM_WORLD, 134)
+        call MPI_ABORT(mpi%commWorld, 134)
     ENDIF
     ! Aux. variables A+/-
     Ap = SQRT(8.*y+b*b-4*c) 
@@ -1078,7 +1080,7 @@ CONTAINS
     IF(d2.LT.0.) THEN
         PRINT *, ' d2 (using A+) negative in ZerosPolyO4. No real roots found! '
         PRINT *, d2
-        call MPI_ABORT(MPI_COMM_WORLD, 134)
+        call MPI_ABORT(mpi%commWorld, 134)
     ENDIF
     !
     solution(1) = (-b2-SQRT(d2))/(2.*a2)
@@ -1093,7 +1095,7 @@ CONTAINS
     IF(d2.LT.0.) THEN
         PRINT *, ' d2 (using A-) negative in ZerosPolyO4. No real roots found! '
         PRINT *, d2
-        call MPI_ABORT(MPI_COMM_WORLD, 134)
+        call MPI_ABORT(mpi%commWorld, 134)
     ENDIF
     !
     solution(3) = (-b2-SQRT(d2))/(2.*a2)

--- a/src/Reader/read_backgroundstress.f90
+++ b/src/Reader/read_backgroundstress.f90
@@ -374,13 +374,14 @@ CONTAINS
  
   !---------------------------------------------------------------------------!
   
-  SUBROUTINE read_scec_stress(DISC,IO)
+  SUBROUTINE read_scec_stress(DISC,IO,MPI)
     !< subroutine reads in SCEC specific background stress
     !-------------------------------------------------------------------------!
     IMPLICIT NONE    
     !-------------------------------------------------------------------------!
     TYPE(tDiscretization)   :: DISC                                           !< Discretization struct.!
     TYPE(tInputOutput)      :: IO                                             !< IO structure          !
+    TYPE(tMPI)              :: MPI                                            !
     !-------------------------------------------------------------------------!
     ! Local variable declaration                                              !
     INTEGER                         :: i
@@ -398,7 +399,8 @@ CONTAINS
     CALL OpenFile(                                       &                        
          UnitNr       = IO%UNIT%other01                , &                        
          Name         = IO%FileName_BackgroundStress   , &
-         create       = .FALSE.                          )    
+         create       = .FALSE.                        , &
+         MPI          = MPI                              )    
         
     ! Read header
     READ(IO%UNIT%other01,*) intDummy, intDummy

--- a/src/Reader/readpar.f90
+++ b/src/Reader/readpar.f90
@@ -130,17 +130,17 @@ CONTAINS
     logInfo0(*) '<  Parameters read from file: ', TRIM(IO%ParameterFile) ,'              >'
     logInfo0(*) '<                                                         >'
     !                                                                        !
-    CALL OpenFile(UnitNr=IO%UNIT%FileIn, name=trim(IO%ParameterFile), create=.FALSE.)
+    CALL OpenFile(UnitNr=IO%UNIT%FileIn, name=trim(IO%ParameterFile), create=.FALSE., MPI=MPI)
     !                                                                        !
     CALL readpar_header(IO,IC,actual_version_of_readpar,programTitle) !
     !                                                                        !
-    CALL readpar_equations(EQN,DISC,SOURCE,IC,IO)                  !
+    CALL readpar_equations(EQN,DISC,SOURCE,IC,IO,MPI)                        !
     !                                                                        !
     CALL readpar_ini_condition(EQN,IC,SOURCE,IO)                   !
     !                                                                        !
-    CALL readpar_boundaries(EQN,BND,IC,DISC,IO,CalledFromStructCode)    !
+    CALL readpar_boundaries(EQN,BND,IC,DISC,IO,MPI,CalledFromStructCode)     !
     !                                                                        !                                                                        !
-    CALL readpar_sourceterm(EQN,SOURCE,IO)                                   !
+    CALL readpar_sourceterm(EQN,SOURCE,IO, MPI)                              !
     !                                                                        !
     CALL readpar_spongelayer(DISC,EQN,SOURCE,IO)
     !                                                                        !
@@ -148,7 +148,7 @@ CONTAINS
     !                                                                        !
     CALL readpar_discretisation(EQN,usMESH,DISC,SOURCE,IO)         !
     !                                                                        !
-    CALL readpar_output(EQN,DISC,IO,CalledFromStructCode)          !
+    CALL readpar_output(EQN,DISC,IO,MPI,CalledFromStructCode)                !
     !                                                                        !
     CALL readpar_abort(DISC,IO)                                    !
     !                                                                        !
@@ -213,7 +213,7 @@ CONTAINS
   ! E Q U A T I O N S
   !============================================================================
 
-  SUBROUTINE readpar_equations(EQN,DISC,SOURCE,IC, IO)
+  SUBROUTINE readpar_equations(EQN,DISC,SOURCE,IC, IO, MPI)
     !------------------------------------------------------------------------
     !------------------------------------------------------------------------
     IMPLICIT NONE
@@ -223,6 +223,7 @@ CONTAINS
     TYPE (tSource)             :: SOURCE
     TYPE (tInitialCondition)   :: IC
     TYPE (tInputOutput)        :: IO
+    TYPE (tMPI)                :: MPI
     ! localVariables
     INTEGER                    :: intDummy
     INTEGER                    :: readStat
@@ -367,7 +368,7 @@ CONTAINS
     END SELECT
 
     IF(EQN%Adjoint.EQ.1) THEN
-     call readadjoint(IO, DISC, SOURCE, AdjFileName)
+     call readadjoint(IO, DISC, SOURCE, AdjFileName, MPI)
     END IF
     !
     inquire(file=MaterialFileName , exist=fileExists)
@@ -433,11 +434,12 @@ CONTAINS
     !------------------------------------------------------------------------
      !Adjoint set to yes
     !------------------------------------------------------------------------
-  SUBROUTINE readadjoint(IO, DISC, SOURCE, AdjFileName)
+  SUBROUTINE readadjoint(IO, DISC, SOURCE, AdjFileName, MPI)
     IMPLICIT NONE
     TYPE (tInputOutput)                               :: IO
     TYPE (tDiscretization)                            :: DISC
     TYPE (tSource)                                    :: SOURCE
+    TYPE (tMPI)                                       :: MPI
     INTENT(INOUT)                                     :: IO, SOURCE
     INTEGER                                           :: i
     CHARACTER(600)                                    :: AdjFileName
@@ -448,7 +450,8 @@ CONTAINS
       CALL OpenFile(                                       &
         UnitNr       = IO%UNIT%other01                , &
         Name         = ADJFileName                    , &
-        create       = .FALSE.                          )
+        create       = .FALSE.                        , &
+        MPI          = MPI                              )
       !
       ! Inversion information is read now
       !
@@ -589,7 +592,7 @@ CONTAINS
   !------------------------------------------------------------------------
   !------------------------------------------------------------------------
 
-  subroutine readpar_faultAtPickpoint(EQN,BND,IC,DISC,IO,CalledFromStructCode)
+  subroutine readpar_faultAtPickpoint(EQN,BND,IC,DISC,IO,MPI,CalledFromStructCode)
     !------------------------------------------------------------------------
     !------------------------------------------------------------------------
     IMPLICIT NONE
@@ -599,6 +602,7 @@ CONTAINS
     TYPE (tInitialCondition)   :: IC
     TYPE (tDiscretization)     :: DISC
     TYPE (tInputOutput)        :: IO
+    TYPE (tMPI)                :: MPI
     LOGICAL                    :: CalledFromStructCode
     ! localVariables
     INTEGER                    :: allocStat, OutputMask(12), i
@@ -639,8 +643,9 @@ CONTAINS
       logInfo(*) ' Pickpoints read from ', TRIM(PPFileName)
       CALL OpenFile(                                 &
             UnitNr       = IO%UNIT%other01         , &
-            Name         = PPFileName            , &
-            create       = .FALSE.                          )
+            Name         = PPFileName              , &
+            create       = .FALSE.                 , &
+            MPI          = MPI                       )
         DO i = 1, nOutPoints
           READ(IO%UNIT%other01,*) X(i), Y(i), Z(i)
 
@@ -767,7 +772,7 @@ CONTAINS
   ! B O U N D A R I E S
   !============================================================================
 
-  SUBROUTINE readpar_boundaries(EQN,BND,IC,DISC,IO,CalledFromStructCode)
+  SUBROUTINE readpar_boundaries(EQN,BND,IC,DISC,IO,MPI,CalledFromStructCode)
     !------------------------------------------------------------------------
     !------------------------------------------------------------------------
     IMPLICIT NONE
@@ -777,6 +782,7 @@ CONTAINS
     TYPE (tInitialCondition)   :: IC
     TYPE (tDiscretization)     :: DISC
     TYPE (tInputOutput)        :: IO
+    TYPE (tMPI)                :: MPI
     LOGICAL                    :: CalledFromStructCode
     ! localVariables
     INTEGER                    :: stat
@@ -856,7 +862,7 @@ CONTAINS
           logInfo(*) '-----------------------------------  '
 
           IF(EQN%DR.EQ.1) THEN
-         call readdr(IO, EQN, DISC, BND, IC)
+         call readdr(IO, EQN, DISC, BND, IC, MPI)
        ENDIF ! EQN%DR.EQ.1
       !--------------------------------------------------------------------------------------!
       ! Inflow
@@ -875,7 +881,7 @@ CONTAINS
             logError(*) 'could not allocate Inflow variables!'                               ! Error Handler
             call exit(134)                                                                             ! Error Handler
          END IF                                                                              ! Error Handler
-      call readinfl(BND, IC, EQN, IO, DISC, BC_if)
+      call readinfl(BND, IC, EQN, IO, DISC, MPI, BC_if)
       END IF
       !
       !--------------------------------------------------------------------------------------!
@@ -913,14 +919,15 @@ CONTAINS
     !------------------------------------------------------------------------
      !Dynamic Rupture
     !------------------------------------------------------------------------
-  SUBROUTINE readdr(IO, EQN, DISC, BND, IC)
+  SUBROUTINE readdr(IO, EQN, DISC, BND, IC, MPI)
     IMPLICIT NONE
     TYPE (tInputOutput)                    :: IO
     TYPE (tEquations)                      :: EQN
     TYPE (tDiscretization)                 :: DISC
     TYPE (tBoundary)                       :: BND
     TYPE (tInitialCondition)               :: IC
-    INTENT(INOUT)                          :: IO, EQN, DISC, BND
+    TYPE (tMPI)                            :: MPI
+    INTENT(INOUT)                          :: IO, EQN, DISC, BND, MPI
     INTEGER                                :: FL, BackgroundType, Nucleation, inst_healing, RF_output_on, DS_output_on, &
                                               OutputPointType, magnitude_output_on,  energy_rate_output_on, read_fault_file,refPointMethod, &
                                               thermalPress, SlipRateOutputType, readStat
@@ -1114,7 +1121,7 @@ CONTAINS
            elseif(DISC%DynRup%OutputPointType.EQ.3) THEN
                 ! in case of OutputPointType 3, read in receiver locations:
                 ! DISC%DynRup%DynRup_out_atPickpoint%nOutPoints is for option 3 the number of pickpoints
-                call readpar_faultAtPickpoint(EQN,BND,IC,DISC,IO,CalledFromStructCode)
+                call readpar_faultAtPickpoint(EQN,BND,IC,DISC,IO,MPI,CalledFromStructCode)
            ELSEIF(DISC%DynRup%OutputPointType.EQ.4) THEN
                 ! elementwise output -> 2 dimensional fault output
                 call readpar_faultElementwise(EQN,BND,IC,DISC,IO,CalledFromStructCode)
@@ -1122,7 +1129,7 @@ CONTAINS
                 ! ALICE: TO BE DONE
                 ! fault receiver + 2 dimensional fault output
                 call readpar_faultElementwise(EQN,BND,IC,DISC,IO,CalledFromStructCode)
-                call readpar_faultAtPickpoint(EQN,BND,IC,DISC,IO,CalledFromStructCode)
+                call readpar_faultAtPickpoint(EQN,BND,IC,DISC,IO,MPI,CalledFromStructCode)
            ELSE
                logError(*) 'Unkown fault output type (e.g.3,4,5)',DISC%DynRup%OutputPointType
                call exit(134)
@@ -1132,13 +1139,14 @@ CONTAINS
     !------------------------------------------------------------------------
      !Inflow Boundaries
     !------------------------------------------------------------------------
-  SUBROUTINE readinfl(BND, IC, EQN, IO, DISC, n4)
+  SUBROUTINE readinfl(BND, IC, EQN, IO, DISC, MPI, n4)
     IMPLICIT NONE
     TYPE (tInputOutput)                    :: IO
     TYPE (tEquations)                      :: EQN
     TYPE (tDiscretization)                 :: DISC
     TYPE (tBoundary)                       :: BND
     TYPE (tInitialCondition)               :: IC
+    TYPE (tMPI)                            :: MPI
     INTENT(INOUT)                          :: IO, EQN, DISC, BND
     INTEGER                                :: n4, i, j, iVar, readstat, startComment
     INTEGER                                :: nsteps, nPW, iObject, isteps
@@ -1224,7 +1232,8 @@ CONTAINS
                 CALL OpenFile(                                        &
                       UnitNr       = IO%UNIT%other01                , &
                       Name         = PWFileName                     , &
-                      create       = .FALSE.                          )
+                      create       = .FALSE.                        , &
+                      MPI          = MPI                              )
                 logInfo(*) 'Reading inflow wave time-history file ...  '
                 READ(IO%UNIT%other01,'(i10,a)') nsteps                        ! Number of timesteps included
                 BND%ObjInflow(iObject)%PW%TimeHistnSteps = nsteps
@@ -1322,7 +1331,7 @@ CONTAINS
    ! S O U R C E   T E R M
    !============================================================================
 
-  SUBROUTINE readpar_sourceterm(EQN,SOURCE,IO)
+  SUBROUTINE readpar_sourceterm(EQN,SOURCE,IO,MPI)
    !------------------------------------------------------------------------
    IMPLICIT NONE
    !------------------------------------------------------------------------
@@ -1330,6 +1339,7 @@ CONTAINS
    TYPE (tEquations)                :: EQN
    TYPE (tSource)                   :: SOURCE
    TYPE (tInputOutput)              :: IO
+   TYPE (tMPI)                      :: MPI
    ! local variable declaration
    INTEGER                          :: i,j,k,iVar,iDummy1
    INTEGER                          :: startComment
@@ -1510,7 +1520,8 @@ CONTAINS
        CALL OpenFile(                                       &
             UnitNr       = IO%UNIT%other01                , &
             Name         = SOURCE%FSRMFileName            , &
-            create       = .FALSE.                          )
+            create       = .FALSE.                        , &
+            MPI          = MPI                              )
        logInfo(*) 'Reading single force file ...  '
        !
        ! LEGEND
@@ -1589,7 +1600,8 @@ CONTAINS
        CALL OpenFile(                                       &
             UnitNr       = IO%UNIT%other01                , &
             Name         = SOURCE%FSRMFileName            , &
-            create       = .FALSE.                          )
+            create       = .FALSE.                        , &
+            MPI          = MPI                              )
        logInfo(*) 'Reading rupture model file of Type  ',SOURCE%RP%Type
        !
        ! Rupture Plane Geometrie and Subfault information is read now
@@ -1774,7 +1786,8 @@ CONTAINS
        CALL OpenFile(                                       &
             UnitNr       = IO%UNIT%other01                , &
             Name         = SOURCE%FSRMFileName            , &
-            create       = .FALSE.                          )
+            create       = .FALSE.                        , &
+            MPI          = MPI                              )
        logInfo(*) 'Reading rupture model file ...  '
        !
        ! Moment Tensor, Rupture Plane Geometrie and Subfault information is read now
@@ -1830,7 +1843,8 @@ CONTAINS
        CALL OpenFile(                                       &
             UnitNr       = IO%UNIT%other01                , &
             Name         = SOURCE%FSRMFileName            , &
-            create       = .FALSE.                          )
+            create       = .FALSE.                        , &
+            MPI          = MPI                              )
        logInfo(*) 'Reading rupture model file ...  '
        !
        ! Moment Tensor, Rupture Plane Geometrie and Subfault information is read now
@@ -2536,13 +2550,14 @@ ALLOCATE( SpacePositionx(nDirac), &
   ! O U T P U T
   !============================================================================
 
-    SUBROUTINE readpar_output(EQN,DISC,IO,CalledFromStructCode)
+    SUBROUTINE readpar_output(EQN,DISC,IO,MPI,CalledFromStructCode)
       !------------------------------------------------------------------------
       IMPLICIT NONE
       !------------------------------------------------------------------------
       TYPE (tEquations)             :: EQN
       TYPE (tDiscretization)        :: DISC
       TYPE (tInputOutput)           :: IO
+      TYPE (tMPI)                   :: MPI
       LOGICAL                       :: CalledFromStructCode
       ! local Variables
       INTEGER                       :: i,n, NPTS
@@ -2902,8 +2917,9 @@ ALLOCATE( SpacePositionx(nDirac), &
          logInfo(*) 'Record Points read from ', TRIM(RFileName)
          CALL OpenFile(                                 &
                UnitNr       = IO%UNIT%other01         , &
-               Name         = RFileName            , &
-               create       = .FALSE.                          )
+               Name         = RFileName               , &
+               create       = .FALSE.                 , &
+               MPI          = MPI                       )
 
          DO i = 1,nRecordPoints
             READ(IO%UNIT%other01,*) X(i), Y(i), Z(i)
@@ -2960,7 +2976,8 @@ ALLOCATE( SpacePositionx(nDirac), &
               CALL OpenFile(                                       &
                    UnitNr       = IO%UNIT%other01                , &
                    Name         = IO%PGMLocationsFile            , &
-                   create       = .FALSE.                          )
+                   create       = .FALSE.                        , &
+                   MPI          = MPI                              )
               READ(IO%UNIT%other01,'(i10)') IO%nPGMRecordPoint                         ! Number of Peak Ground Motion Locations
               logInfo(*) 'Reading ',IO%nPGMRecordPoint,' PGM locations ... '
               logInfo(*) ' '


### PR DESCRIPTION
It turns out that using MPI_f08 breaks the compilation with openmpi (at least 3.1.4).
I then remove MPI_f08 by passing the MPI structure in operator and dgbasis.f90.