### PR TITLE
Add option to enable address sanitzer in debug mode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -263,6 +263,12 @@ if (WITH_GPU)
   target_compile_definitions(SeisSol-lib PUBLIC ACL_DEVICE)
 endif()
 
+if (ADDRESS_SANITIZER_DEBUG)
+  target_link_libraries(SeisSol-lib PUBLIC debug
+          -fno-omit-frame-pointer -fsanitize=address -fsanitize-recover=address
+  )
+endif()
+
 target_include_directories(SeisSol-lib PUBLIC
 				   ${CMAKE_CURRENT_SOURCE_DIR}/src
 				   ${CMAKE_CURRENT_SOURCE_DIR}/submodules

--- a/cmake/process_users_input.cmake
+++ b/cmake/process_users_input.cmake
@@ -7,6 +7,7 @@ option(OPENMP "Use OpenMP parallelization" ON)
 option(ASAGI "Use asagi for material input" OFF)
 option(MEMKIND "Use memkind library for hbw memory support" OFF)
 option(USE_IMPALA_JIT_LLVM "Use llvm version of impalajit" OFF)
+option(ADDRESS_SANITIZER_DEBUG "Use address sanitzer in debug mode" OFF)
 
 # todo:
 option(SIONLIB "Use sionlib for checkpointing" OFF)


### PR DESCRIPTION
Can use option -DADDRESS_SANITIZER_DEBUG to link with address sanitzer when in debug mode.
https://en.wikipedia.org/wiki/AddressSanitizer can help a lot with finding memory leaks and related issues.