### PR TITLE
Thomas/nan info sources

### DIFF
--- a/Documentation/supermuc.rst
+++ b/Documentation/supermuc.rst
@@ -123,6 +123,20 @@ set compiler options, run cmake, and compile with:
    CC=mpicc CXX=mpiCC FC=mpif90  cmake -DCOMMTHREAD=ON -DNUMA_AWARE_PINNING=ON -DASAGI=ON -DCMAKE_BUILD_TYPE=Release -DHOST_ARCH=skx -DPRECISION=single -DORDER=4 -DCMAKE_INSTALL_PREFIX=$(pwd)/build-release -DGEMM_TOOLS_LIST=LIBXSMM,PSpaMM -DPSpaMM_PROGRAM=~/bin/pspamm.py ..
    make -j 48
 
+Note that to use sanitzer (https://en.wikipedia.org/wiki/AddressSanitizer), SeisSol needs to be compiled with gcc.
+For that modules and compiler need to be switched:
+
+::
+    module switch netcdf-hdf5-all netcdf-hdf5-all/4.7_hdf5-1.8-gcc8-impi
+    module unload intel-mpi intel
+    module load intel-mpi/2019-gcc
+    module switch gcc gcc/9
+    export CC=mpigcc
+    export CXX=mpigxx
+    export FC=mpifc
+
+Then cmake (without ``CC=mpicc CXX=mpiCC FC=mpif90``) on a new build folder.
+
 Running SeisSol
 ---------------
 

--- a/Documentation/supermuc.rst
+++ b/Documentation/supermuc.rst
@@ -136,6 +136,7 @@ For that modules and compiler need to be switched:
     export FC=mpifc
 
 Then cmake (without ``CC=mpicc CXX=mpiCC FC=mpif90``) on a new build folder.
+To enable sanitizer, add `-DADDRESS_SANITIZER_DEBUG=ON` to the argument list of cmake, and change the `CMAKE_BUILD_TYPE` to `RelWithDebInfo` or `Debug`.
 
 Running SeisSol
 ---------------

--- a/src/Reader/readpar.f90
+++ b/src/Reader/readpar.f90
@@ -316,7 +316,7 @@ CONTAINS
     EQN%Anelasticity = Anelasticity
     SELECT CASE(Anelasticity)
     CASE(0)
-      logInfo(*) 'No attenuation assumed. '
+      logInfo0(*) 'No attenuation assumed. '
       EQN%nAneMaterialVar = 3
       EQN%nMechanisms    = 0
       EQN%nAneFuncperMech= 0
@@ -330,12 +330,13 @@ CONTAINS
       EQN%nBackgroundVar = 3
 #endif
     CASE(1)
-       logInfo(*) 'Viscoelastic attenuation assumed ... '
+       logInfo0(*) 'Viscoelastic attenuation assumed ... '
        EQN%nAneMaterialVar = 5        ! rho, mu, lambda, Qp, Qs
        EQN%nMechanisms = NUMBER_OF_RELAXATION_MECHANISMS
        IF(EQN%Anisotropy.NE.2)   THEN
-         EQN%nAneFuncperMech = 6                                                    !
-         logInfo(*) '... using ', EQN%nAneFuncperMech,' anelastic functions per Mechanism.'                                                   !
+         EQN%nAneFuncperMech = 6
+         logInfo0(*) '... using ', NUMBER_OF_RELAXATION_MECHANISMS,' mechanisms.'
+         logInfo0(*) '... using ', EQN%nAneFuncperMech,' anelastic functions per mechanism.'
        ENDIF
        EQN%nVarTotal = EQN%nVar + EQN%nAneFuncperMech * EQN%nMechanisms
        EQN%nBackgroundVar  = 3 + EQN%nMechanisms * 4
@@ -348,10 +349,10 @@ CONTAINS
     !
       SELECT CASE(Adjoint)
       CASE(0)
-         logInfo(*) 'No adjoint wavefield generated. '
+         logInfo0(*) 'No adjoint wavefield generated. '
          EQN%Adjoint = Adjoint
       CASE(1)
-         logInfo(*) 'Adjoint wavefield simultaneously generated. '
+         logInfo0(*) 'Adjoint wavefield simultaneously generated. '
          EQN%Adjoint = Adjoint
       CASE DEFAULT
         logError(*) 'Choose 0, 1 as adjoint wavefield assumption. '
@@ -361,13 +362,13 @@ CONTAINS
     EQN%Anisotropy = Anisotropy
     SELECT CASE(Anisotropy)
     CASE(0)
-      logInfo(*) 'Isotropic material is assumed. '
+      logInfo0(*) 'Isotropic material is assumed. '
       EQN%nNonZeroEV = 3
     CASE(1)
       IF(Anelasticity.EQ.1) THEN
         logError(*) 'Anelasticity does not work together with Anisotropy'
       END IF
-      logInfo(*) 'Full triclinic material is assumed. '
+      logInfo0(*) 'Full triclinic material is assumed. '
       EQN%nBackgroundVar = 22
       EQN%nNonZeroEV = 3
     CASE DEFAULT
@@ -610,12 +611,13 @@ CONTAINS
      logInfo(*) '| '
      logInfo(*) 'Record points for DR are allocated'
      logInfo(*) 'Output interval:',DISC%DynRup%DynRup_out_atPickpoint%printtimeinterval,'.'
+     logInfo0(*) 'Number of pickPoints = ', nOutPoints
 
      ALLOCATE(X(DISC%DynRup%DynRup_out_atPickpoint%nOutPoints))
      ALLOCATE(Y(DISC%DynRup%DynRup_out_atPickpoint%nOutPoints))
      ALLOCATE(Z(DISC%DynRup%DynRup_out_atPickpoint%nOutPoints))
 
-      logInfo(*) ' Pickpoints read from ', TRIM(PPFileName)
+      logInfo0(*) ' Pickpoints read from ', TRIM(PPFileName)
       CALL OpenFile(                                 &
             UnitNr       = IO%UNIT%other01         , &
             Name         = PPFileName              , &
@@ -2759,9 +2761,9 @@ ALLOCATE( SpacePositionx(nDirac), &
       !                                                                        !
       SELECT CASE(IO%Format)
       case(6)
-         logInfo0(*) 'Output data is in XDMF format (new implementation)'
+         logInfo0(*) 'Volume output is in XDMF format (new implementation)'
       case(10)
-         logInfo0(*) 'Output data is disabled'
+         logInfo0(*) 'Volume output is disabled'
       CASE DEFAULT
          logError(*) 'print_format must be {6,10}'
          call exit(134)
@@ -2875,7 +2877,7 @@ ALLOCATE( SpacePositionx(nDirac), &
            ! we don't want output, so avoid confusing time stepping by setting
            ! plot interval to "infinity"
            IO%outInterval%TimeInterval = 1E99
-           logInfo0(*) 'No output (FORMAT=10) specified, delta T set to: ', IO%OutInterval%TimeInterval
+           logInfo(*) 'No volume output specified (FORMAT=10), delta T set to: ', IO%OutInterval%TimeInterval
          ELSE
            IO%outInterval%TimeInterval = TimeInterval          !
            logInfo0(*) 'Output data are generated at delta T= ', IO%OutInterval%TimeInterval
@@ -2914,11 +2916,11 @@ ALLOCATE( SpacePositionx(nDirac), &
        ENDIF
 
      IO%nRecordPoint = nRecordPoints  ! number of points to pick temporal signal
-     logInfo(*) 'Number of Record Points = ', IO%nRecordPoint
+     logInfo0(*) 'Number of Record Points = ', IO%nRecordPoint
      ALLOCATE( X(IO%nRecordPoint), Y(IO%nRecordPoint), Z(IO%nRecordPoint) )
       ! Read the single record points
       IF (nRecordPoints .GT. 0) THEN
-         logInfo(*) 'Record Points read from ', TRIM(RFileName)
+         logInfo0(*) 'Record Points read from ', TRIM(RFileName)
          CALL OpenFile(                                 &
                UnitNr       = IO%UNIT%other01         , &
                Name         = RFileName               , &
@@ -2928,10 +2930,10 @@ ALLOCATE( SpacePositionx(nDirac), &
          DO i = 1,nRecordPoints
             READ(IO%UNIT%other01,*) X(i), Y(i), Z(i)
 
-               logInfo0(*) 'in point :'                             !
-               logInfo0(*) 'x = ', X(i)         !
-               logInfo0(*) 'y = ', Y(i)         !
-               logInfo0(*) 'z = ', Z(i)         !
+               logInfo(*) 'in point :'                             !
+               logInfo(*) 'x = ', X(i)         !
+               logInfo(*) 'y = ', Y(i)         !
+               logInfo(*) 'z = ', Z(i)         !
 
          ENDDO
          !
@@ -3077,23 +3079,23 @@ ALLOCATE( SpacePositionx(nDirac), &
       SELECT CASE(Refinement)
          CASE(0)
 
-            logInfo0(*) 'Refinement is disabled'
+            logInfo0(*) 'Refinement for volume output is disabled'
 
          CASE(1)
 
-             logInfo0(*) 'Refinement strategy is Face Extraction :  4 subcells per cell'
+             logInfo0(*) 'Refinement strategy for volume output is Face Extraction :  4 subcells per cell'
 
          CASE(2)
 
-             logInfo0(*) 'Refinement strategy is Equal Face Area : 8 subcells per cell'
+             logInfo0(*) 'Refinement strategy for volume output is Equal Face Area : 8 subcells per cell'
 
          CASE(3)
 
-             logInfo0(*) 'Refinement strategy is Equal Face Area and Face Extraction : 32 subcells per cell'
+             logInfo0(*) 'Refinement strategy for volume output is Equal Face Area and Face Extraction : 32 subcells per cell'
 
          CASE DEFAULT
 
-             logError(*) 'Refinement strategy is N O T supported'
+             logError(*) 'Refinement strategy', Refinement,' for volume output is N O T supported'
              call exit(134)
 
       END SELECT

--- a/src/ResultWriter/WaveFieldWriter.cpp
+++ b/src/ResultWriter/WaveFieldWriter.cpp
@@ -411,11 +411,11 @@ void seissol::writer::WaveFieldWriter::write(double time)
 		real* managedBuffer = async::Module<WaveFieldWriterExecutor,
 				WaveFieldInitParam, WaveFieldParam>::managedBuffer<real*>(nextId);
 		m_variableSubsampler->get(m_dofs, m_map, i, managedBuffer);
-	    for (unsigned int j = 0; j < m_numCells; j++) {
-          if (!std::isfinite(managedBuffer[j])) {
-            logError() << "Detected Inf/NaN in volume output. Aborting.";
-          }
-        }
+		for (unsigned int j = 0; j < m_numCells; j++) {
+			if (!std::isfinite(managedBuffer[j])) {
+ 				logError() << "Detected Inf/NaN in volume output. Aborting.";
+			}
+		}
 		sendBuffer(nextId, m_numCells*sizeof(real));
 
 		nextId++;

--- a/src/ResultWriter/WaveFieldWriter.cpp
+++ b/src/ResultWriter/WaveFieldWriter.cpp
@@ -411,7 +411,11 @@ void seissol::writer::WaveFieldWriter::write(double time)
 		real* managedBuffer = async::Module<WaveFieldWriterExecutor,
 				WaveFieldInitParam, WaveFieldParam>::managedBuffer<real*>(nextId);
 		m_variableSubsampler->get(m_dofs, m_map, i, managedBuffer);
-
+	    for (unsigned int j = 0; j < m_numCells; j++) {
+          if (!std::isfinite(managedBuffer[j])) {
+            logError() << "Detected Inf/NaN in volume output. Aborting.";
+          }
+        }
 		sendBuffer(nextId, m_numCells*sizeof(real));
 
 		nextId++;

--- a/src/SourceTerm/Manager.cpp
+++ b/src/SourceTerm/Manager.cpp
@@ -419,6 +419,19 @@ void seissol::sourceterm::Manager::loadSourcesFromNRF(  char const*             
   }
   delete[] contained;
 
+  // Checking that all sources are within the domain
+  int globalnumSources = numSources;
+#ifdef USE_MPI
+  MPI_Reduce(&numSources, &globalnumSources, 1, MPI_INT, MPI_SUM, 0, seissol::MPI::mpi.comm());
+#endif
+
+  if (rank==0) {
+     int numSourceOutside = nrf.source - globalnumSources;
+     if (numSourceOutside > 0) {
+        logError() << nrf.source - globalnumSources <<" point sources are outside the domain.";
+     }
+  }
+
   logInfo(rank) << "Mapping point sources to LTS cells...";
   mapPointSourcesToClusters(meshIds, numSources, ltsTree, lts, ltsLut);
   

--- a/src/seissolxx.f90
+++ b/src/seissolxx.f90
@@ -105,20 +105,20 @@ open(FORTRAN_STDERR, recl=FORTRAN_LINE_SIZE)
    SELECT CASE(domain%MPI%real_kind)
    CASE(4)
      logInfo0(*) 'Single precision used for real.'
-     logInfo0(*) 'Setting MPI_AUTODOUBLE to MPI_REAL'
+     logInfo(*) 'Setting MPI_AUTODOUBLE to MPI_REAL'
      domain%MPI%MPI_AUTO_REAL = MPI_REAL
    CASE(8)
      logInfo0(*) ' Double precision used for real.'
-     logInfo0(*) ' Setting MPI_AUTODOUBLE to MPI_DOUBLE_PRECISION'
+     logInfo(*) ' Setting MPI_AUTODOUBLE to MPI_DOUBLE_PRECISION'
      domain%MPI%MPI_AUTO_REAL = MPI_DOUBLE_PRECISION
    CASE DEFAULT
      logError(*) 'Unknown kind ', domain%MPI%real_kind
      call MPI_ABORT(domain%MPI%commWorld, 134)
    END SELECT
-   logInfo0(*) ' MPI_AUTO_REAL feature initialized. '
+   logInfo(*) ' MPI_AUTO_REAL feature initialized. '
    domain%MPI%MPI_AUTO_INTEGER = 0
    !  
-   logInfo0(*) ' MPI initialization done. '
+   logInfo(*) ' MPI initialization done. '
    logInfo0('(a)') ' <--------------------------------------------------------->'
    WRITE(domain%IO%ErrorFile,'(a,i5.5,a)') 'IRREGULARITIES.', domain%MPI%myrank, '.log'    ! Name der Datei in die Fehler geschrieben werden
 #else


### PR DESCRIPTION
Various small changes I made on Friday when playing with attenuation: 

1. gcc build
I documented the gcc build of seissol on supermuc

2. output log
I moved stuff from logInfo to logInfo0 and inversely.

3. nan checker in wavefield output
I added such checker to catch nan more rapidely

4. check that all sources of a nrf file are within the domain and rise error if not (save CPUh).