### PR TITLE
Fix include type for easi headers

### DIFF
--- a/src/Initializer/tree/InterfaceHelper.hpp
+++ b/src/Initializer/tree/InterfaceHelper.hpp
@@ -40,7 +40,7 @@
 #ifndef INITIALIZER_INTERFACEHELPER_H_
 #define INITIALIZER_INTERFACEHELPER_H_
 
-#include <easi/util/Magic.h>
+#include "easi/util/Magic.h"
 
 namespace seissol {
   template<typename X>

--- a/src/Reader/AsagiReader.h
+++ b/src/Reader/AsagiReader.h
@@ -43,7 +43,7 @@
 
 #include "Parallel/MPI.h"
 #include <asagi.h>
-#include <easi/util/AsagiReader.h>
+#include "easi/util/AsagiReader.h"
 
 #include "utils/env.h"
 #include "utils/logger.h"


### PR DESCRIPTION
Otherwise, searches first in system header files and not in sub-
modules

https://stackoverflow.com/a/21594
