### PR TITLE
Add -qopt-zmm-usage=high for skx

### DIFF
--- a/cmake/cpu_arch_flags.cmake
+++ b/cmake/cpu_arch_flags.cmake
@@ -32,7 +32,7 @@ function(get_arch_flags architecture compiler)
     # Skylake cpu architecture
     elseif ("${HOST_ARCH}" STREQUAL "skx")
         if (compiler STREQUAL "Intel")
-            set(CPU_ARCH_FLAGS "-xCORE-AVX512" "-fma" PARENT_SCOPE)
+            set(CPU_ARCH_FLAGS "-xCORE-AVX512" "-fma" "-qopt-zmm-usage=high" PARENT_SCOPE)
         elseif(compiler MATCHES "GNU|Clang")
             set(CPU_ARCH_FLAGS "-march=skylake-avx512" PARENT_SCOPE)
         endif()


### PR DESCRIPTION
This may increase performance by using the zmm registers more aggressively:
https://www.intel.com/content/www/us/en/develop/documentation/cpp-compiler-developer-guide-and-reference/top/compiler-reference/compiler-options/compiler-option-details/advanced-optimization-options/qopt-zmm-usage-qopt-zmm-usage.html

Draft because it is currently untested (and mainly because I do not want to forget that this flag exists!)