### PR TITLE
Small improvements: std::clamp, aligned_allocator

### DIFF
--- a/src/DynamicRupture/FrictionLaws/GpuImpl/LinearSlipWeakening.h
+++ b/src/DynamicRupture/FrictionLaws/GpuImpl/LinearSlipWeakening.h
@@ -261,9 +261,9 @@ class LinearSlipWeakeningLaw
         if (t0 == 0) {
           f2 = 1.0 * (tn >= forcedRuptureTime[ltsFace][pointIndex]);
         } else {
-          f2 = std::max(
-              static_cast<real>(0.0),
-              std::min(static_cast<real>(1.0), (tn - forcedRuptureTime[ltsFace][pointIndex]) / t0));
+          f2 = std::clamp((tn - forcedRuptureTime[ltsFace][pointIndex]) / t0,
+                          static_cast<real>(0.0),
+                          static_cast<real>(1.0));
         }
         stateVariable[pointIndex] = std::max(localStateVariable, f2);
       });

--- a/src/DynamicRupture/FrictionLaws/LinearSlipWeakening.h
+++ b/src/DynamicRupture/FrictionLaws/LinearSlipWeakening.h
@@ -183,10 +183,10 @@ class LinearSlipWeakeningLaw : public BaseFrictionLaw<LinearSlipWeakeningLaw<Spe
         // if time > forcedRuptureTime, then f2 = 1.0, else f2 = 0.0
         f2 = 1.0 * (time >= this->forcedRuptureTime[ltsFace][pointIndex]);
       } else {
-        f2 = std::max(static_cast<real>(0.0),
-                      std::min(static_cast<real>(1.0),
-                               (time - this->forcedRuptureTime[ltsFace][pointIndex]) /
-                                   this->drParameters->t0));
+        f2 = std::clamp((time - this->forcedRuptureTime[ltsFace][pointIndex]) /
+                            this->drParameters->t0,
+                        static_cast<real>(0.0),
+                        static_cast<real>(1.0));
       }
       stateVariable[pointIndex] = std::max(stateVariable[pointIndex], f2);
     }

--- a/src/DynamicRupture/Initializers/ImposedSlipRatesInitializer.cpp
+++ b/src/DynamicRupture/Initializers/ImposedSlipRatesInitializer.cpp
@@ -86,7 +86,7 @@ void ImposedSlipRatesInitializer::rotateSlipToFaultCS(
     misc::computeStrikeAndDipVectors(fault.normal, strikeVector, dipVector);
 
     // cos^2 can be greater than 1 because of rounding errors
-    real cos = std::min(1.0, MeshTools::dot(strikeVector, fault.tangent1));
+    real cos = std::clamp(MeshTools::dot(strikeVector, fault.tangent1), -1.0, 1.0);
     VrtxCoords crossProduct{};
     MeshTools::cross(strikeVector, fault.tangent1, crossProduct);
     real scalarProduct = MeshTools::dot(crossProduct, fault.normal);

--- a/src/DynamicRupture/Output/DataTypes.hpp
+++ b/src/DynamicRupture/Output/DataTypes.hpp
@@ -157,7 +157,7 @@ struct ReceiverOutputData {
       stressFaceAlignedToGlb;
   std::vector<std::array<real, seissol::tensor::T::size()>> faceAlignedToGlbData;
   std::vector<std::array<real, seissol::tensor::Tinv::size()>> glbToFaceAlignedData;
-  std::vector<Eigen::Matrix<real, 2, 2>, Eigen::aligned_allocator<Eigen::Matrix<real, 2, 2>>> 
+  std::vector<Eigen::Matrix<real, 2, 2>, Eigen::aligned_allocator<Eigen::Matrix<real, 2, 2>>>
       jacobianT2d;
 
   std::vector<FaultDirections> faultDirections{};

--- a/src/DynamicRupture/Output/DataTypes.hpp
+++ b/src/DynamicRupture/Output/DataTypes.hpp
@@ -157,7 +157,9 @@ struct ReceiverOutputData {
       stressFaceAlignedToGlb;
   std::vector<std::array<real, seissol::tensor::T::size()>> faceAlignedToGlbData;
   std::vector<std::array<real, seissol::tensor::Tinv::size()>> glbToFaceAlignedData;
-  std::vector<Eigen::Matrix<real, 2, 2>> jacobianT2d;
+  std::vector<Eigen::Matrix<real, 2, 2>, Eigen::aligned_allocator<Eigen::Matrix<real, 2, 2>>> 
+      jacobianT2d;
+
   std::vector<FaultDirections> faultDirections{};
   std::vector<double> cachedTime{};
   size_t currentCacheLevel{0};


### PR DESCRIPTION
1. I had some problems with unaligned data on SuperMUC-NG. The aligned allocator fixes that.
2. Use std::clamp to avoid `min(max(...))` constructs.