### PR TITLE
Optimize computation of gravitational boundary condition

### DIFF
--- a/generated_code/NodalBoundaryConditions.py
+++ b/generated_code/NodalBoundaryConditions.py
@@ -37,6 +37,14 @@ def addKernels(generator, aderdg, include_tensors, matricesDir, dynamicRuptureMe
                         simpleParameterSpace(4),
                         projectToNodalBoundaryRotated)
 
+    projectDerivativeToNodalBoundaryRotated = lambda i, j: aderdg.INodal['kp'] <= aderdg.db.V3mTo2nFace[j]['kl'] \
+                                              * aderdg.dQs[i]['lm'] \
+                                              * aderdg.Tinv['pm']
+
+    generator.addFamily('projectDerivativeToNodalBoundaryRotated',
+                        simpleParameterSpace(aderdg.order, 4),
+                        projectDerivativeToNodalBoundaryRotated)
+
     # To be used as Tinv in flux solver - this way we can save two rotations for
     # Dirichlet boundary, as ghost cell dofs are already rotated
     identity_rotation = np.double(aderdg.transformation_spp())

--- a/generated_code/aderdg.py
+++ b/generated_code/aderdg.py
@@ -263,6 +263,8 @@ class LinearADERDG(ADERDGBase):
                     self.I['kp'] <= power * dQ0['kp'],
                     target=target)
 
+      self.dQs = [dQ0]
+
       for i in range(1,self.order):
         derivativeSum = Add()
         if self.sourceMatrix():
@@ -273,6 +275,7 @@ class LinearADERDG(ADERDGBase):
         derivativeSum = DeduceIndices( self.Q['kp'].indices ).visit(derivativeSum)
         derivativeSum = EquivalentSparsityPattern().visit(derivativeSum)
         dQ = OptionalDimTensor('dQ({})'.format(i), self.Q.optName(), self.Q.optSize(), self.Q.optPos(), qShape, spp=derivativeSum.eqspp(), alignStride=True)
+        self.dQs.append(dQ)
 
         generator.add(f'{name_prefix}derivative({i})', dQ['kp'] <= derivativeSum, target=target)
         generator.add(f'{name_prefix}derivativeTaylorExpansion({i})',

--- a/generated_code/viscoelastic2.py
+++ b/generated_code/viscoelastic2.py
@@ -160,6 +160,7 @@ class Viscoelastic2ADERDG(ADERDGBase):
   def addTime(self, generator, targets):
     qShape = (self.numberOf3DBasisFunctions(), self.numberOfQuantities())
     dQ = [OptionalDimTensor('dQ({})'.format(d), self.Q.optName(), self.Q.optSize(), self.Q.optPos(), qShape, alignStride=True) for d in range(self.order)]
+    self.dQs = dQ
     dQext = [OptionalDimTensor('dQext({})'.format(d), self.Q.optName(), self.Q.optSize(), self.Q.optPos(), self._qShapeExtended, alignStride=True) for d in range(self.order)]
     dQane = [OptionalDimTensor('dQane({})'.format(d), self.Q.optName(), self.Q.optSize(), self.Q.optPos(), self._qShapeAnelastic, alignStride=True) for d in range(self.order)]
 

--- a/src/Equations/elastic/Kernels/GravitationalFreeSurfaceBC.cpp
+++ b/src/Equations/elastic/Kernels/GravitationalFreeSurfaceBC.cpp
@@ -7,4 +7,38 @@ double getGravitationalAcceleration() {
   return SeisSol::main.getGravitationSetup().acceleration;
 }
 
+std::pair<long long, long long>
+GravitationalFreeSurfaceBc::getFlopsDisplacementFace(unsigned int face, FaceType faceType) {
+  long long hardwareFlops = 0;
+  long long nonZeroFlops = 0;
+
+  constexpr auto numberOfNodes = nodal::tensor::nodes2D::Shape[0];
+
+  // initialize integral of displacement
+  hardwareFlops += 1 * numberOfNodes;
+  nonZeroFlops += 1 * numberOfNodes;
+
+  // Note: This neglects roughly 10 * CONVERGENCE_ORDER * numNodes2D flops
+  // Before adjusting the range of the loop, check range of loop in computation!
+  for (int order = 1; order < CONVERGENCE_ORDER + 1; ++order) {
+#ifdef USE_ELASTIC
+    constexpr auto flopsPerQuadpoint =
+        4 + // Computing coefficient
+        6 + // Updating displacement
+        2; // Updating integral of displacement
+#else
+    constexpr auto flopsPerQuadpoint = 0;
+#endif
+    constexpr auto flopsUpdates = flopsPerQuadpoint * numberOfNodes;
+
+    nonZeroFlops += kernel::projectDerivativeToNodalBoundaryRotated::nonZeroFlops(order - 1, face) + flopsUpdates;
+    hardwareFlops += kernel::projectDerivativeToNodalBoundaryRotated::hardwareFlops(order - 1, face) + flopsUpdates;
+  }
+
+  // Two rotations: One to face-aligned, one to global
+  hardwareFlops += 2 * kernel::rotateFaceDisplacement::HardwareFlops;
+  nonZeroFlops += 2 * kernel::rotateFaceDisplacement::NonZeroFlops;
+
+  return {nonZeroFlops, hardwareFlops};
+}
 } // namespace seissol

--- a/src/Equations/elastic/Kernels/GravitationalFreeSurfaceBC.cpp
+++ b/src/Equations/elastic/Kernels/GravitationalFreeSurfaceBC.cpp
@@ -18,7 +18,6 @@ GravitationalFreeSurfaceBc::getFlopsDisplacementFace(unsigned int face, FaceType
   hardwareFlops += 1 * numberOfNodes;
   nonZeroFlops += 1 * numberOfNodes;
 
-  // Note: This neglects roughly 10 * CONVERGENCE_ORDER * numNodes2D flops
   // Before adjusting the range of the loop, check range of loop in computation!
   for (int order = 1; order < CONVERGENCE_ORDER + 1; ++order) {
 #ifdef USE_ELASTIC

--- a/src/Equations/elastic/Kernels/GravitationalFreeSurfaceBC.h
+++ b/src/Equations/elastic/Kernels/GravitationalFreeSurfaceBC.h
@@ -126,9 +126,11 @@ public:
       projectKernel.dQ(i) = derivatives + derivativesOffsets[i];
     }
 
+#ifdef USE_ELASTIC
     const double rho = materialData.local.rho;
     const double g = getGravitationalAcceleration(); // [m/s^2]
     const double Z = std::sqrt(materialData.local.lambda * rho) ;
+#endif
 
     // Note: Probably need to increase CONVERGENCE_ORDER by 1 here!
     for (int order = 1; order < CONVERGENCE_ORDER+1; ++order) {
@@ -150,7 +152,11 @@ public:
         const auto wInside = dofsFaceNodal(i, uIdx + 2);
         const auto pressureInside = dofsFaceNodal(i, pIdx);
 
+#ifdef USE_ELASTIC
         const double curCoeff = uInside - (1.0/Z) * (rho * g * prevCoefficients[i] + pressureInside);
+#else
+        const double curCoeff = uInside;
+#endif
         prevCoefficients[i] = curCoeff;
 
         rotatedFaceDisplacement(i, 0) += factorEvaluated * curCoeff;

--- a/src/Equations/elastic/Kernels/Time.cpp
+++ b/src/Equations/elastic/Kernels/Time.cpp
@@ -519,6 +519,39 @@ void seissol::kernels::Time::computeBatchedTaylorExpansion(real time,
 #endif
 }
 
+void seissol::kernels::Time::computeDerivativeTaylorExpansion(real time,
+                                                     real expansionPoint,
+                                                     real const*  timeDerivatives,
+                                                     real timeEvaluated[tensor::Q::size()],
+                                                     unsigned order) {
+  /*
+   * assert alignments.
+   */
+  assert( ((uintptr_t)timeDerivatives)  % ALIGNMENT == 0 );
+  assert( ((uintptr_t)timeEvaluated)    % ALIGNMENT == 0 );
+
+  // assert that this is a forward evaluation in time
+  assert( time >= expansionPoint );
+
+  real deltaT = time - expansionPoint;
+
+  static_assert(tensor::I::size() == tensor::Q::size(), "Sizes of tensors I and Q must match");
+
+  kernel::derivativeTaylorExpansion intKrnl;
+  intKrnl.I = timeEvaluated;
+  for (unsigned i = 0; i < yateto::numFamilyMembers<tensor::dQ>(); ++i) {
+    intKrnl.dQ(i) = timeDerivatives + m_derivativesOffsets[i];
+  }
+  intKrnl.power = 1.0;
+
+  // iterate over time derivatives
+  for(unsigned derivative = order; derivative < CONVERGENCE_ORDER; ++derivative) {
+    intKrnl.execute(derivative);
+    intKrnl.power *= deltaT / real(derivative+1);
+  }
+}
+
+
 void seissol::kernels::Time::flopsTaylorExpansion(long long& nonZeroFlops, long long& hardwareFlops) {
   // reset flops
   nonZeroFlops = 0; hardwareFlops = 0;

--- a/src/Equations/elastic/Kernels/Time.cpp
+++ b/src/Equations/elastic/Kernels/Time.cpp
@@ -130,7 +130,8 @@ void seissol::kernels::Time::setHostGlobalData(GlobalData const* global) {
 
   m_krnlPrototype.kDivMT = global->stiffnessMatricesTransposed;
 
-  projectRotatedKrnlPrototype.V3mTo2nFace = global->V3mTo2nFace;
+  projectDerivativeToNodalBoundaryRotated.V3mTo2nFace = global->V3mTo2nFace;
+
 #endif //USE_STP
 }
 
@@ -230,10 +231,10 @@ void seissol::kernels::Time::computeAder(double i_timeStepWidth,
     for (unsigned face = 0; face < 4; ++face) {
       if (data.faceDisplacements[face] != nullptr
           && data.cellInformation.faceTypes[face] == FaceType::freeSurfaceGravity) {
-        std::fill(tmp.nodalAvgDisplacements[face].begin(), tmp.nodalAvgDisplacements[face].end(), 0.0);
+        //std::fill(tmp.nodalAvgDisplacements[face].begin(), tmp.nodalAvgDisplacements[face].end(), 0.0);
         bc.evaluate(
             face,
-            projectRotatedKrnlPrototype,
+            projectDerivativeToNodalBoundaryRotated,
             data.boundaryMapping[face],
             data.faceDisplacements[face],
             tmp.nodalAvgDisplacements[face].data(),
@@ -561,4 +562,8 @@ void seissol::kernels::Time::flopsTaylorExpansion(long long& nonZeroFlops, long 
     nonZeroFlops  += kernel::derivativeTaylorExpansion::nonZeroFlops(der);
     hardwareFlops += kernel::derivativeTaylorExpansion::hardwareFlops(der);
   }
+}
+
+unsigned int* seissol::kernels::Time::getDerivativesOffsets() {
+  return m_derivativesOffsets;
 }

--- a/src/Equations/elastic/Kernels/Time.cpp
+++ b/src/Equations/elastic/Kernels/Time.cpp
@@ -231,7 +231,6 @@ void seissol::kernels::Time::computeAder(double i_timeStepWidth,
     for (unsigned face = 0; face < 4; ++face) {
       if (data.faceDisplacements[face] != nullptr
           && data.cellInformation.faceTypes[face] == FaceType::freeSurfaceGravity) {
-        //std::fill(tmp.nodalAvgDisplacements[face].begin(), tmp.nodalAvgDisplacements[face].end(), 0.0);
         bc.evaluate(
             face,
             projectDerivativeToNodalBoundaryRotated,

--- a/src/Equations/elastic/Kernels/TimeBase.h
+++ b/src/Equations/elastic/Kernels/TimeBase.h
@@ -92,7 +92,8 @@ class seissol::kernels::TimeBase {
 #else    
     kernel::derivative m_krnlPrototype;
 #endif
-    kernel::projectToNodalBoundaryRotated projectRotatedKrnlPrototype;
+    kernel::projectDerivativeToNodalBoundaryRotated projectDerivativeToNodalBoundaryRotated;
+
 
   /*
    *! Offsets of the derivatives.
@@ -115,6 +116,7 @@ public:
      * Constructor, which initializes the time kernel.
      **/
     TimeBase();
+
 };
 
 #endif

--- a/src/Kernels/Time.h
+++ b/src/Kernels/Time.h
@@ -131,6 +131,13 @@ class seissol::kernels::Time : public TimeBase {
                                  real const*  timeDerivatives,
                                  real         timeEvaluated[tensor::Q::size()] );
 
+    void computeDerivativeTaylorExpansion(real time,
+                                          real expansionPoint,
+                                          real const*  timeDerivatives,
+                                          real timeEvaluated[tensor::Q::size()],
+                                          unsigned derivativeOrder);
+
+
   void computeBatchedTaylorExpansion(real time,
                                      real expansionPoint,
                                      real** timeDerivatives,

--- a/src/Kernels/Time.h
+++ b/src/Kernels/Time.h
@@ -144,7 +144,9 @@ class seissol::kernels::Time : public TimeBase {
                                      real** timeEvaluated,
                                      size_t numElements);
 
-    void flopsTaylorExpansion(long long& nonZeroFlops, long long& hardwareFlops);
+  void flopsTaylorExpansion(long long& nonZeroFlops, long long& hardwareFlops);
+
+  unsigned int* getDerivativesOffsets();
 };
 
 #endif

--- a/src/Solver/time_stepping/TimeCluster.cpp
+++ b/src/Solver/time_stepping/TimeCluster.cpp
@@ -986,8 +986,7 @@ void seissol::time_stepping::TimeCluster::computeLocalIntegrationFlops(
       if (cellInformation->faceTypes[face] == FaceType::freeSurfaceGravity) {
         const auto [nonZeroFlopsDisplacement, hardwareFlopsDisplacement] =
         GravitationalFreeSurfaceBc::getFlopsDisplacementFace(face,
-                                                             cellInformation[cell].faceTypes[face],
-                                                             m_timeKernel);
+                                                             cellInformation[cell].faceTypes[face]);
         nonZeroFlops += nonZeroFlopsDisplacement;
         hardwareFlops += hardwareFlopsDisplacement;
       }


### PR DESCRIPTION
Old way: Use RK to compute the ODE that defines the displacement
New way: Use ADER-magic to compute the Taylor series of the displacement directly and evaluate it at end of timestep and compute integral of displacement. Does this in-place without storing all coefficients. A lot faster, and of arbitrary order.

Draft because: Needs to be tested for realistic application, flop counter needs to be checked (@sebwolf-de if you're bored ;)).

I've already verified that it works for convergence tests. I get the exact same results but faster.