### PR TITLE
Remove incorrect error

### DIFF
--- a/src/Parallel/Pin.h
+++ b/src/Parallel/Pin.h
@@ -41,6 +41,7 @@
 #ifndef PARALLEL_PIN_H_
 #define PARALLEL_PIN_H_
 
+#include <sched.h>
 #include <string>
 
 namespace seissol {

--- a/src/ResultWriter/WaveFieldWriter.cpp
+++ b/src/ResultWriter/WaveFieldWriter.cpp
@@ -286,11 +286,6 @@ void seissol::writer::WaveFieldWriter::init(unsigned int numVars,
     m_map = map;
   }
 
-  if (numElems == 0) {
-    logError() << "WaveFieldWriter: All elements have been filtered out (OutputRegionBounds and "
-                  "OutputGroups).";
-  }
-
   logInfo(rank) << "Refinement class initialized";
   logDebug() << "Cells : " << numElems << "refined-to ->" << meshRefiner->getNumCells();
   logDebug() << "Vertices : " << numVerts << "refined-to ->" << meshRefiner->getNumVertices();


### PR DESCRIPTION
Remove check for group filter

This checked whether all elements are filtered out.
However, it only checks that the current rank has more than zero elements.
Hence, in MPI scenarios, this may crash.

Includes changes in #675, hence only merged after #675 has been merged.
