### PR TITLE
dr/cpp: add FL 33 and 34 to the pipeline again

### DIFF
--- a/gitlab-cpu-pipeline.yml
+++ b/gitlab-cpu-pipeline.yml
@@ -139,7 +139,7 @@ tpv_run:
     parallel:
         matrix:
             - precision: [double, single]
-              tpv: [5, 101, 101-slip, 104, 105]
+              tpv: [5, 101, 101-slip, 104, 105, 33, 34]
     script: 
         - echo "run TPV${tpv}"
         - git clone https://github.com/7bits-register/precomputed-seissol.git
@@ -174,7 +174,7 @@ tpv_check_faultoutput:
     parallel:
         matrix:
             - precision: [double, single]
-              tpv: [5, 101, 101-slip, 104, 105]
+              tpv: [5, 101, 101-slip, 104, 105, 33, 34]
     script: 
         - echo "check TPV{$tpv}"
         - ls
@@ -195,7 +195,7 @@ tpv_check_receivers:
     parallel:
         matrix:
             - precision: [double, single]
-              tpv: [5, 101, 101-slip, 104, 105]
+              tpv: [5, 101, 101-slip, 104, 105, 33, 34]
     script: 
         - echo "check TPV{$tpv}"
         - ls


### PR DESCRIPTION
I created a slip distribution without the need for ASAGI to test FL 33 and 34 in the gitlab pipeline. See also the changes here: https://github.com/7bits-register/precomputed-seissol/commit/fd9f4bfaa21d521c46ba42341ffa4c32137cbd56 
The Pipeline has passed before I created the PR ;-)