### PR TITLE
Add csv error output

### DIFF
--- a/src/ResultWriter/AnalysisWriter.cpp
+++ b/src/ResultWriter/AnalysisWriter.cpp
@@ -288,11 +288,22 @@ void AnalysisWriter::printAnalysis(double simulationTime) {
       MeshTools::center(elements[elemLInfLocal[i]],
             vertices,
             center);
-
-      logInfo() << "L1, var[" << i << "] =\t" << errL1Local[i] << "\t" << errL1Local[i] / analyticalL1Local[i];
-      logInfo() << "L2, var[" << i << "] =\t" << std::sqrt(errL2Local[i]) << "\t" << std::sqrt(errL2Local[i] / analyticalL2Local[i]);
-      logInfo() << "LInf, var[" << i << "] =\t" << errLInfLocal[i << "\t" << errLInfLocal[i] /analyticalLInfLocal[i]]
+      const auto errL1 = errL1Local[i];
+      const auto errL2 = std::sqrt(errL2Local[i]);
+      const auto errLInf = errLInfLocal[i];
+      const auto errL1Rel = errL1 / analyticalL1Local[i];
+      const auto errL2Rel = std::sqrt(errL2Local[i] / analyticalL2Local[i]);
+      const auto errLInfRel = errLInf / analyticalLInfLocal[i];
+      logInfo() << "L1  , var[" << i << "] =\t" << errL1 << "\t" << errL1Rel;
+      logInfo() << "L2  , var[" << i << "] =\t" << errL2 << "\t" << errL2Rel;
+      logInfo() << "LInf, var[" << i << "] =\t" << errLInf << "\t" << errLInfRel
           << "\tat [" << center[0] << ",\t" << center[1] << ",\t" << center[2] << "\t]";
+      csvWriter.addObservation(std::to_string(i), "L1", errL1);
+      csvWriter.addObservation(std::to_string(i), "L2", errL2);
+      csvWriter.addObservation(std::to_string(i), "LInf", errLInf);
+      csvWriter.addObservation(std::to_string(i), "L1_rel", errL1Rel);
+      csvWriter.addObservation(std::to_string(i), "L2_rel", errL2Rel);
+      csvWriter.addObservation(std::to_string(i), "LInf_rel", errLInfRel);
     }
 #endif // USE_MPI
   }

--- a/src/ResultWriter/AnalysisWriter.cpp
+++ b/src/ResultWriter/AnalysisWriter.cpp
@@ -118,7 +118,8 @@ void AnalysisWriter::printAnalysis(double simulationTime) {
     alignas(ALIGNMENT) real numericalSolutionData[tensor::dofsQP::size()];
     alignas(ALIGNMENT) real analyticalSolutionData[numQuadPoints*numberOfQuantities];
 #ifdef _OPENMP
-#pragma omp parallel for default(none) shared(elements, vertices, iniFields, quadraturePoints, globalData, errsLInfLocal, simulationTime, ltsLut, lts, sim, quadratureWeights, elemsLInfLocal, errsL2Local, errsL1Local, analyticalsL1Local, analyticalsL2Local, analyticalsLInfLocal) firstprivate(quadraturePointsXyz) private(numericalSolutionData, analyticalSolutionData)
+    // Note: Adding default(none) leads error when using gcc-8
+#pragma omp parallel for shared(elements, vertices, iniFields, quadraturePoints, globalData, errsLInfLocal, simulationTime, ltsLut, lts, sim, quadratureWeights, elemsLInfLocal, errsL2Local, errsL1Local, analyticalsL1Local, analyticalsL2Local, analyticalsLInfLocal) firstprivate(quadraturePointsXyz) private(numericalSolutionData, analyticalSolutionData)
 #endif
     for (std::size_t meshId = 0; meshId < elements.size(); ++meshId) {
 #ifdef _OPENMP

--- a/src/ResultWriter/AnalysisWriter.cpp
+++ b/src/ResultWriter/AnalysisWriter.cpp
@@ -11,7 +11,40 @@
 #include "Geometry/MeshReader.h"
 #include <Physics/InitialField.h>
 
-void seissol::writer::AnalysisWriter::printAnalysis(double simulationTime) {
+namespace seissol::writer {
+
+CsvAnalysisWriter::CsvAnalysisWriter() :
+    out(), isActive(false) { }
+
+void CsvAnalysisWriter::writeHeader() {
+  if (isActive) {
+    out << "variable,norm,error\n";
+  }
+}
+
+void CsvAnalysisWriter::addObservation(std::string_view variable,
+                                       std::string_view normType,
+                                       real error) {
+  if (isActive) {
+    out << variable << "," << normType << "," << error << "\n";
+  }
+}
+
+void CsvAnalysisWriter::activate() {
+  isActive = true;
+  out.open("analysis.csv");
+}
+
+CsvAnalysisWriter::~CsvAnalysisWriter() {
+  if (isActive) {
+    out.close();
+    if (!out) {
+      logError() << "Error when writing analysis output to file";
+    }
+  }
+}
+
+void AnalysisWriter::printAnalysis(double simulationTime) {
   const auto& mpi = seissol::MPI::mpi;
 
   const auto initialConditionType = std::string(e_interoperability.getInitialConditionType());
@@ -85,7 +118,7 @@ void seissol::writer::AnalysisWriter::printAnalysis(double simulationTime) {
     alignas(ALIGNMENT) real numericalSolutionData[tensor::dofsQP::size()];
     alignas(ALIGNMENT) real analyticalSolutionData[numQuadPoints*numberOfQuantities];
 #ifdef _OPENMP
-#pragma omp parallel for firstprivate(quadraturePointsXyz) private(numericalSolutionData, analyticalSolutionData)
+#pragma omp parallel for default(none) shared(elements, vertices, iniFields, quadraturePoints, globalData, errsLInfLocal, simulationTime, ltsLut, lts, sim, quadratureWeights, elemsLInfLocal, errsL2Local, errsL1Local, analyticalsL1Local, analyticalsL2Local, analyticalsLInfLocal) firstprivate(quadraturePointsXyz) private(numericalSolutionData, analyticalSolutionData)
 #endif
     for (std::size_t meshId = 0; meshId < elements.size(); ++meshId) {
 #ifdef _OPENMP
@@ -175,8 +208,6 @@ void seissol::writer::AnalysisWriter::printAnalysis(double simulationTime) {
 
     }
 
-    // TODO(Lukas) Print hs, fortran: MESH%MaxSQRTVolume, MESH%MaxCircle
-
 #ifdef USE_MPI
     const auto& comm = mpi.comm();
 
@@ -206,6 +237,11 @@ void seissol::writer::AnalysisWriter::printAnalysis(double simulationTime) {
     auto analyticalLInfMPI = ErrorArray_t{0.0};
     MPI_Reduce(analyticalLInfLocal.data(), analyticalLInfMPI.data(), analyticalLInfLocal.size(), MPI_DOUBLE, MPI_MAX, 0, comm);
 
+    auto csvWriter = CsvAnalysisWriter();
+    if (mpi.rank() == 0) {
+      csvWriter.activate();
+      csvWriter.writeHeader();
+    }
 
     for (unsigned int i = 0; i < numberOfQuantities; ++i) {
       VrtxCoords centerSend;
@@ -225,12 +261,24 @@ void seissol::writer::AnalysisWriter::printAnalysis(double simulationTime) {
         } else {
           MPI_Recv(centerRecv, 3, MPI_DOUBLE,  errLInfRecv[i].rank, i, comm, MPI_STATUS_IGNORE);
         }
-        logInfo(mpi.rank()) << "L1  , var[" << i << "] =\t" << errL1MPI[i] << "\t" << errL1MPI[i] / analyticalL1MPI[i];
-        logInfo(mpi.rank()) << "L2  , var[" << i << "] =\t" << std::sqrt(errL2MPI[i]) << "\t" << std::sqrt(errL2MPI[i] / analyticalL2MPI[i]);
-        logInfo(mpi.rank()) << "LInf, var[" << i << "] =\t" << errLInfRecv[i].val << "\t" << errLInfRecv[i].val / analyticalLInfMPI[i]
+
+        const auto errL1 = errL1MPI[i];
+        const auto errL2 = std::sqrt(errL2MPI[i]);
+        const auto errLInf = errLInfRecv[i].val;
+        const auto errL1Rel = errL1 / analyticalL1MPI[i];
+        const auto errL2Rel = std::sqrt(errL2MPI[i] / analyticalL2MPI[i]);
+        const auto errLInfRel = errLInf / analyticalLInfMPI[i];
+        logInfo(mpi.rank()) << "L1  , var[" << i << "] =\t" << errL1 << "\t" << errL1Rel;
+        logInfo(mpi.rank()) << "L2  , var[" << i << "] =\t" << errL2 << "\t" << errL2Rel;
+        logInfo(mpi.rank()) << "LInf, var[" << i << "] =\t" << errLInf << "\t" << errLInfRel
             << "at rank " << errLInfRecv[i].rank
             << "\tat [" << centerRecv[0] << ",\t" << centerRecv[1] << ",\t" << centerRecv[2] << "\t]";
-
+        csvWriter.addObservation(std::to_string(i), "L1", errL1);
+        csvWriter.addObservation(std::to_string(i), "L2", errL2);
+        csvWriter.addObservation(std::to_string(i), "LInf", errLInf);
+        csvWriter.addObservation(std::to_string(i), "L1_rel", errL1Rel);
+        csvWriter.addObservation(std::to_string(i), "L2_rel", errL2Rel);
+        csvWriter.addObservation(std::to_string(i), "LInf_rel", errLInfRel);
       }
     }
 #else
@@ -248,4 +296,5 @@ void seissol::writer::AnalysisWriter::printAnalysis(double simulationTime) {
 #endif // USE_MPI
   }
 }
+} // namespace seissol::writer
 

--- a/src/ResultWriter/AnalysisWriter.h
+++ b/src/ResultWriter/AnalysisWriter.h
@@ -21,7 +21,7 @@ extern seissol::Interoperability e_interoperability;
 namespace seissol::writer {
 class CsvAnalysisWriter {
 public:
-  CsvAnalysisWriter();
+  CsvAnalysisWriter(std::string fileName);
 
   void writeHeader();
 
@@ -29,12 +29,13 @@ public:
                       std::string_view normType,
                       real error);
 
-  void activate();
+  void enable();
 
   ~CsvAnalysisWriter();
 private:
   std::ofstream out;
-  bool isActive;
+  bool isEnabled;
+  std::string fileName;
 };
 
   class AnalysisWriter {
@@ -46,13 +47,17 @@ private:
 
     bool isEnabled; // TODO(Lukas) Do we need this?
     const MeshReader* meshReader;
+
+    std::string fileName;
 public:
   AnalysisWriter() :
     isEnabled(false) { }
 
-    void init(const MeshReader* meshReader) {
+    void init(const MeshReader* meshReader,
+              std::string_view fileNamePrefix) {
       isEnabled = true;
       this->meshReader = meshReader;
+      fileName = std::string(fileNamePrefix) + "_analysis.csv";
     }  
 
     

--- a/src/ResultWriter/AnalysisWriter.h
+++ b/src/ResultWriter/AnalysisWriter.h
@@ -1,9 +1,10 @@
 #ifndef ANALYSISWRITER_H
 #define ANALYSISWRITER_H
 
-// TODO(Lukas) Clean up includes.
 #include <array>
 #include <cmath>
+#include <fstream>
+#include <iostream>
 
 #include "Solver/Interoperability.h"
 #include "Physics/InitialField.h"
@@ -15,13 +16,27 @@
 
 #include <Geometry/MeshReader.h>
 
-//#include <Initializer/LTS.h>
-//#include <Initializer/tree/LTSTree.hpp>
-
 extern seissol::Interoperability e_interoperability;
 
-namespace seissol {
-namespace writer {
+namespace seissol::writer {
+class CsvAnalysisWriter {
+public:
+  CsvAnalysisWriter();
+
+  void writeHeader();
+
+  void addObservation(std::string_view variable,
+                      std::string_view normType,
+                      real error);
+
+  void activate();
+
+  ~CsvAnalysisWriter();
+private:
+  std::ofstream out;
+  bool isActive;
+};
+
   class AnalysisWriter {
 private:
     struct data {
@@ -43,6 +58,7 @@ public:
     
     void printAnalysis(double simulationTime);
   }; // class AnalysisWriter
-} // namespace Writer
-} // namespace Solver
+
+
+} // namespace seissol::writer
 #endif // ANALYSISWRITER_H

--- a/src/Solver/Interoperability.cpp
+++ b/src/Solver/Interoperability.cpp
@@ -894,7 +894,9 @@ void seissol::Interoperability::initializeIO(
 	// (at least at the moment ...)
 
 	// TODO(Lukas) Free the mesh reader if not doing convergence test.
-	seissol::SeisSol::main.analysisWriter().init(&seissol::SeisSol::main.meshReader());
+	seissol::SeisSol::main.analysisWriter().init(
+	    &seissol::SeisSol::main.meshReader(),
+	    freeSurfaceFilename);
 	//seissol::SeisSol::main.freeMeshReader();
 }
 


### PR DESCRIPTION
This PR adds an CSV error writer. After running a scenario with an analytical solution, it also writes the output to a csv file (using the path given for other output options).

The files (note: truncated!) looks roughly like this:
```
variable,norm,error
0,L1,0.326084
0,L2,0.129683
0,LInf,0.251285
1,L1,0.307356
1,L2,0.128929
1,LInf,0.251285
2,L1,0.350589
2,L2,0.133231
2,LInf,0.251285
3,L1,0.0129171
3,L2,0.00674716
3,LInf,0.0248785
```