### PR TITLE
print Mw: change logInfo to explicit logInfo0DR

### DIFF
--- a/src/ResultWriter/magnitude_output.f90
+++ b/src/ResultWriter/magnitude_output.f90
@@ -149,7 +149,8 @@ CONTAINS
         !
         ! Write output
         WRITE(UNIT_MAG,*) magnitude0
-        logInfo(*) 'seismic moment', magnitude0, 'Mw', 2./3.*log10(magnitude0)-6.07
+        write(FORTRAN_STDOUT, '(A, I8, A)', advance='no') 'Rank: ', MPI%myrank, ' | Info    |'
+        write(FORTRAN_STDOUT,*) 'seismic moment', magnitude0, 'Mw', 2./3.*log10(magnitude0)-6.07
         CLOSE( UNIT_Mag )
 
     ENDIF 


### PR DESCRIPTION
What we need for printing Mw is a loginfo0 for the DR subgroup.
The current implementation (logInfo) does not print with the default:
```
LOG_LEVEL                        warning                                                                                                                                                                                                      
 LOG_LEVEL_MASTER                 info                                                                                                                                                                                                         
```
loginfo0 would not print either if rank 0 is not in the DR subgroup.
So I propose the following workaround.