### PR TITLE
Document Frontera seissol-env

### DIFF
--- a/Documentation/frontera.rst
+++ b/Documentation/frontera.rst
@@ -12,9 +12,9 @@ Add these lines to ``~/.bashrc``:
     module switch python3 python3/3.9.2
     module use /work2/09160/ulrich/frontera/spack/share/spack/modules/linux-centos7-cascadelake
     module load seissol-env-develop-intel-19.1.1.217-x52n3zf
-    export cc=mpiicc    
+    export cc=mpiicc
     export CXX=mpiicpc
-    export FN=mpiifort
+    export FC=mpiifort
 
 This will load a preinstalled seissol-env module.
 

--- a/Documentation/frontera.rst
+++ b/Documentation/frontera.rst
@@ -1,0 +1,83 @@
+.. _compile_run_frontera:
+
+
+Frontera
+========
+
+
+Add these lines to ``~/.bashrc``:
+
+::
+
+    module switch python3 python3/3.9.2
+    module use /work2/09160/ulrich/frontera/spack/share/spack/modules/linux-centos7-cascadelake
+    module load seissol-env-develop-intel-19.1.1.217-x52n3zf
+    export cc=mpiicc    
+    export CXX=mpiicpc
+    export FN=mpiifort
+
+This will load a preinstalled seissol-env module.
+
+Alternatively (and for reference), to compile seissol-env on Frontera, follow the procedure below:
+
+.. code-block:: bash
+
+    git clone --depth 1 --branch v0.18.1 https://github.com/spack/spack.git
+    cd spack
+    echo "export SPACK_ROOT=$PWD" >> $HOME/.bashrc
+    echo "export PATH=\$SPACK_ROOT/bin:\$PATH" >> $HOME/.bashrc
+    # clone seissol-spack-aid and add the repository
+    git clone --branch supermuc_NG https://github.com/SeisSol/seissol-spack-aid.git
+    cd seissol-spack-aid
+    spack repo add ./spack
+    spack compiler find
+
+Following the workaround proposed in https://github.com/spack/spack/issues/10308, precise the module of the intel compilers in ``~/.spack/linux/compilers.yaml`` by changing ``modules: []`` to ``modules: ['intel/19.1.1']``.
+
+Then, update ``~/.spack/packages.yaml`` as follow:
+
+.. code-block:: yaml
+
+    packages:
+      autoconf:
+        externals:
+        - spec: autoconf@2.69
+          prefix: /opt/apps/autotools/1.2
+      python:
+        externals:
+        - spec: python@3.9.2
+          buildable: false
+          prefix: /opt/apps/intel19/python3/3.9.2
+          modules:
+          - python3/3.9.2
+      intel-mpi:
+        buildable: false
+        externals:
+        - spec: intel-mpi@2019.0.9
+          modules:
+          - impi/19.0.9
+      all:
+        providers:
+          mpi: [intel-mpi]
+
+(note that the compilation was not successful with trying to add the cmake/3.24.2 module to packages.yaml).
+
+Finally, install seissol-env with 
+
+.. code-block:: bash
+
+    spack install -j 16 seissol-env %intel@19.1.1.217 ^intel-mpi
+
+and create a module with:
+
+.. code-block:: bash
+
+    spack module tcl refresh seissol-env
+
+To access the module at start up, add to your ``~/.bashrc``:
+
+.. code-block:: bash
+
+    module use $SPACK_ROOT/share/spack/modules/linux-centos7-cascadelake/
+
+Finally, install SeisSol with cmake, as usual, with ``-DHOST_ARCH=skx``.

--- a/Documentation/index.rst
+++ b/Documentation/index.rst
@@ -67,6 +67,7 @@ We gratefully acknowledge the funding of the German Research Foundation (as part
   behind_firewall
   supermuc
   shaheen
+  frontera
   marconi
 
 .. toctree::

--- a/Documentation/installing-dependencies.rst
+++ b/Documentation/installing-dependencies.rst
@@ -34,7 +34,7 @@ Spack installation
 It automates the process of installing, upgrading, configuring, and removing computer programs.
 In particular, our spack package `seissol-env` allows automatically installing all dependencies of SeisSol (e.g. mpi, hdf5, netcdf, easi, asagi, etc).
 See https://github.com/SeisSol/seissol-spack-aid/tree/main/spack for details on the installation with spack.
-See also for reference our documentation on how to compile seissol-env on :ref:`supermuc <compile_run_supermuc>` and :ref:`shaheen <compile_run_shaheen>`.
+See also for reference our documentation on how to compile seissol-env on :ref:`SuperMUC-NG <compile_run_supermuc>`, :ref:`Shaheen <compile_run_shaheen>` (Cray system) and :ref:`Frontera <compile_run_frontera>`.
 
 
 Manual installation

--- a/Documentation/shaheen.rst
+++ b/Documentation/shaheen.rst
@@ -20,7 +20,7 @@ Add these lines to ``~/.bashrc``:
     module load seissol-env-develop-gcc-11.2.0-rckyrcj
     export cc=cc
     export CXX=CC
-    export FN=ftn
+    export FC=ftn
 
 This will load a preinstalled seissol-env module.
 


### PR DESCRIPTION
Document seissol-env installation on Frontera.
You will say, it starts to be a catalog of supercomputer installations.
But there are always tricks (e.g., the module in the compilers.yaml) that were not detailed before.