### PR TITLE
Fixing typo in TPV24 example

### DIFF
--- a/Documentation/tpv24.rst
+++ b/Documentation/tpv24.rst
@@ -138,9 +138,9 @@ The friction parameters are listed in Table [table:tpv24fric].
 +-------------+--------------------------------+---------+--------+
 | Parameter   | Description                    | Value   | Unit   |
 +=============+================================+=========+========+
-| mu\_s       | static friction coefficient    | 0.12    |        |
+| mu\_s       | static friction coefficient    | 0.18    |        |
 +-------------+--------------------------------+---------+--------+
-| mu\_d       | dynamic friction coefficient   | 0.18    |        |
+| mu\_d       | dynamic friction coefficient   | 0.12    |        |
 +-------------+--------------------------------+---------+--------+
 | d\_c        | critical distance              | 0.30    | m      |
 +-------------+--------------------------------+---------+--------+


### PR DESCRIPTION
There was a typo in the table showing the static and dynamic friction coefficient values: static was 0.12 and dynamic was 0.18, which should be the opposite. Fixed the values in the table accordingly.