### PR TITLE
Fix typo in Frontera doc

### DIFF
--- a/Documentation/frontera.rst
+++ b/Documentation/frontera.rst
@@ -12,7 +12,7 @@ Add these lines to ``~/.bashrc``:
     module switch python3 python3/3.9.2
     module use /work2/09160/ulrich/frontera/spack/share/spack/modules/linux-centos7-cascadelake
     module load seissol-env-develop-intel-19.1.1.217-x52n3zf
-    export cc=mpiicc
+    export CC=mpiicc
     export CXX=mpiicpc
     export FC=mpiifort
 

--- a/Documentation/shaheen.rst
+++ b/Documentation/shaheen.rst
@@ -18,7 +18,7 @@ Add these lines to ``~/.bashrc``:
     # to use preinstall seissol-env module
     module use /project/k1587/ulrich/spack/share/spack/modules/cray-cnl7-ivybridge/
     module load seissol-env-develop-gcc-11.2.0-rckyrcj
-    export cc=cc
+    export CC=cc
     export CXX=CC
     export FC=ftn
 


### PR DESCRIPTION
`cc` in small letters does not have an effect, which is not a big problem, since we do not use the c compiler, but for completeness, I'd correct it.