### PR TITLE
Switched CPU and GPU pipelines to gitlab-kubernetes-runners

### DIFF
--- a/gitlab-cpu-pipeline.yml
+++ b/gitlab-cpu-pipeline.yml
@@ -1,6 +1,6 @@
 default:
     tags:
-        - 10core-docker-runner
+        - lrzcc-k8s-4cores-16gb 
     image:
         name: $CI_REGISTRY_USER/$cpu_image_name:$cpu_image_version
         entrypoint: [""]
@@ -34,38 +34,37 @@ build_seissol:
     parallel:
         matrix:
         - precision: [double, single]
+          build_type: [Debug, Release]
     script:
         - cmake --version
         - equation=elastic
         - mechanisms=0
-        - for build_type in Debug Release ; 
-             do for equation in elastic ;
-                 do dirname="build_${equation}_${precision}_${build_type}";
-                 echo "mkdir $dirname";
-                 if [ "$equation" = viscoelastic2 ]; then mechanisms=3; else mechanisms=0; fi;
-                 mkdir -p $dirname && cd $dirname ;
-                 pwd; 
-                 CMAKE_PREFIX_PATH=~ ;
-                 cmake ..
-                 -DNETCDF=OFF
-                 -DMETIS=ON
-                 -DCOMMTHREAD=ON
-                 -DASAGI=OFF
-                 -DHDF5=ON
-                 -DCMAKE_BUILD_TYPE=$build_type
-                 -DTESTING=ON
-                 -DLOG_LEVEL=warning
-                 -DLOG_LEVEL_MASTER=info
-                 -DHOST_ARCH=hsw
-                 -DPRECISION=$precision
-                 -DEQUATIONS=$equation
-                 -DNUMBER_OF_MECHANISMS=$mechanisms
-                 -DDR_QUAD_RULE=stroud 
-                 -DGEMM_TOOLS_LIST=LIBXSMM 
-                 -DCMAKE_EXPORT_COMPILE_COMMANDS=ON;
-                 make -j $(nproc);
-                 cd .. ; 
-             done; 
+        - for equation in elastic ;
+            do dirname="build_${equation}_${precision}_${build_type}";
+            echo "mkdir $dirname";
+            if [ "$equation" = viscoelastic2 ]; then mechanisms=3; else mechanisms=0; fi;
+            mkdir -p $dirname && cd $dirname ;
+            pwd;
+            CMAKE_PREFIX_PATH=~ ;
+            cmake ..
+            -DNETCDF=OFF
+            -DMETIS=ON
+            -DCOMMTHREAD=ON
+            -DASAGI=OFF
+            -DHDF5=ON
+            -DCMAKE_BUILD_TYPE=$build_type
+            -DTESTING=ON
+            -DLOG_LEVEL=warning
+            -DLOG_LEVEL_MASTER=info
+            -DHOST_ARCH=hsw
+            -DPRECISION=$precision
+            -DEQUATIONS=$equation
+            -DNUMBER_OF_MECHANISMS=$mechanisms
+            -DDR_QUAD_RULE=stroud
+            -DGEMM_TOOLS_LIST=LIBXSMM
+            -DCMAKE_EXPORT_COMPILE_COMMANDS=ON;
+            make -j $(nproc);
+            cd .. ;
           done;
           
     artifacts:

--- a/gitlab-cpu-pipeline.yml
+++ b/gitlab-cpu-pipeline.yml
@@ -1,9 +1,12 @@
 default:
     tags:
-        - lrzcc-k8s-4cores-16gb 
+        - lrzcc-k8s-4cores-10gb 
     image:
         name: $CI_REGISTRY_USER/$cpu_image_name:$cpu_image_version
         entrypoint: [""]
+
+variables:
+    HOST: "hsw"
 
 stages:
     - pre_build
@@ -56,7 +59,7 @@ build_seissol:
             -DTESTING=ON
             -DLOG_LEVEL=warning
             -DLOG_LEVEL_MASTER=info
-            -DHOST_ARCH=hsw
+            -DHOST_ARCH=${HOST}
             -DPRECISION=$precision
             -DEQUATIONS=$equation
             -DNUMBER_OF_MECHANISMS=$mechanisms

--- a/gitlab-gpu-pipeline.yml
+++ b/gitlab-gpu-pipeline.yml
@@ -1,6 +1,6 @@
 default:
     tags:
-        - atsccs68-docker-executor
+        - tum05-k8s-4cores-16gb-gpu
     image:
         name: $CI_REGISTRY_USER/$gpu_image_name:$gpu_image_version
         entrypoint: [""]
@@ -81,7 +81,7 @@ gpu_build:
             -DHOST_ARCH=${HOST}
             -DPRECISION=${precision}
             -DPROXY_PYBINDING=ON ;
-            make -j 2 ;
+            make -j $(nproc) ;
             cd .. ;
           done;
         - set +u
@@ -228,7 +228,11 @@ gpu_performance_test:
     stage: performance_eval
     allow_failure: true
     needs:
-        - job: gpu_convergence_test
+        - job: gpu_build
+          artifacts: true
+        - job: gpu_run_tpv
+          artifacts: false
+
     parallel:
         matrix:
         - BACKEND: [cuda, hipsycl, hip]

--- a/gitlab-gpu-pipeline.yml
+++ b/gitlab-gpu-pipeline.yml
@@ -1,9 +1,14 @@
 default:
     tags:
-        - tum05-k8s-4cores-16gb-gpu
+        - tum05-k8s-4cores-16gb
     image:
         name: $CI_REGISTRY_USER/$gpu_image_name:$gpu_image_version
         entrypoint: [""]
+
+variables:
+    HOST: "snb"
+    GPU_VENDOR: "nvidia"
+    GPU_MODEL: "sm_60"
 
 stages:
     - pre_build
@@ -24,7 +29,6 @@ gpu_pre_build:
     script:
         - echo "HOST arch.:" $HOST
         - echo "GPU model:" $GPU_MODEL
-        - nvidia-smi
         - mkdir ./self_usr
         - git clone https://github.com/uphoffc/ImpalaJIT.git impalajit &&
           mkdir -p impalajit/build && cd impalajit/build &&
@@ -95,6 +99,8 @@ gpu_convergence_test:
     allow_failure: false
     needs:
         - job: gpu_build
+    tags:
+        - tum05-k8s-1core-8gb-gpu
     parallel:
         matrix:
         - BACKEND: [cuda, hipsycl, hip]
@@ -128,6 +134,8 @@ gpu_run_tpv:
     allow_failure: false
     needs:
         - job: gpu_build
+    tags:
+        - tum05-k8s-1core-8gb-gpu
     parallel:
         matrix:
             - precision: [single]
@@ -232,7 +240,8 @@ gpu_performance_test:
           artifacts: true
         - job: gpu_run_tpv
           artifacts: false
-
+    tags:
+        - tum05-k8s-1core-8gb-gpu
     parallel:
         matrix:
         - BACKEND: [cuda, hipsycl, hip]


### PR DESCRIPTION
- Created a kubernetes cluster on LRZ compute cloud with two nodes: master (10 cores) & worker (20 cores)
- Set `static` CPU Management Policies to enforce `Guaranteed` Quality of Service Class which sets `cpu-set` for each pod (container)
- installed gitlab-runner with `helm chart`: 4 cores, 10 gb of RAM for each pod, concurrency level 5
- switched our GPU pipeline to a GPU kubernetes gitlab runner provided by TUMI05

Notes for the next CI update:
- let's use `make install` to copy all executables and libraries to a specific folder which we will copy to the next stage as `artifacts`
- @sebwolf-de, I guess we need to use checkpoints to drastically reduce run-times for `tpv*` tests
- move recorded solutions from `https://github.com/7bits-register/precomputed-seissol.git` to a sub-project of `SeisSol organization`     