### PR TITLE
Copy neighbor material also in case of dynamic rupture BC

### DIFF
--- a/src/Initializer/dg_setup.f90
+++ b/src/Initializer/dg_setup.f90
@@ -437,8 +437,8 @@ CONTAINS
           materialVal = BND%ObjMPI(iObject)%NeighborBackground(1:EQN%nBackgroundVar,MPIIndex) ! rho,mu,lambda
       ELSE
           SELECT CASE(MESH%ELEM%Reference(iSide,iElem))
-          CASE(0)
-              iNeighbor       = MESH%ELEM%SideNeighbor(iSide,iElem)
+          CASE(0, 3) ! For regular faces and dynamic rupture faces, use the values from the outer material.
+              iNeighbor = MESH%ELEM%SideNeighbor(iSide,iElem)
               materialVal = OptionalFields%BackgroundValue(iNeighbor,:)
           CASE DEFAULT ! For boundary conditions take inside material
               materialVal = OptionalFields%BackgroundValue(iElem,:)


### PR DESCRIPTION
With this fix, we set the neighbor material correctly for all internal faces. In particular, this fixes the problem that at dynamic rupture interfaces, we used the wrong impedances to compute the Godunov state.
Verification: See attached picture of receiver 3 for the TPV6 benchmark. Blue: master, orange: this fix.
Estimated arrival time of the wave is ~3.8s (see SCEC screenshot)
![Screenshot from 2022-07-08 13-55-03](https://user-images.githubusercontent.com/24592027/177987484-ffd57110-7fb3-467f-bb60-24d9a0677a67.png)
![Screenshot from 2022-07-08 13-54-40](https://user-images.githubusercontent.com/24592027/177987488-f4c4fb8b-48c9-4623-ab42-20d1274caa89.png)
