### PR TITLE
adjust receiver variable names for better consistency

### DIFF
--- a/src/ResultWriter/ReceiverWriter.cpp
+++ b/src/ResultWriter/ReceiverWriter.cpp
@@ -102,9 +102,9 @@ void seissol::writer::ReceiverWriter::writeHeader( unsigned               pointI
                                                    Eigen::Vector3d const& point   ) {
   auto name = fileName(pointId);
 
-  std::vector<std::string> names({"xx", "yy", "zz", "xy", "yz", "xz", "u", "v", "w"});
+  std::vector<std::string> names({"xx", "yy", "zz", "xy", "yz", "xz", "v1", "v2", "v3"});
 #ifdef USE_POROELASTIC
-  std::array<std::string, 4> additionalNames({"p", "u_f", "v_f", "w_f"});
+  std::array<std::string, 4> additionalNames({"p", "v1_f", "v2_f", "v3_f"});
   names.insert(names.end() ,additionalNames.begin(), additionalNames.end());
 #endif
 


### PR DESCRIPTION
Within the free surface output of SeisSol we have the following output variables:

    v1, v2, v3: ground velocities, x y and z components
    u1, u2, u3: ground displacements, x y and z components

So far the three particle velocities within the off-fault receiver output files were named u, v, w. I would like to rename them to v1, v2, v3 for better consistency.