### PR TITLE
Fix viscoelastic compilation

### DIFF
--- a/src/Equations/viscoelastic/Kernels/GravitationalFreeSurfaceBC.h
+++ b/src/Equations/viscoelastic/Kernels/GravitationalFreeSurfaceBC.h
@@ -1,0 +1,1 @@
+../../elastic/Kernels/GravitationalFreeSurfaceBC.h


### PR DESCRIPTION
I just found out that the `viscoelastic` compilation (without the `2`) failed. Here is an easy fix.