### PR TITLE
Refactored DR Energy Output computations

### DIFF
--- a/generated_code/DynamicRupture.py
+++ b/generated_code/DynamicRupture.py
@@ -119,13 +119,13 @@ def addKernels(generator, aderdg, matricesDir, drQuadRule, targets):
   # where the normal points from the plus side to the minus side
   QInterpolatedPlus = OptionalDimTensor('QInterpolatedPlus', aderdg.Q.optName(), aderdg.Q.optSize(), aderdg.Q.optPos(), gShape, alignStride=True)
   QInterpolatedMinus = OptionalDimTensor('QInterpolatedMinus', aderdg.Q.optName(), aderdg.Q.optSize(), aderdg.Q.optPos(), gShape, alignStride=True)
-  slipRateInterpolated = Tensor('slipRateInterpolated', (numberOfPoints,3))
-  slipInterpolated = Tensor('slipInterpolated', (numberOfPoints,3))
-  squaredNormSlipRateInterpolated = Tensor('squaredNormSlipRateInterpolated', (numberOfPoints,))
-  tractionInterpolated = Tensor('tractionInterpolated', (numberOfPoints,3))
+  slipRateInterpolated = Tensor('slipRateInterpolated', (numberOfPoints,3), alignStride=True)
+  slipInterpolated = Tensor('slipInterpolated', (numberOfPoints,3), alignStride=True)
+  squaredNormSlipRateInterpolated = Tensor('squaredNormSlipRateInterpolated', (numberOfPoints,), alignStride=True)
+  tractionInterpolated = Tensor('tractionInterpolated', (numberOfPoints,3), alignStride=True)
   frictionalEnergy = Tensor('frictionalEnergy', ())
   timeWeight = Scalar('timeWeight')
-  spaceWeights = Tensor('spaceWeights', (numberOfPoints,))
+  spaceWeights = Tensor('spaceWeights', (numberOfPoints,), alignStride=True)
 
   computeSlipRateInterpolated = slipRateInterpolated['kp'] <= QInterpolatedMinus['kq'] * aderdg.selectVelocity['qp'] - QInterpolatedPlus['kq'] * aderdg.selectVelocity['qp']
   generator.add('computeSlipRateInterpolated', computeSlipRateInterpolated)

--- a/generated_code/DynamicRupture.py
+++ b/generated_code/DynamicRupture.py
@@ -120,24 +120,13 @@ def addKernels(generator, aderdg, matricesDir, drQuadRule, targets):
   QInterpolatedPlus = OptionalDimTensor('QInterpolatedPlus', aderdg.Q.optName(), aderdg.Q.optSize(), aderdg.Q.optPos(), gShape, alignStride=True)
   QInterpolatedMinus = OptionalDimTensor('QInterpolatedMinus', aderdg.Q.optName(), aderdg.Q.optSize(), aderdg.Q.optPos(), gShape, alignStride=True)
   slipRateInterpolated = Tensor('slipRateInterpolated', (numberOfPoints,3), alignStride=True)
-  slipInterpolated = Tensor('slipInterpolated', (numberOfPoints,3), alignStride=True)
-  squaredNormSlipRateInterpolated = Tensor('squaredNormSlipRateInterpolated', (numberOfPoints,), alignStride=True)
   tractionInterpolated = Tensor('tractionInterpolated', (numberOfPoints,3), alignStride=True)
   frictionalEnergy = Tensor('frictionalEnergy', ())
   timeWeight = Scalar('timeWeight')
   spaceWeights = Tensor('spaceWeights', (numberOfPoints,), alignStride=True)
 
-  computeSlipRateInterpolated = slipRateInterpolated['kp'] <= QInterpolatedMinus['kq'] * aderdg.selectVelocity['qp'] - QInterpolatedPlus['kq'] * aderdg.selectVelocity['qp']
-  generator.add('computeSlipRateInterpolated', computeSlipRateInterpolated)
-
   computeTractionInterpolated = tractionInterpolated['kp'] <= QInterpolatedMinus['kq'] * aderdg.tractionMinusMatrix['qp'] + QInterpolatedPlus['kq'] * aderdg.tractionPlusMatrix['qp']
   generator.add('computeTractionInterpolated', computeTractionInterpolated)
-
-  accumulateSlipInterpolated = slipInterpolated['kp'] <= slipInterpolated['kp'] + timeWeight * slipRateInterpolated['kp']
-  generator.add('accumulateSlipInterpolated', accumulateSlipInterpolated)
-
-  computeSquaredNormSlipRateInterpolated = squaredNormSlipRateInterpolated['k'] <= slipRateInterpolated['kp'] * slipRateInterpolated['kp']
-  generator.add('computeSquaredNormSlipRateInterpolated', computeSquaredNormSlipRateInterpolated)
 
   accumulateFrictionalEnergy = frictionalEnergy[''] <= frictionalEnergy[''] + timeWeight * tractionInterpolated['kp'] * slipRateInterpolated['kp'] * spaceWeights['k']
   generator.add('accumulateFrictionalEnergy', accumulateFrictionalEnergy)

--- a/gitlab-gpu-pipeline.yml
+++ b/gitlab-gpu-pipeline.yml
@@ -202,6 +202,27 @@ check_receivers:
         - if [ ${tpv} = 5 ] || [ ${tpv} = 5-nuc ] || [ ${tpv} = 6 ] || [ ${tpv} = 16 ]; then mode=lsw; elif [ ${tpv} = 105 ]; then mode=tp; else mode=rs; fi;
             python3 ../postprocessing/validation/compare-receivers.py . ./precomputed --epsilon ${epsilon} --mode $mode
 
+gpu_check_energies:
+    stage: check
+    allow_failure: false
+    needs:
+        - job: gpu_run_tpv
+    variables:
+        energy_file: "tpv-energy.csv"
+        epsilon: "0.05"
+    parallel:
+        matrix:
+            - precision: [single]
+              tpv: [5, 5-nuc, 6]
+              backend: [cuda]
+    before_script:
+        - pip3 install pandas
+    script:
+        - echo "check TPV${tpv}"
+        - ls
+        - cd output-tpv{$tpv}-${precision}-${backend}
+        - ls
+        - python3 ../postprocessing/validation/compare-energies.py ./${energy_file} ./precomputed/${energy_file} --epsilon ${epsilon}
 
 gpu_performance_test:
     stage: performance_eval

--- a/src/DynamicRupture/FrictionLaws/BaseFrictionLaw.h
+++ b/src/DynamicRupture/FrictionLaws/BaseFrictionLaw.h
@@ -25,8 +25,7 @@ class BaseFrictionLaw : public FrictionSolver {
   void evaluate(seissol::initializers::Layer& layerData,
                 seissol::initializers::DynamicRupture const* const dynRup,
                 real fullUpdateTime,
-                const double timeWeights[CONVERGENCE_ORDER],
-                const real spaceWeights[misc::numPaddedPoints]) override {
+                const double timeWeights[CONVERGENCE_ORDER]) override {
     SCOREP_USER_REGION_DEFINE(myRegionHandle)
     BaseFrictionLaw::copyLtsTreeToLocal(layerData, dynRup, fullUpdateTime);
     static_cast<Derived*>(this)->copyLtsTreeToLocal(layerData, dynRup, fullUpdateTime);

--- a/src/DynamicRupture/FrictionLaws/BaseFrictionLaw.h
+++ b/src/DynamicRupture/FrictionLaws/BaseFrictionLaw.h
@@ -25,7 +25,8 @@ class BaseFrictionLaw : public FrictionSolver {
   void evaluate(seissol::initializers::Layer& layerData,
                 seissol::initializers::DynamicRupture const* const dynRup,
                 real fullUpdateTime,
-                const double timeWeights[CONVERGENCE_ORDER]) override {
+                const double timeWeights[CONVERGENCE_ORDER],
+                const real spaceWeights[misc::numPaddedPoints]) override {
     SCOREP_USER_REGION_DEFINE(myRegionHandle)
     BaseFrictionLaw::copyLtsTreeToLocal(layerData, dynRup, fullUpdateTime);
     static_cast<Derived*>(this)->copyLtsTreeToLocal(layerData, dynRup, fullUpdateTime);
@@ -111,6 +112,14 @@ class BaseFrictionLaw : public FrictionSolver {
                                                    timeWeights);
       LIKWID_MARKER_STOP("computeDynamicRupturePostcomputeImposedState");
       SCOREP_USER_REGION_END(myRegionHandle)
+
+      common::computeFrictionEnergy(energyData[ltsFace],
+                                    qInterpolatedPlus[ltsFace],
+                                    qInterpolatedMinus[ltsFace],
+                                    impAndEta[ltsFace],
+                                    timeWeights,
+                                    spaceWeights,
+                                    godunovData[ltsFace]);
     }
   }
 };

--- a/src/DynamicRupture/FrictionLaws/FrictionSolver.cpp
+++ b/src/DynamicRupture/FrictionLaws/FrictionSolver.cpp
@@ -31,6 +31,8 @@ void FrictionSolver::copyLtsTreeToLocal(seissol::initializers::Layer& layerData,
   traction2 = layerData.var(dynRup->traction2);
   imposedStatePlus = layerData.var(dynRup->imposedStatePlus);
   imposedStateMinus = layerData.var(dynRup->imposedStateMinus);
+  energyData = layerData.var(dynRup->drEnergyOutput);
+  godunovData = layerData.var(dynRup->godunovData);
   mFullUpdateTime = fullUpdateTime;
   dynStressTime = layerData.var(dynRup->dynStressTime);
   dynStressTimePending = layerData.var(dynRup->dynStressTimePending);

--- a/src/DynamicRupture/FrictionLaws/FrictionSolver.h
+++ b/src/DynamicRupture/FrictionLaws/FrictionSolver.h
@@ -16,14 +16,17 @@ namespace seissol::dr::friction_law {
 class FrictionSolver {
   public:
   // Note: FrictionSolver must be trivially copyable. It is important for GPU offloading
-  explicit FrictionSolver(dr::DRParameters* userDrParameters) : drParameters(userDrParameters){};
+  explicit FrictionSolver(dr::DRParameters* userDrParameters) : drParameters(userDrParameters) {
+    real points[NUMBER_OF_SPACE_QUADRATURE_POINTS][2];
+    std::fill_n(spaceWeights, dr::misc::numPaddedPoints, static_cast<real>(0.0));
+    seissol::quadrature::TriangleQuadrature(points, spaceWeights, CONVERGENCE_ORDER + 1);
+  }
   virtual ~FrictionSolver() = default;
 
   virtual void evaluate(seissol::initializers::Layer& layerData,
                         seissol::initializers::DynamicRupture const* const dynRup,
                         real fullUpdateTime,
-                        const double timeWeights[CONVERGENCE_ORDER],
-                        const real spaceWeights[misc::numPaddedPoints]) = 0;
+                        const double timeWeights[CONVERGENCE_ORDER]) = 0;
 
   /**
    * compute the DeltaT from the current timePoints call this function before evaluate
@@ -66,6 +69,7 @@ class FrictionSolver {
   real (*traction2)[misc::numPaddedPoints];
   real (*imposedStatePlus)[tensor::QInterpolated::size()];
   real (*imposedStateMinus)[tensor::QInterpolated::size()];
+  real spaceWeights[misc::numPaddedPoints];
   DREnergyOutput* energyData{};
   DRGodunovData* godunovData{};
 

--- a/src/DynamicRupture/FrictionLaws/FrictionSolver.h
+++ b/src/DynamicRupture/FrictionLaws/FrictionSolver.h
@@ -22,7 +22,8 @@ class FrictionSolver {
   virtual void evaluate(seissol::initializers::Layer& layerData,
                         seissol::initializers::DynamicRupture const* const dynRup,
                         real fullUpdateTime,
-                        const double timeWeights[CONVERGENCE_ORDER]) = 0;
+                        const double timeWeights[CONVERGENCE_ORDER],
+                        const real spaceWeights[misc::numPaddedPoints]) = 0;
 
   /**
    * compute the DeltaT from the current timePoints call this function before evaluate
@@ -65,6 +66,8 @@ class FrictionSolver {
   real (*traction2)[misc::numPaddedPoints];
   real (*imposedStatePlus)[tensor::QInterpolated::size()];
   real (*imposedStateMinus)[tensor::QInterpolated::size()];
+  DREnergyOutput* energyData{};
+  DRGodunovData* godunovData{};
 
   // be careful only for some FLs initialized:
   real (*dynStressTime)[misc::numPaddedPoints];

--- a/src/DynamicRupture/FrictionLaws/FrictionSolver.h
+++ b/src/DynamicRupture/FrictionLaws/FrictionSolver.h
@@ -17,7 +17,7 @@ class FrictionSolver {
   public:
   // Note: FrictionSolver must be trivially copyable. It is important for GPU offloading
   explicit FrictionSolver(dr::DRParameters* userDrParameters) : drParameters(userDrParameters) {
-    real points[NUMBER_OF_SPACE_QUADRATURE_POINTS][2];
+    real points[dr::misc::numPaddedPoints][2];
     std::fill_n(spaceWeights, dr::misc::numPaddedPoints, static_cast<real>(0.0));
     seissol::quadrature::TriangleQuadrature(points, spaceWeights, CONVERGENCE_ORDER + 1);
   }

--- a/src/DynamicRupture/FrictionLaws/FrictionSolverCommon.h
+++ b/src/DynamicRupture/FrictionLaws/FrictionSolverCommon.h
@@ -361,6 +361,71 @@ inline void savePeakSlipRateOutput(real slipRateMagnitude[misc::numPaddedPoints]
     peakSlipRate[pointIndex] = std::max(peakSlipRate[pointIndex], slipRateMagnitude[pointIndex]);
   }
 }
+
+template <RangeType Type = RangeType::CPU>
+inline void computeFrictionEnergy(
+    DREnergyOutput& energyData,
+    const real qInterpolatedPlus[CONVERGENCE_ORDER][tensor::QInterpolated::size()],
+    const real qInterpolatedMinus[CONVERGENCE_ORDER][tensor::QInterpolated::size()],
+    const ImpedancesAndEta& impAndEta,
+    const double timeWeights[CONVERGENCE_ORDER],
+    const real spaceWeights[NUMBER_OF_SPACE_QUADRATURE_POINTS],
+    const DRGodunovData& godunovData,
+    size_t startIndex = 0) {
+
+  auto* slip = reinterpret_cast<real(*)[misc::numPaddedPoints]>(energyData.slip);
+  auto* accumulatedSlip = energyData.accumulatedSlip;
+  auto* frictionalEnergy = energyData.frictionalEnergy;
+  const double doubledSurfaceArea = godunovData.doubledSurfaceArea;
+
+  using QInterpolatedShapeT = const real(*)[misc::numQuantities][misc::numPaddedPoints];
+  auto* qIPlus = reinterpret_cast<QInterpolatedShapeT>(qInterpolatedPlus);
+  auto* qIMinus = reinterpret_cast<QInterpolatedShapeT>(qInterpolatedMinus);
+
+  const auto aPlus = impAndEta.etaP * impAndEta.invZp;
+  const auto bPlus = impAndEta.etaS * impAndEta.invZs;
+
+  const auto aMinus = impAndEta.etaP * impAndEta.invZpNeig;
+  const auto bMinus = impAndEta.etaS * impAndEta.invZsNeig;
+
+  using Range = typename NumPoints<Type>::Range;
+
+  using namespace dr::misc::quantity_indices;
+  for (size_t o = 0; o < CONVERGENCE_ORDER; ++o) {
+    const auto timeWeight = timeWeights[o];
+
+#ifndef ACL_DEVICE
+    #pragma omp simd
+#endif
+    for (size_t index = Range::start; index < Range::end; index += Range::step) {
+      const size_t i{startIndex + index};
+
+      const real interpolatedSlipU = qIMinus[o][U][i] - qIPlus[o][U][i];
+      const real interpolatedSlipV = qIMinus[o][V][i] - qIPlus[o][V][i];
+      const real interpolatedSlipW = qIMinus[o][W][i] - qIPlus[o][W][i];
+
+      const real interpolatedSlipMagnitude =
+          misc::magnitude(interpolatedSlipU, interpolatedSlipV, interpolatedSlipW);
+
+      accumulatedSlip[i] += timeWeight * interpolatedSlipMagnitude;
+
+      slip[0][i] += timeWeight * interpolatedSlipU;
+      slip[1][i] += timeWeight * interpolatedSlipV;
+      slip[2][i] += timeWeight * interpolatedSlipW;
+
+      const real interpolatedTractionXX = aPlus * qIMinus[o][XX][i] + aMinus * qIPlus[o][XX][i];
+      const real interpolatedTractionXY = bPlus * qIMinus[o][XY][i] + bMinus * qIPlus[o][XY][i];
+      const real interpolatedTractionXZ = bPlus * qIMinus[o][XZ][i] + bMinus * qIPlus[o][XZ][i];
+
+      const auto spaceWeight = spaceWeights[i];
+      const auto weight = -1.0 * timeWeight * spaceWeight * doubledSurfaceArea;
+      frictionalEnergy[i] += weight * (interpolatedTractionXX * interpolatedSlipU +
+                                       interpolatedTractionXY * interpolatedSlipV +
+                                       interpolatedTractionXZ * interpolatedSlipW);
+    }
+  }
+}
+
 } // namespace seissol::dr::friction_law::common
 
 #endif // SEISSOL_FRICTIONSOLVER_COMMON_H

--- a/src/DynamicRupture/FrictionLaws/FrictionSolverCommon.h
+++ b/src/DynamicRupture/FrictionLaws/FrictionSolverCommon.h
@@ -400,28 +400,28 @@ inline void computeFrictionEnergy(
     for (size_t index = Range::start; index < Range::end; index += Range::step) {
       const size_t i{startIndex + index};
 
-      const real interpolatedSlipU = qIMinus[o][U][i] - qIPlus[o][U][i];
-      const real interpolatedSlipV = qIMinus[o][V][i] - qIPlus[o][V][i];
-      const real interpolatedSlipW = qIMinus[o][W][i] - qIPlus[o][W][i];
+      const real interpolatedSlipRate1 = qIMinus[o][U][i] - qIPlus[o][U][i];
+      const real interpolatedSlipRate2 = qIMinus[o][V][i] - qIPlus[o][V][i];
+      const real interpolatedSlipRate3 = qIMinus[o][W][i] - qIPlus[o][W][i];
 
-      const real interpolatedSlipMagnitude =
-          misc::magnitude(interpolatedSlipU, interpolatedSlipV, interpolatedSlipW);
+      const real interpolatedSlipRateMagnitude =
+          misc::magnitude(interpolatedSlipRate1, interpolatedSlipRate2, interpolatedSlipRate3);
 
-      accumulatedSlip[i] += timeWeight * interpolatedSlipMagnitude;
+      accumulatedSlip[i] += timeWeight * interpolatedSlipRateMagnitude;
 
-      slip[0][i] += timeWeight * interpolatedSlipU;
-      slip[1][i] += timeWeight * interpolatedSlipV;
-      slip[2][i] += timeWeight * interpolatedSlipW;
+      slip[0][i] += timeWeight * interpolatedSlipRate1;
+      slip[1][i] += timeWeight * interpolatedSlipRate2;
+      slip[2][i] += timeWeight * interpolatedSlipRate3;
 
-      const real interpolatedTractionXX = aPlus * qIMinus[o][XX][i] + aMinus * qIPlus[o][XX][i];
-      const real interpolatedTractionXY = bPlus * qIMinus[o][XY][i] + bMinus * qIPlus[o][XY][i];
-      const real interpolatedTractionXZ = bPlus * qIMinus[o][XZ][i] + bMinus * qIPlus[o][XZ][i];
+      const real interpolatedTraction11 = aPlus * qIMinus[o][XX][i] + aMinus * qIPlus[o][XX][i];
+      const real interpolatedTraction12 = bPlus * qIMinus[o][XY][i] + bMinus * qIPlus[o][XY][i];
+      const real interpolatedTraction13 = bPlus * qIMinus[o][XZ][i] + bMinus * qIPlus[o][XZ][i];
 
       const auto spaceWeight = spaceWeights[i];
       const auto weight = -1.0 * timeWeight * spaceWeight * doubledSurfaceArea;
-      frictionalEnergy[i] += weight * (interpolatedTractionXX * interpolatedSlipU +
-                                       interpolatedTractionXY * interpolatedSlipV +
-                                       interpolatedTractionXZ * interpolatedSlipW);
+      frictionalEnergy[i] += weight * (interpolatedTraction11 * interpolatedSlipRate1 +
+                                       interpolatedTraction12 * interpolatedSlipRate2 +
+                                       interpolatedTraction13 * interpolatedSlipRate3);
     }
   }
 }

--- a/src/DynamicRupture/FrictionLaws/GpuImpl/GpuBaseFrictionLaw.cpp
+++ b/src/DynamicRupture/FrictionLaws/GpuImpl/GpuBaseFrictionLaw.cpp
@@ -62,7 +62,7 @@ void GpuBaseFrictionLaw::copyStaticDataToDevice() {
 
   {
     const size_t requiredNumBytes = misc::numPaddedPoints * sizeof(real);
-    this->queue.memcpy(devSpaceWeights, &spaceWeights[0], requiredNumBytes).wait();
+    queue.memcpy(devSpaceWeights, &spaceWeights[0], requiredNumBytes).wait();
   }
 }
 } // namespace seissol::dr::friction_law::gpu

--- a/src/DynamicRupture/FrictionLaws/GpuImpl/GpuBaseFrictionLaw.cpp
+++ b/src/DynamicRupture/FrictionLaws/GpuImpl/GpuBaseFrictionLaw.cpp
@@ -12,6 +12,7 @@ GpuBaseFrictionLaw::~GpuBaseFrictionLaw() {
   free(stateVariableBuffer, queue);
   free(strengthBuffer, queue);
   free(devTimeWeights, queue);
+  free(devSpaceWeights, queue);
   free(devDeltaT, queue);
   free(resampleMatrix, queue);
 }
@@ -42,6 +43,11 @@ void GpuBaseFrictionLaw::allocateAuxiliaryMemory() {
   {
     const size_t requiredNumBytes = CONVERGENCE_ORDER * sizeof(double);
     devTimeWeights = static_cast<double*>(sycl::malloc_shared(requiredNumBytes, queue));
+  }
+
+  {
+    const size_t requiredNumBytes = misc::numPaddedPoints * sizeof(real);
+    devSpaceWeights = static_cast<real*>(sycl::malloc_shared(requiredNumBytes, queue));
   }
 
   {

--- a/src/DynamicRupture/FrictionLaws/GpuImpl/GpuBaseFrictionLaw.cpp
+++ b/src/DynamicRupture/FrictionLaws/GpuImpl/GpuBaseFrictionLaw.cpp
@@ -13,7 +13,6 @@ GpuBaseFrictionLaw::~GpuBaseFrictionLaw() {
   free(strengthBuffer, queue);
   free(devTimeWeights, queue);
   free(devSpaceWeights, queue);
-  free(devDeltaT, queue);
   free(resampleMatrix, queue);
 }
 
@@ -49,19 +48,21 @@ void GpuBaseFrictionLaw::allocateAuxiliaryMemory() {
     const size_t requiredNumBytes = misc::numPaddedPoints * sizeof(real);
     devSpaceWeights = static_cast<real*>(sycl::malloc_shared(requiredNumBytes, queue));
   }
-
-  {
-    const size_t requiredNumBytes = CONVERGENCE_ORDER * sizeof(real);
-    devDeltaT = static_cast<real*>(sycl::malloc_shared(requiredNumBytes, queue));
-  }
 }
 
 void GpuBaseFrictionLaw::copyStaticDataToDevice() {
-  constexpr auto dim0 = misc::dimSize<init::resample, 0>();
-  constexpr auto dim1 = misc::dimSize<init::resample, 1>();
-  const size_t requiredNumBytes = dim0 * dim1 * sizeof(real);
+  {
+    constexpr auto dim0 = misc::dimSize<init::resample, 0>();
+    constexpr auto dim1 = misc::dimSize<init::resample, 1>();
+    const size_t requiredNumBytes = dim0 * dim1 * sizeof(real);
 
-  resampleMatrix = static_cast<real*>(sycl::malloc_shared(requiredNumBytes, queue));
-  queue.memcpy(resampleMatrix, &init::resample::Values[0], requiredNumBytes).wait();
+    resampleMatrix = static_cast<real*>(sycl::malloc_shared(requiredNumBytes, queue));
+    queue.memcpy(resampleMatrix, &init::resample::Values[0], requiredNumBytes).wait();
+  }
+
+  {
+    const size_t requiredNumBytes = misc::numPaddedPoints * sizeof(real);
+    this->queue.memcpy(devSpaceWeights, &spaceWeights[0], requiredNumBytes).wait();
+  }
 }
 } // namespace seissol::dr::friction_law::gpu

--- a/src/DynamicRupture/FrictionLaws/GpuImpl/GpuBaseFrictionLaw.h
+++ b/src/DynamicRupture/FrictionLaws/GpuImpl/GpuBaseFrictionLaw.h
@@ -35,6 +35,7 @@ class GpuBaseFrictionLaw : public FrictionSolver {
   real (*strengthBuffer)[misc::numPaddedPoints]{nullptr};
   real* resampleMatrix{nullptr};
   double* devTimeWeights{nullptr};
+  real* devSpaceWeights{nullptr};
   real* devDeltaT{nullptr};
 
   sycl::device device;

--- a/src/DynamicRupture/FrictionLaws/GpuImpl/GpuBaseFrictionLaw.h
+++ b/src/DynamicRupture/FrictionLaws/GpuImpl/GpuBaseFrictionLaw.h
@@ -13,7 +13,7 @@ namespace seissol::dr::friction_law::gpu {
 class GpuBaseFrictionLaw : public FrictionSolver {
   public:
   GpuBaseFrictionLaw(dr::DRParameters* drParameters);
-  ~GpuBaseFrictionLaw();
+  ~GpuBaseFrictionLaw() override;
 
   void initSyclQueue();
   void setMaxClusterSize(size_t size) { maxClusterSize = size; }
@@ -36,7 +36,6 @@ class GpuBaseFrictionLaw : public FrictionSolver {
   real* resampleMatrix{nullptr};
   double* devTimeWeights{nullptr};
   real* devSpaceWeights{nullptr};
-  real* devDeltaT{nullptr};
 
   sycl::device device;
   sycl::queue queue;

--- a/src/DynamicRupture/FrictionLaws/GpuImpl/GpuFrictionSolver.h
+++ b/src/DynamicRupture/FrictionLaws/GpuImpl/GpuFrictionSolver.h
@@ -16,8 +16,7 @@ class GpuFrictionSolver : public GpuBaseFrictionLaw {
   void evaluate(seissol::initializers::Layer& layerData,
                 seissol::initializers::DynamicRupture const* const dynRup,
                 real fullUpdateTime,
-                const double timeWeights[CONVERGENCE_ORDER],
-                const real spaceWeights[misc::numPaddedPoints]) override {
+                const double timeWeights[CONVERGENCE_ORDER]) override {
 
     FrictionSolver::copyLtsTreeToLocal(layerData, dynRup, fullUpdateTime);
     this->copySpecificLtsDataTreeToLocal(layerData, dynRup, fullUpdateTime);
@@ -25,12 +24,6 @@ class GpuFrictionSolver : public GpuBaseFrictionLaw {
 
     size_t requiredNumBytes = CONVERGENCE_ORDER * sizeof(double);
     this->queue.memcpy(devTimeWeights, &timeWeights[0], requiredNumBytes).wait();
-
-    requiredNumBytes = misc::numPaddedPoints * sizeof(real);
-    this->queue.memcpy(devSpaceWeights, &spaceWeights[0], requiredNumBytes).wait();
-
-    requiredNumBytes = CONVERGENCE_ORDER * sizeof(real);
-    this->queue.memcpy(devDeltaT, &deltaT[0], requiredNumBytes).wait();
 
     {
       constexpr common::RangeType gpuRangeType{common::RangeType::GPU};

--- a/src/DynamicRupture/Misc.h
+++ b/src/DynamicRupture/Misc.h
@@ -8,6 +8,7 @@
 #include <generated_code/init.h>
 #include <stdexcept>
 #include <tuple>
+#include <type_traits>
 
 namespace seissol::dr::misc {
 // TODO: this can be moved to yateto headers
@@ -68,21 +69,28 @@ inline auto power(T base) -> T {
   return result;
 }
 
-/**
- * Computes the magnitude of the vector (x, y)
- * @param x First component of the vector
- * @param y Second component of the vector
- * @return magnitude of the vector
- */
-inline real magnitude(real x, real y) { return std::sqrt(x * x + y * y); }
+template <typename T>
+inline typename std::enable_if<std::is_floating_point<T>::value, T>::type square(T t) {
+  return t * t;
+}
 
 /**
- * Computes the magnitude of the vector (x, y)
- * @param x First component of the vector
- * @param y Second component of the vector
+ * Computes a squared sum of an N-dimensional vector
  * @return magnitude of the vector
  */
-inline real magnitude(real x, real y, real z) { return std::sqrt(x * x + y * y + z * z); }
+template <typename T, typename... Tn>
+inline T square(T t1, Tn... tn) {
+  return square(t1) + square(tn...);
+}
+
+/**
+ * Computes the magnitude of an N-dimensional vector
+ * @return magnitude of the vector
+ */
+template <typename T, typename... Tn>
+inline T magnitude(T t1, Tn... tn) {
+  return std::sqrt(square(t1) + square(tn...));
+}
 
 /**
  * Computes the arcus sinus hyperbolicus of x.

--- a/src/DynamicRupture/Misc.h
+++ b/src/DynamicRupture/Misc.h
@@ -77,6 +77,14 @@ inline auto power(T base) -> T {
 inline real magnitude(real x, real y) { return std::sqrt(x * x + y * y); }
 
 /**
+ * Computes the magnitude of the vector (x, y)
+ * @param x First component of the vector
+ * @param y Second component of the vector
+ * @return magnitude of the vector
+ */
+inline real magnitude(real x, real y, real z) { return std::sqrt(x * x + y * y + z * z); }
+
+/**
  * Computes the arcus sinus hyperbolicus of x.
  * Note: precision has to be double, otherwise we would loose too much precision.
  * @param x

--- a/src/Initializer/typedefs.hpp
+++ b/src/Initializer/typedefs.hpp
@@ -433,7 +433,7 @@ struct DRGodunovData {
 };
 
 struct DREnergyOutput {
-  real slip[seissol::tensor::slipInterpolated::size()];
+  real slip[seissol::tensor::slipRateInterpolated::size()];
   real accumulatedSlip[seissol::dr::misc::numPaddedPoints];
   real frictionalEnergy[seissol::dr::misc::numPaddedPoints];
 };

--- a/src/Initializer/typedefs.hpp
+++ b/src/Initializer/typedefs.hpp
@@ -53,6 +53,7 @@
 #include "Equations/datastructures.hpp"
 #include <generated_code/tensor.h>
 #include <DynamicRupture/Typedefs.hpp>
+#include <DynamicRupture/Misc.h>
 
 #include <cstddef>
 
@@ -433,8 +434,8 @@ struct DRGodunovData {
 
 struct DREnergyOutput {
   real slip[seissol::tensor::slipInterpolated::size()];
-  real accumulatedSlip[seissol::tensor::squaredNormSlipRateInterpolated::size()];
-  real frictionalEnergy;
+  real accumulatedSlip[seissol::dr::misc::numPaddedPoints];
+  real frictionalEnergy[seissol::dr::misc::numPaddedPoints];
 };
 
 struct CellDRMapping {

--- a/src/Kernels/DynamicRupture.cpp
+++ b/src/Kernels/DynamicRupture.cpp
@@ -139,10 +139,6 @@ void seissol::kernels::DynamicRupture::spaceTimeInterpolation(  DRFaceInformatio
   alignas(PAGESIZE_STACK) real degreesOfFreedomPlus[tensor::Q::size()] ;
   alignas(PAGESIZE_STACK) real degreesOfFreedomMinus[tensor::Q::size()];
 
-  alignas(ALIGNMENT) real slipRateInterpolated[tensor::slipRateInterpolated::size()];
-  alignas(ALIGNMENT) real squaredNormSlipRateInterpolated[tensor::squaredNormSlipRateInterpolated::size()];
-  alignas(ALIGNMENT) real tractionInterpolated[tensor::tractionInterpolated::size()];
-
   dynamicRupture::kernel::evaluateAndRotateQAtInterpolationPoints krnl = m_krnlPrototype;
   for (unsigned timeInterval = 0; timeInterval < CONVERGENCE_ORDER; ++timeInterval) {
     m_timeKernel.computeTaylorExpansion(timePoints[timeInterval], 0.0, timeDerivativePlus, degreesOfFreedomPlus);
@@ -271,20 +267,6 @@ void seissol::kernels::DynamicRupture::flopsGodunovState( DRFaceInformation cons
   o_nonZeroFlops += dynamicRupture::kernel::evaluateAndRotateQAtInterpolationPoints::nonZeroFlops(faceInfo.minusSide, faceInfo.faceRelation);
   o_hardwareFlops += dynamicRupture::kernel::evaluateAndRotateQAtInterpolationPoints::hardwareFlops(faceInfo.minusSide, faceInfo.faceRelation);
 
-  o_nonZeroFlops += dynamicRupture::kernel::computeSlipRateInterpolated::NonZeroFlops;
-  o_hardwareFlops += dynamicRupture::kernel::computeSlipRateInterpolated::HardwareFlops;
-
-  o_nonZeroFlops += dynamicRupture::kernel::computeTractionInterpolated::NonZeroFlops;
-  o_hardwareFlops += dynamicRupture::kernel::computeTractionInterpolated::HardwareFlops;
-
-  o_nonZeroFlops += dynamicRupture::kernel::computeSquaredNormSlipRateInterpolated::NonZeroFlops;
-  o_hardwareFlops += dynamicRupture::kernel::computeSquaredNormSlipRateInterpolated::HardwareFlops;
-  o_nonZeroFlops += 2*tensor::squaredNormSlipRateInterpolated::size();
-  o_hardwareFlops += 2*tensor::squaredNormSlipRateInterpolated::size();
-
-  o_nonZeroFlops += dynamicRupture::kernel::accumulateFrictionalEnergy::NonZeroFlops;
-  o_hardwareFlops += dynamicRupture::kernel::accumulateFrictionalEnergy::HardwareFlops;
-  
   o_nonZeroFlops *= CONVERGENCE_ORDER;
   o_hardwareFlops *= CONVERGENCE_ORDER;
 }

--- a/src/Kernels/DynamicRupture.cpp
+++ b/src/Kernels/DynamicRupture.cpp
@@ -78,9 +78,6 @@ void seissol::kernels::DynamicRupture::setGlobalData(const CompoundGlobalData& g
   m_gpuKrnlPrototype.V3mTo2n = global.onDevice->faceToNodalMatrices;
   m_timeKernel.setGlobalData(global);
 #endif
-  real points[NUMBER_OF_SPACE_QUADRATURE_POINTS][2];
-  std::fill_n(spaceWeights, dr::misc::numPaddedPoints, static_cast<real>(0.0));
-  seissol::quadrature::TriangleQuadrature(points, spaceWeights, CONVERGENCE_ORDER+1);
 }
 
 

--- a/src/Kernels/DynamicRupture.h
+++ b/src/Kernels/DynamicRupture.h
@@ -65,9 +65,7 @@ class seissol::kernels::DynamicRupture {
 
   public:
     double timePoints[CONVERGENCE_ORDER];
-    double timeSteps[CONVERGENCE_ORDER];
     double timeWeights[CONVERGENCE_ORDER];
-    real spaceWeights[dr::misc::numPaddedPoints];
 
   DynamicRupture() {}
 

--- a/src/Kernels/DynamicRupture.h
+++ b/src/Kernels/DynamicRupture.h
@@ -67,7 +67,7 @@ class seissol::kernels::DynamicRupture {
     double timePoints[CONVERGENCE_ORDER];
     double timeSteps[CONVERGENCE_ORDER];
     double timeWeights[CONVERGENCE_ORDER];
-    real spaceWeights[NUMBER_OF_SPACE_QUADRATURE_POINTS];
+    real spaceWeights[dr::misc::numPaddedPoints];
 
   DynamicRupture() {}
 

--- a/src/ResultWriter/EnergyOutput.cpp
+++ b/src/ResultWriter/EnergyOutput.cpp
@@ -90,7 +90,7 @@ real EnergyOutput::computeStaticWork(const real* degreesOfFreedomPlus,
                                      const real* degreesOfFreedomMinus,
                                      const DRFaceInformation& faceInfo,
                                      const DRGodunovData& godunovData,
-                                     const real slip[seissol::tensor::slipInterpolated::size()]) {
+                                     const real slip[seissol::tensor::slipRateInterpolated::size()]) {
   real points[NUMBER_OF_SPACE_QUADRATURE_POINTS][2];
   real spaceWeights[NUMBER_OF_SPACE_QUADRATURE_POINTS];
   seissol::quadrature::TriangleQuadrature(points, spaceWeights, CONVERGENCE_ORDER + 1);

--- a/src/ResultWriter/EnergyOutput.h
+++ b/src/ResultWriter/EnergyOutput.h
@@ -63,7 +63,7 @@ class EnergyOutput : public Module {
                          const real* degreesOfFreedomMinus,
                          DRFaceInformation const& faceInfo,
                          DRGodunovData const& godunovData,
-                         const real slip[seissol::tensor::slipInterpolated::size()]);
+                         const real slip[seissol::tensor::slipRateInterpolated::size()]);
 
   void computeDynamicRuptureEnergies();
 

--- a/src/Solver/time_stepping/TimeCluster.cpp
+++ b/src/Solver/time_stepping/TimeCluster.cpp
@@ -274,8 +274,7 @@ void seissol::time_stepping::TimeCluster::computeDynamicRupture( seissol::initia
   frictionSolver->evaluate(layerData,
                            m_dynRup,
                            ct.correctionTime,
-                           m_dynamicRuptureKernel.timeWeights,
-                           m_dynamicRuptureKernel.spaceWeights);
+                           m_dynamicRuptureKernel.timeWeights);
   SCOREP_USER_REGION_END(myRegionHandle)
 #pragma omp parallel 
   {
@@ -306,8 +305,7 @@ void seissol::time_stepping::TimeCluster::computeDynamicRupture( seissol::initia
     frictionSolver->evaluate(layerData,
                              m_dynRup,
                              ct.correctionTime,
-                             m_dynamicRuptureKernel.timeWeights,
-                             m_dynamicRuptureKernel.spaceWeights);
+                             m_dynamicRuptureKernel.timeWeights);
     device.api->popLastProfilingMark();
   }
   m_loopStatistics->end(m_regionComputeDynamicRupture, layerData.getNumberOfCells(), m_globalClusterId);

--- a/src/Solver/time_stepping/TimeCluster.cpp
+++ b/src/Solver/time_stepping/TimeCluster.cpp
@@ -274,7 +274,8 @@ void seissol::time_stepping::TimeCluster::computeDynamicRupture( seissol::initia
   frictionSolver->evaluate(layerData,
                            m_dynRup,
                            ct.correctionTime,
-                           m_dynamicRuptureKernel.timeWeights);
+                           m_dynamicRuptureKernel.timeWeights,
+                           m_dynamicRuptureKernel.spaceWeights);
   SCOREP_USER_REGION_END(myRegionHandle)
 #pragma omp parallel 
   {
@@ -305,7 +306,8 @@ void seissol::time_stepping::TimeCluster::computeDynamicRupture( seissol::initia
     frictionSolver->evaluate(layerData,
                              m_dynRup,
                              ct.correctionTime,
-                             m_dynamicRuptureKernel.timeWeights);
+                             m_dynamicRuptureKernel.timeWeights,
+                             m_dynamicRuptureKernel.spaceWeights);
     device.api->popLastProfilingMark();
   }
   m_loopStatistics->end(m_regionComputeDynamicRupture, layerData.getNumberOfCells(), m_globalClusterId);


### PR DESCRIPTION
This PR contains a draft refactoring of the DR energy output computations. The implementation became common for CPUs and GPUs. The data structured were aligned.

TODO:
- ~remove unnecessary yateto kernels which we do not need anymore~
- ~adjust flop counters~
- rename variables `aPlus`, `aMinus`, `bPlus`, `bMinus` 
- ~`spaceWeights` are not changing during computations and thus need to be copied to GPUs only once~
- ~`inline real magnitude` can be generalized for an N-dimensional vector with templates~