### PR TITLE
precise tutorial with python3, precise paths

### DIFF
--- a/Documentation/adapting-the-cad-model-resolution-using-gocad.rst
+++ b/Documentation/adapting-the-cad-model-resolution-using-gocad.rst
@@ -12,7 +12,7 @@ The coarse topography has been created using the "hole" and "subsample"
 options of the script create_surface_from_structured_grid.py, using the following
 command line:
 
-``python create_surface_from_structured_grid.py --subsample 8 --objectname topoE --hole 89.5  97.0 1.5 14.5 structuredPointSet.xyz topoExt.ts --proj EPSG:32646``
+``python3 create_surface_from_structured_grid.py --subsample 8 --objectname topoE --hole 89.5  97.0 1.5 14.5 structuredPointSet.xyz topoExt.ts --proj EPSG:32646``
 
 Now we want to seal the gap between both surfaces. To do that we will
 create surfaces "from 2 surface borders". To facilitate the work of

--- a/Documentation/cad-models.rst
+++ b/Documentation/cad-models.rst
@@ -63,7 +63,7 @@ Here is a commented example of our use of Gdal to create a ts surface from a hig
    gdal_translate -of netCDF -co "FOMRAT=NC4" data/file250.tif data/file250.nc
    #python script from 'creating_geometric_model'
    #The specified hole allows to use algorithm described in 'remeshing the topography'
-   python create_surface_from_rectilinear_grid.py data/file250.nc data/file250.stl --proj "+init=EPSG:32645" --hole 84.8 86.5 27.1 28.3
+   python3 create_surface_from_rectilinear_grid.py data/file250.nc data/file250.stl --proj "+init=EPSG:32645" --hole 84.8 86.5 27.1 28.3
 
 
 Topographic data coarsening with SimModeler

--- a/Documentation/generating-a-cad-model-using-gocad-basic-tutorial.rst
+++ b/Documentation/generating-a-cad-model-using-gocad-basic-tutorial.rst
@@ -19,10 +19,10 @@ Triangulating structured point clouds
 
 | First, we construct triangulated surfaces from the structured point
   clouds using create_surface_from_structured_grid.py
-| ``python create_surface_from_structured_grid.py --NX 161 topography.dat topography.ts``
+| ``python3 create_surface_from_structured_grid.py --NX 161 topography.dat topography.ts``
 | If the points of the cloud share the same coordinates along a row or a
   column, then the -NX option can be omitted
-| ``python create_surface_from_structured_grid.py topography.dat topography.ts``
+| ``python3 create_surface_from_structured_grid.py topography.dat topography.ts``
 
 CAD model generation in GOCAD
 -----------------------------
@@ -85,7 +85,7 @@ A third option for creating the side surface
 | To trim the tube at the requested depth, we export the curve ctopo in
   a pl file (File > Export > Gocad ASCII >ctopo.pl) and we use the
   script change_depth_pl_curve.py:
-| ``python change_depth_pl_curve.py ctopo.pl ctopo_new.pl --depth 60e3``
+| ``python3 change_depth_pl_curve.py ctopo.pl ctopo_new.pl --depth 60e3``
 | Then we import ctopo_new.pl into the project, create the bottom
   surface of the box from it (using Surface > New > Closed Curved). We
   can then intersected this new surface with the tube, and remove the
@@ -99,7 +99,7 @@ and we can export the CAD surface in a ts format.
 
 | File > Export > Gocad ASCII > choose a filename (example test.ts).
 | Now let's convert the ts file to stl using convertTs.py:
-| ``convertTs.py test.ts``
+| ``python3 convertTs.py test.ts``
 | The --merged option merges all surfaces in a single stl 'solid'. If
   not set, each Gocad surface will be isolated into a different stl
   'solid'. Each surface will then be viewed as a different entity by

--- a/Documentation/remeshing-the-topography.rst
+++ b/Documentation/remeshing-the-topography.rst
@@ -17,7 +17,7 @@ Using the script create_surface_from_rectilinear_grid.py, available
 we will downsample the data overall, project them and isolate a square
 region away from which a fine discretization is not necessary.
 
-| ``python create_surface_from_rectilinear_grid.py data/GEBCO_2014_2D_90.0_1.5_97.0_14.5.nc  trash.stl --subsample 2 --proj EPSG:32646  --hole 94 95 8 10``
+| ``python3 create_surface_from_rectilinear_grid.py data/GEBCO_2014_2D_90.0_1.5_97.0_14.5.nc  trash.stl --subsample 2 --proj EPSG:32646  --hole 94 95 8 10``
 | Now we can import the data in SimModeler5 (the version is important,
   as SimModeler4 does not have the ABAQUS 2D export):
 | File > Import discrete Data > uncheck all.
@@ -26,7 +26,7 @@ region away from which a fine discretization is not necessary.
 | |meshed topography| The mesh can then be exported:
 | File > Export mesh > ABAQUS 2D > test.inp (for example).
 | We finally convert the inp file to a ts file readable by gocad using:
-| ``python convertInp.py test.inp --isolate``
+| ``python3 convertInp.py test.inp --isolate``
 
 .. |topography in SimModeler| image:: LatexFigures/fine2coarse2.png
 .. |meshed topography| image:: LatexFigures/fine2coarse.png

--- a/Documentation/simmodelerCAD-workflow.rst
+++ b/Documentation/simmodelerCAD-workflow.rst
@@ -21,7 +21,7 @@ We then project the data (see :ref:`On the use of projections` for the choice of
 
 .. code-block:: bash
 
-   python SeisSol/Meshing/creating_geometric_models/create_surface_from_rectilinear_grid.py --proj '+init=EPSG:23839' data/GEBCO_2014_2D_118.1904_-2.4353_121.6855_1.0113.nc bathy.stl
+   python3 SeisSol/Meshing/creating_geometric_models/create_surface_from_rectilinear_grid.py --proj '+init=EPSG:23839' data/GEBCO_2014_2D_118.1904_-2.4353_121.6855_1.0113.nc bathy.stl
 
 We then load the stl file into SimModeler
 
@@ -84,9 +84,9 @@ We therefore generate the faults using:
 .. code-block:: bash
 
     dx=0.5e3
-    python SeisSol/Meshing/creating_geometric_models/create_fault_from_trace.py ExampleFiles/SimModeler_workflow/segmentSouth_d90_long.dat 0 90 --dd $dx --maxdepth 16e3 --extend 4e3
-    python SeisSol/Meshing/creating_geometric_models/create_fault_from_trace.py ExampleFiles/SimModeler_workflow/smootherNorthBend.dat 0 65 --dd $dx --maxdepth 16e3 --extend 4e3
-    python SeisSol/Meshing/creating_geometric_models/create_fault_from_trace.py ExampleFiles/SimModeler_workflow/segmentBayAndConnectingFault.dat 2 ExampleFiles/SimModeler_workflow/segmentBayAndConnectingFaultDip.dat --dd $dx --maxdepth 16e3 --extend 4e3
+    python3 SeisSol/Meshing/creating_geometric_models/create_fault_from_trace.py SeisSol/Meshing/creating_geometric_models/ExampleFiles/SimModeler_workflow/segmentSouth_d90_long.dat 0 90 --dd $dx --maxdepth 16e3 --extend 4e3
+    python3 SeisSol/Meshing/creating_geometric_models/create_fault_from_trace.py SeisSol/Meshing/creating_geometric_models/ExampleFiles/SimModeler_workflow/smootherNorthBend.dat 0 65 --dd $dx --maxdepth 16e3 --extend 4e3
+    python3 SeisSol/Meshing/creating_geometric_models/create_fault_from_trace.py SeisSol/Meshing/creating_geometric_models/ExampleFiles/SimModeler_workflow/segmentBayAndConnectingFault.dat 2 SeisSol/Meshing/creating_geometric_models/ExampleFiles/SimModeler_workflow/segmentBayAndConnectingFaultDip.dat --dd $dx --maxdepth 16e3 --extend 4e3
 
 
 Mutual surface intersection


### PR DESCRIPTION
Small PR that precises the tutorials:

- use python3 instead of python when calling the cad scripts 
- precise path to Examples

(or maybe it would be preferable to add a shebang (`#!/usr/bin/env python3`) to all these scripts?)