### PR TITLE
improve compilation documentation

### DIFF
--- a/Documentation/asagi.rst
+++ b/Documentation/asagi.rst
@@ -38,19 +38,16 @@ Installing ASAGI
 
 Be careful that the python and gcc package is the same as for the
 compilation of SeisSol in a later step!
-
-example on SuperMuc
-~~~~~~~~~~~~~~~~~~~
-
 First clone ASAGI with:
 
 .. code-block:: bash
 
   git clone git@github.com:TUM-I5/ASAGI
+  # git clone https://github.com/TUM-I5/ASAGI.git
   cd ASAGI
   git submodule update --init
- 
-set compiler options, run cmake, and compile with:
+
+Set compiler options, e.g. for intel compilers on SuperMuc:
 
 .. code-block:: bash
 
@@ -58,9 +55,13 @@ set compiler options, run cmake, and compile with:
   export CXX=mpiCC
   export CC=mpicc
 
+Run cmake, and compile with:
+
+.. code-block:: bash
+
   mkdir build && cd build
   CMAKE_PREFIX_PATH=$NETCDF_BASE
-  cmake .. -DSHARED_LIB=no -DSTATIC_LIB=yes -DNONUMA=on -DCMAKE_INSTALL_PREFIX=$HOME
+  cmake .. -DSHARED_LIB=no -DSTATIC_LIB=yes -DCMAKE_INSTALL_PREFIX=$HOME
   make -j 48
   make install
   (Know errors: 1.Numa could not found - turn off Numa by adding -DNONUMA=on . )

--- a/Documentation/asagi.rst
+++ b/Documentation/asagi.rst
@@ -42,49 +42,29 @@ compilation of SeisSol in a later step!
 example on SuperMuc
 ~~~~~~~~~~~~~~~~~~~
 
--  load the following modules 
+First clone ASAGI with:
 
 .. code-block:: bash
 
-   module load intel intel-mpi
-   module load netcdf-hdf5-all/4.7_hdf5-1.10-intel19-impi
-   module load gcc/9
-   module load cmake/3.16.5
-
--  get the repository
-
-On a cluster without restricted access to outside sources, you could then clone the repository using:
+  git clone git@github.com:TUM-I5/ASAGI
+  cd ASAGI
+  git submodule update --init
+ 
+set compiler options, run cmake, and compile with:
 
 .. code-block:: bash
 
-   git clone --recursive https://github.com/TUM-I5/ASAGI.git
-   
-On supermuc, you have to set up port forwarding as described in :ref:`compile_run_supermuc`.
+  export FC=mpif90
+  export CXX=mpiCC
+  export CC=mpicc
 
-Then you can clone the project with 
+  mkdir build && cd build
+  CMAKE_PREFIX_PATH=$NETCDF_BASE
+  cmake .. -DSHARED_LIB=no -DSTATIC_LIB=yes -DNONUMA=on -DCMAKE_INSTALL_PREFIX=$HOME
+  make -j 48
+  make install
+  (Know errors: 1.Numa could not found - turn off Numa by adding -DNONUMA=on . )
 
-.. code-block:: bash
-
-   git clone git@github.com:TUM-I5/ASAGI.git
-   git submodule update --init
-
-
--  install:
-
-.. code-block:: bash
-
-   mkdir build && cd build
-   export CMAKE_PREFIX_PATH=$NETCDF_BASE
-   cmake FC=mpif90 CXX=mpiCC CC=mpicc .. -DCMAKE_INSTALL_PREFIX=$(pwd)/build
-   make -j8
-   make install
-
--  set the following paths
-
-.. code-block:: bash
-
-   export PKG_CONFIG_PATH=<path_to_ASAGI>/build/lib/pkgconfig
-   export LD_LIBRARY_PATH=<path_to_ASAGI>/build/lib
 
 building SeisSol with ASAGI support
 -----------------------------------

--- a/Documentation/compilation.rst
+++ b/Documentation/compilation.rst
@@ -181,6 +181,7 @@ including all submodules:
 .. code-block:: bash
 
    git clone https://github.com/SeisSol/SeisSol.git
+   cd SeisSol
    git submodule update --init
 
 Compile SeisSol with (e.g.)

--- a/Documentation/supermuc.rst
+++ b/Documentation/supermuc.rst
@@ -95,40 +95,15 @@ Building SeisSol
   export PATH=~/bin:$PATH
   
   ####  local setup for SeisSol. 
-  export PATH=/hppfs/work/pr63qo/di73yeq4/myLibs/libxsmm/bin:$PATH
-  export PKG_CONFIG_PATH=/hppfs/work/pr63qo/di73yeq4/myLibs/ASAGI/build/lib/pkgconfig:$PKG_CONFIG_PATH
-  export LD_LIBRARY_PATH=/hppfs/work/pr63qo/di73yeq4/myLibs/ASAGI/build/lib:$LD_LIBRARY_PATH
+  export PATH=~/bin:$PATH
+  export PKG_CONFIG_PATH=~/lib/pkgconfig:$PKG_CONFIG_PATH
+  export LD_LIBRARY_PATH=~/lib:$LD_LIBRARY_PATH
 
 
 3. Install metis, parmetis, libxsmm, PSpaMM, easi and ASAGI
 
 See :ref:`installing_parmetis`, :ref:`installing_libxsmm`, :ref:`installing_pspamm`, :ref:`installing_ASAGI` and `Installing easi <https://easyinit.readthedocs.io/en/latest/getting_started.html>`_.
 Note that ASAGI needs to be compiled before easi.
-Note that on project pr63qo, we already installed and shared libxsmm and ASAGI (but not pspamm).
-The compiled libs are in /hppfs/work/pr63qo/di73yeq4/myLibs/xxxx/build with xxxx=ASAGI or libxsmm.
-If you need to compile ASAGI, first clone ASAGI with:
-
-.. code-block:: bash
-
-  git clone git@github.com:TUM-I5/ASAGI
-  cd ASAGI
-  git submodule update --init
- 
-set compiler options, run cmake, and compile with:
-
-::
-
-  export FC=mpif90
-  export CXX=mpiCC
-  export CC=mpicc
-
-  mkdir build && cd build
-  CMAKE_PREFIX_PATH=$NETCDF_BASE
-  cmake ../ -DSHARED_LIB=no -DSTATIC_LIB=yes -DNONUMA=on -DCMAKE_INSTALL_PREFIX=$HOME/<folder-to-ASAGI>/build/ 
-  make -j 48
-  make install
-  (Know errors: 1.Numa could not found - turn off Numa by adding -DNONUMA=on . )
-
 
 4. Install SeisSol with cmake, e.g. with (more options with ccmake)
 


### PR DESCRIPTION
fixes Asagi compilation on supermuc described twice.
Removed reference to precompiles ASAGI and libxmm on supermuc (in the end, I don't think it is a significant time gain).