### PR TITLE
negative state variable check (Fix 668) + updated space weights initialization

### DIFF
--- a/src/DynamicRupture/FrictionLaws/FrictionSolver.h
+++ b/src/DynamicRupture/FrictionLaws/FrictionSolver.h
@@ -17,9 +17,9 @@ class FrictionSolver {
   public:
   // Note: FrictionSolver must be trivially copyable. It is important for GPU offloading
   explicit FrictionSolver(dr::DRParameters* userDrParameters) : drParameters(userDrParameters) {
-    real points[dr::misc::numPaddedPoints][2];
-    std::fill_n(spaceWeights, dr::misc::numPaddedPoints, static_cast<real>(0.0));
-    seissol::quadrature::TriangleQuadrature(points, spaceWeights, CONVERGENCE_ORDER + 1);
+    std::copy(&init::quadweights::Values[init::quadweights::Start[0]],
+              &init::quadweights::Values[init::quadweights::Stop[0]],
+              &spaceWeights[0]);
   }
   virtual ~FrictionSolver() = default;
 

--- a/src/DynamicRupture/Initializers/RateAndStateInitializer.cpp
+++ b/src/DynamicRupture/Initializers/RateAndStateInitializer.cpp
@@ -69,6 +69,10 @@ RateAndStateInitializer::StateAndFriction
                          std::exp((rsA * std::log(std::exp(tmp) - std::exp(-tmp)) - rsF0 -
                                    rsA * std::log(initialSlipRate / rsSr0)) /
                                   rsB);
+  if (result.stateVariable < 0) {
+    logError() << "Found a negative state variable while initializing the fault. Are you sure your "
+                  "setup is correct?";
+  }
   const double tmp2 = initialSlipRate * 0.5 / rsSr0 *
                       std::exp((rsF0 + rsB * std::log(rsSr0 * result.stateVariable / rsSl0)) / rsA);
   result.frictionCoefficient = rsA * std::asinh(tmp2);
@@ -101,6 +105,10 @@ RateAndStateInitializer::StateAndFriction
   const real tmp = std::abs(absoluteTraction / (rsA * pressure));
   result.stateVariable =
       rsA * std::log(2.0 * rsSr0 / initialSlipRate * (std::exp(tmp) - std::exp(-tmp)) / 2.0);
+  if (result.stateVariable < 0) {
+    logError() << "Found a negative state variable while initializing the fault. Are you sure your "
+                  "setup is correct?";
+  }
   const real tmp2 = initialSlipRate * 0.5 / rsSr0 * std::exp(result.stateVariable / rsA);
   result.frictionCoefficient = rsA * misc::asinh(tmp2);
   return result;


### PR DESCRIPTION
* Found a way to easier initialize the space weights
* Throw an error, if the state variable is negative