### PR TITLE
to avoid zero in LocSV

### DIFF
--- a/src/Physics/Evaluate_friction_law.f90
+++ b/src/Physics/Evaluate_friction_law.f90
@@ -1124,7 +1124,7 @@ MODULE Eval_friction_law_mod
         ! steady-state state variable
         ! For compiling reasons we write SINH(X)=(EXP(X)-EXP(-X))/2
         SVss = RS_a * LOG(2.0D0*RS_sr0/SR_tmp * (EXP(fss/RS_a)-EXP(-fss/RS_a))/2.0D0)
-
+        SVss = max(1e-8,SVss)
         ! exact integration of dSV/dt DGL, assuming constant V over integration step
         LocSV = Svss*(1.0D0-EXP(-SR_tmp*time_inc/RS_sl0))+EXP(-SR_tmp*time_inc/RS_sl0)*SV0
     END SELECT  


### PR DESCRIPTION
As Alice asked, we should discuss how to address the NaN issue in FL103. Is adding a waterlevel for state variable (LocSV) a proper solution to this? This is an emergent issue for James but could happen to everyone.