### PR TITLE
update Building SeisSol on SuperMUC-NG - use double precision

### DIFF
--- a/Documentation/supermuc.rst
+++ b/Documentation/supermuc.rst
@@ -134,7 +134,7 @@ set compiler options, run cmake, and compile with:
 ::
 
    mkdir build-release && cd build-release
-   CC=mpicc CXX=mpiCC FC=mpif90  cmake -DCOMMTHREAD=ON -DNUMA_AWARE_PINNING=ON -DASAGI=ON -DCMAKE_BUILD_TYPE=Release -DHOST_ARCH=skx -DPRECISION=single -DORDER=4 -DCMAKE_INSTALL_PREFIX=$(pwd)/build-release -DGEMM_TOOLS_LIST=LIBXSMM,PSpaMM -DPSpaMM_PROGRAM=~/bin/pspamm.py ..
+   CC=mpicc CXX=mpiCC FC=mpif90  cmake -DCOMMTHREAD=ON -DNUMA_AWARE_PINNING=ON -DASAGI=ON -DCMAKE_BUILD_TYPE=Release -DHOST_ARCH=skx -DPRECISION=double -DORDER=4 -DCMAKE_INSTALL_PREFIX=$(pwd)/build-release -DGEMM_TOOLS_LIST=LIBXSMM,PSpaMM -DPSpaMM_PROGRAM=~/bin/pspamm.py ..
    make -j 48
 
 Note that to use sanitzer (https://en.wikipedia.org/wiki/AddressSanitizer), SeisSol needs to be compiled with gcc.


### PR DESCRIPTION
I adjusted the documentation for compiling SeisSol on SuperMUC-NG (https://seissol.readthedocs.io/en/latest/supermuc.html#building-seissol).

Double precision should be used as default instead of single precision (-DPRECISION=double instead of -DPRECISION=single).