### PR TITLE
change variable names of free surface output

### DIFF
--- a/Documentation/free-surface-output.rst
+++ b/Documentation/free-surface-output.rst
@@ -27,8 +27,8 @@ each subtriangle.
 variables
 ---------
 
-   | **u**, **v**, **w**: ground velocities, x y and z components
-   | **U**, **V**, **W**: ground displacements, x y and z components
+   | **v1**, **v2**, **v3**: ground velocities, x y and z components
+   | **u1**, **u2**, **u3**: ground displacements, x y and z components
 
 Additionally, the writer outputs a quantity called "locationFlag", which has the values
 0 and 1 when at the elastic or acoustic side of an elastic-acoustic interface.

--- a/src/ResultWriter/FreeSurfaceWriterExecutor.cpp
+++ b/src/ResultWriter/FreeSurfaceWriterExecutor.cpp
@@ -98,5 +98,5 @@ void seissol::writer::FreeSurfaceWriterExecutor::execInit(const async::ExecInfo 
 }
 
 char const * const seissol::writer::FreeSurfaceWriterExecutor::LABELS[] = {
-	"u", "v", "w", "U", "V", "W", "locationFlag"
+	"v1", "v2", "v3", "u1", "u2", "u3", "locationFlag"
 };


### PR DESCRIPTION
Calling surface velocity uvw and displacements UVW might pose a problem for case insensitive operating systems.
(Windows, and maybe Mac. Note that Bo and Duo do not have problem with case sensitivity on their mac).