### PR TITLE
Fix 492

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -19,9 +19,6 @@
 [submodule "submodules/yateto"]
 	path = submodules/yateto
 	url = ../../SeisSol/yateto.git
-[submodule "submodules/eigen3"]
-	path = submodules/eigen3
-	url = ../../eigenteam/eigen-git-mirror
 [submodule "submodules/Device"]
 	path = submodules/Device
 	url = ../../SeisSol/Device.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -287,14 +287,17 @@ if (ADDRESS_SANITIZER_DEBUG)
 endif()
 
 
-# Note: it is better to include `eigen3` `async` as
+# Note: it is better to include `async` as
 # system headers because they emit lot's of warnings
 # from clang. Most of them are issues with respect
 # to overriden virtual methods
 target_include_directories(SeisSol-lib SYSTEM PUBLIC
-  ${CMAKE_CURRENT_SOURCE_DIR}/submodules/eigen3
   ${CMAKE_CURRENT_SOURCE_DIR}/submodules/async
 )
+
+
+find_package(Eigen3 3.4.0 REQUIRED)
+target_include_directories(SeisSol-lib SYSTEM PUBLIC ${EIGEN3_INCLUDE_DIRS})
 
 find_package(yaml-cpp REQUIRED
         PATHS ${CMAKE_CURRENT_BINARY_DIR})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -296,8 +296,8 @@ target_include_directories(SeisSol-lib SYSTEM PUBLIC
 )
 
 
-find_package(Eigen3 3.4.0 REQUIRED)
-target_include_directories(SeisSol-lib SYSTEM PUBLIC ${EIGEN3_INCLUDE_DIRS})
+find_package(Eigen3 3.4 REQUIRED)
+target_link_libraries(SeisSol-lib PUBLIC Eigen3::Eigen)
 
 find_package(yaml-cpp REQUIRED
         PATHS ${CMAKE_CURRENT_BINARY_DIR})

--- a/Documentation/compilation.rst
+++ b/Documentation/compilation.rst
@@ -77,6 +77,21 @@ Installing netCDF
   make install
   cd ..
 
+.. _installing_eigen3:
+
+Installing Eigen3
+-----------------
+
+.. code-block:: bash
+
+   wget https://gitlab.com/libeigen/eigen/-/archive/3.4.0/eigen-3.4.0.tar.gz
+   tar -xf eigen-3.4.0.tar.gz
+   cd eigen-3.4.0
+   mkdir build && cd build
+   cmake .. -DCMAKE_INSTALL_PREFIX=~
+   make install
+   cd ../..
+
 .. _installing_libxsmm:
 
 Installing Libxsmm

--- a/azure-pipelines-seissol-template.yml
+++ b/azure-pipelines-seissol-template.yml
@@ -33,6 +33,10 @@ jobs:
                         cp bin/libxsmm_gemm_generator $HOME/bin
                         export PATH=$HOME/bin:$PATH
                         cd ..
+
+                        wget https://gitlab.com/libeigen/eigen/-/archive/3.4.0/eigen-3.4.0.tar.gz
+                        tar -xf eigen-3.4.0.tar.gz
+                        mkdir eigen3_build && cd eigen3_build && cmake ../eigen-3.4.0 && sudo make install && cd ..
                           
                         git clone --depth 1 --branch v1.0.0 https://github.com/SeisSol/easi.git    
                         mkdir easi_build

--- a/gitlab-cpu-pipeline.yml
+++ b/gitlab-cpu-pipeline.yml
@@ -23,7 +23,6 @@ ci_builder_pre:
         - git submodule set-url submodules/scons-tools https://github.com/TUM-I5/scons-tools.git
         - git submodule set-url submodules/PUML https://github.com/TUM-I5/PUML2.git
         - git submodule set-url submodules/yateto https://github.com/SeisSol/yateto.git
-        - git submodule set-url submodules/eigen3 https://github.com/eigenteam/eigen-git-mirror
         - git submodule set-url submodules/Device https://github.com/SeisSol/Device.git
         - git submodule --quiet update --init --recursive 
         - wget -q https://syncandshare.lrz.de/dl/fiJNAokgbe2vNU66Ru17DAjT/netcdf-4.6.1.tar.gz
@@ -47,6 +46,9 @@ ci_builder_pre:
         - git clone --depth 1 --branch v1.0.0 https://github.com/SeisSol/easi.git &&
           mkdir easi_build && cd easi_build && cmake -DASAGI=OFF -DIMPALAJIT=OFF ../easi && 
           sudo make -j $(nproc) install && cd ..
+        - wget https://gitlab.com/libeigen/eigen/-/archive/3.4.0/eigen-3.4.0.tar.gz
+        - tar -xf eigen-3.4.0.tar.gz
+        - mkdir eigen3_build && cd eigen3_build && cmake ../eigen-3.4.0 && sudo  make install && cd ..
         
 ci_builder_build:
     stage: build

--- a/gitlab-gpu-pipeline.yml
+++ b/gitlab-gpu-pipeline.yml
@@ -25,6 +25,11 @@ gpu_pre_build:
         - echo "GPU model:" $GPU_MODEL
         - nvidia-smi
         - mkdir ./self_usr
+        - wget https://gitlab.com/libeigen/eigen/-/archive/3.4.0/eigen-3.4.0.tar.gz
+        - tar -xf eigen-3.4.0.tar.gz
+        - mkdir eigen-3.4.0/build && cd eigen-3.4.0/build && 
+          cmake .. -DCMAKE_INSTALL_PREFIX=../../self_usr && make -j ($nproc) install 
+          && cd ../..
         - git clone https://github.com/uphoffc/ImpalaJIT.git impalajit &&
           mkdir -p impalajit/build && cd impalajit/build &&
           cmake .. -DCMAKE_INSTALL_PREFIX=../../self_usr -DCMAKE_CXX_FLAGS="-fPIC" &&


### PR DESCRIPTION
* Remove eigen3 as a submodule.
* Search eigen3 dependency with cmake.
* Add documentation on how to install eigen3.
Eigen3 is header only, so installation should not be a problem in general.
I tested this with tpv5...