### PR TITLE
Flop Counter Improvements

### DIFF
--- a/auto_tuning/proxy/src/proxy_seissol.cpp
+++ b/auto_tuning/proxy/src/proxy_seissol.cpp
@@ -245,9 +245,9 @@ ProxyOutput runProxy(ProxyConfig config) {
   ProxyOutput output{};
   output.time = total;
   output.cycles = total_cycles;
-  output.libxsmmNumTotalGFlop = static_cast<double>(flopCounter.libxsmm_num_total_flops) * 1.e-9;
-  output.pspammNumTotalGFlop = static_cast<double>(flopCounter.pspamm_num_total_flops) * 1.e-9;
-  output.libxsmmAndpspammNumTotalGFlop = static_cast<double>(flopCounter.libxsmm_num_total_flops + flopCounter.pspamm_num_total_flops) * 1.e-9;
+  output.libxsmmNumTotalGFlop = static_cast<double>(libxsmm_num_total_flops) * 1.e-9;
+  output.pspammNumTotalGFlop = static_cast<double>(pspamm_num_total_flops) * 1.e-9;
+  output.libxsmmAndpspammNumTotalGFlop = static_cast<double>(libxsmm_num_total_flops + pspamm_num_total_flops) * 1.e-9;
   output.actualNonZeroGFlop = static_cast<double>(actual_flops.d_nonZeroFlops)  * 1.e-9;
   output.actualHardwareGFlop = static_cast<double>(actual_flops.d_hardwareFlops) * 1.e-9;
   output.gib = bytes_estimate/(1024.0*1024.0*1024.0);

--- a/src/Kernels/Receiver.cpp
+++ b/src/Kernels/Receiver.cpp
@@ -38,6 +38,7 @@
  **/
 
 #include "Receiver.h"
+#include <SeisSol.h>
 #include "Numerical_aux/BasisFunction.h"
 
 #include <Initializer/PointMapper.h>
@@ -92,8 +93,8 @@ double seissol::kernels::ReceiverCluster::calcReceivers(  double time,
       krnl.basisFunctionsAtPoint = receiver.basisFunctions.m_data.data();
 
       m_timeKernel.executeSTP(timeStepWidth, receiver.data, timeEvaluated, stp);
-      g_SeisSolNonZeroFlopsOther += m_nonZeroFlops;
-      g_SeisSolHardwareFlopsOther += m_hardwareFlops;
+      seissol::SeisSol::main.flopCounter().g_SeisSolNonZeroFlopsOther += m_nonZeroFlops;
+      seissol::SeisSol::main.flopCounter().g_SeisSolHardwareFlopsOther += m_hardwareFlops;
 
       receiverTime = time;
       while (receiverTime < expansionPoint + timeStepWidth) {
@@ -144,8 +145,8 @@ double seissol::kernels::ReceiverCluster::calcReceivers(  double time,
                                 tmp,
                                 timeEvaluated, // useless but the interface requires it
                                 timeDerivatives );
-      g_SeisSolNonZeroFlopsOther += m_nonZeroFlops;
-      g_SeisSolHardwareFlopsOther += m_hardwareFlops;
+      seissol::SeisSol::main.flopCounter().g_SeisSolNonZeroFlopsOther += m_nonZeroFlops;
+      seissol::SeisSol::main.flopCounter().g_SeisSolHardwareFlopsOther += m_hardwareFlops;
 
       receiverTime = time;
       while (receiverTime < expansionPoint + timeStepWidth) {

--- a/src/Kernels/Receiver.cpp
+++ b/src/Kernels/Receiver.cpp
@@ -93,8 +93,8 @@ double seissol::kernels::ReceiverCluster::calcReceivers(  double time,
       krnl.basisFunctionsAtPoint = receiver.basisFunctions.m_data.data();
 
       m_timeKernel.executeSTP(timeStepWidth, receiver.data, timeEvaluated, stp);
-      seissol::SeisSol::main.flopCounter().g_SeisSolNonZeroFlopsOther += m_nonZeroFlops;
-      seissol::SeisSol::main.flopCounter().g_SeisSolHardwareFlopsOther += m_hardwareFlops;
+      seissol::SeisSol::main.flopCounter().incrementNonZeroFlopsOther(m_nonZeroFlops);
+      seissol::SeisSol::main.flopCounter().incrementHardwareFlopsOther(m_hardwareFlops);
 
       receiverTime = time;
       while (receiverTime < expansionPoint + timeStepWidth) {
@@ -145,8 +145,8 @@ double seissol::kernels::ReceiverCluster::calcReceivers(  double time,
                                 tmp,
                                 timeEvaluated, // useless but the interface requires it
                                 timeDerivatives );
-      seissol::SeisSol::main.flopCounter().g_SeisSolNonZeroFlopsOther += m_nonZeroFlops;
-      seissol::SeisSol::main.flopCounter().g_SeisSolHardwareFlopsOther += m_hardwareFlops;
+      seissol::SeisSol::main.flopCounter().incrementNonZeroFlopsOther(m_nonZeroFlops);
+      seissol::SeisSol::main.flopCounter().incrementHardwareFlopsOther(m_hardwareFlops);
 
       receiverTime = time;
       while (receiverTime < expansionPoint + timeStepWidth) {

--- a/src/Monitoring/FlopCounter.cpp
+++ b/src/Monitoring/FlopCounter.cpp
@@ -114,6 +114,7 @@ void FlopCounter::printFlops() {
 
   enum Counter {
     Libxsmm = 0,
+    Pspamm,
     WPNonZeroFlops,
     WPHardwareFlops,
     DRNonZeroFlops,
@@ -126,6 +127,7 @@ void FlopCounter::printFlops() {
   double flops[NUM_COUNTERS];
 
   flops[Libxsmm]          = libxsmm_num_total_flops;
+  flops[Pspamm]           = pspamm_num_total_flops;
   flops[WPNonZeroFlops]   = g_SeisSolNonZeroFlopsLocal + g_SeisSolNonZeroFlopsNeighbor + g_SeisSolNonZeroFlopsOther;
   flops[WPHardwareFlops]  = g_SeisSolHardwareFlopsLocal + g_SeisSolHardwareFlopsNeighbor + g_SeisSolHardwareFlopsOther;
   flops[DRNonZeroFlops]   = g_SeisSolNonZeroFlopsDynamicRupture;
@@ -140,7 +142,8 @@ void FlopCounter::printFlops() {
   double* totalFlops = &flops[0];
 #endif
 
-  logInfo(rank) << "Total   measured HW-GFLOP: " << totalFlops[Libxsmm] * 1.e-9;
+  logInfo(rank) << "Total    libxsmm HW-GFLOP: " << totalFlops[Libxsmm] * 1.e-9;
+  logInfo(rank) << "Total     pspamm HW-GFLOP: " << totalFlops[Pspamm] * 1.e-9;
   logInfo(rank) << "Total calculated HW-GFLOP: " << (totalFlops[WPHardwareFlops] + totalFlops[DRHardwareFlops] + totalFlops[PLHardwareFlops]) * 1.e-9;
   logInfo(rank) << "Total calculated NZ-GFLOP: " << (totalFlops[WPNonZeroFlops]  + totalFlops[DRNonZeroFlops]  + totalFlops[PLNonZeroFlops] ) * 1.e-9;
   logInfo(rank) << "WP calculated HW-GFLOP: " << (totalFlops[WPHardwareFlops]) * 1.e-9;

--- a/src/Monitoring/FlopCounter.cpp
+++ b/src/Monitoring/FlopCounter.cpp
@@ -81,17 +81,11 @@ void FlopCounter::printPerformance(double wallTime) {
              0,
              seissol::MPI::mpi.comm());
 
-  double flopsSum = 0;
-  MPI_Reduce(
-      &gflopsPerSecond,
-      &flopsSum,
-      1,
-      MPI_DOUBLE,
-      MPI_SUM,
-      0,
-      seissol::MPI::mpi.comm()
-  );
   if (rank == 0) {
+    double flopsSum = 0;
+    for (size_t i = 0; i < worldSize; i++) {
+      flopsSum += gflopsPerSecondOnRanks[i];
+    }
     const auto flopsPerRank = flopsSum / seissol::MPI::mpi.size();
     logInfo(rank) << flopsSum * 1.e-3  << "TFLOPS"
     << "(rank 0:" << gflopsPerSecond << "GFLOPS, average over ranks:" << flopsPerRank << "GFLOPS)";

--- a/src/Monitoring/FlopCounter.cpp
+++ b/src/Monitoring/FlopCounter.cpp
@@ -89,8 +89,6 @@ void FlopCounter::printPerformance(double wallTime) {
     const auto flopsPerRank = flopsSum / seissol::MPI::mpi.size();
     logInfo(rank) << flopsSum * 1.e-3  << "TFLOPS"
     << "(rank 0:" << gflopsPerSecond << "GFLOPS, average over ranks:" << flopsPerRank << "GFLOPS)";
-    std::ofstream out;
-    out.open("flops.csv");
     out << wallTime << ",";
     for (size_t i = 0; i < worldSize - 1; i++) {
       out << gflopsPerSecondOnRanks[i] << ",";

--- a/src/Monitoring/FlopCounter.cpp
+++ b/src/Monitoring/FlopCounter.cpp
@@ -64,7 +64,7 @@ void FlopCounter::init(std::string outputFileNamePrefix) {
   out << "rank_" << worldSize - 1 << std::endl;
 }
 
-void FlopCounter::printPerformance(double wallTime) {
+void FlopCounter::printPerformanceUpdate(double wallTime) {
   const int rank = seissol::MPI::mpi.rank();
   const int worldSize = seissol::MPI::mpi.size();
   const long long newTotalFlops = g_SeisSolHardwareFlopsLocal
@@ -96,8 +96,8 @@ void FlopCounter::printPerformance(double wallTime) {
       flopsSum += gflopsPerSecondOnRanks[i];
     }
     const auto flopsPerRank = flopsSum / seissol::MPI::mpi.size();
-    logInfo(rank) << flopsSum * 1.e-3  << "TFLOPS"
-    << "(rank 0:" << gflopsPerSecond << "GFLOPS, average over ranks:" << flopsPerRank << "GFLOPS)";
+    logInfo(rank) << flopsSum * 1.e-3  << "TFLOP/s"
+    << "(rank 0:" << gflopsPerSecond << "GFLOP/s, average over ranks:" << flopsPerRank << "GFLOP/s)";
     out << wallTime << ",";
     for (size_t i = 0; i < worldSize - 1; i++) {
       out << gflopsPerSecondOnRanks[i] << ",";
@@ -107,9 +107,9 @@ void FlopCounter::printPerformance(double wallTime) {
 }
   
 /**
- * Prints the measured FLOPS.
+ * Prints the measured FLOP/s.
  */
-void FlopCounter::printFlops() {
+void FlopCounter::printPerformanceSummary(double wallTime) {
   const int rank = seissol::MPI::mpi.rank();
 
   enum Counter {
@@ -148,6 +148,8 @@ void FlopCounter::printFlops() {
 #endif
   logInfo(rank) << "Total calculated HW-GFLOP: " << (totalFlops[WPHardwareFlops] + totalFlops[DRHardwareFlops] + totalFlops[PLHardwareFlops]) * 1.e-9;
   logInfo(rank) << "Total calculated NZ-GFLOP: " << (totalFlops[WPNonZeroFlops]  + totalFlops[DRNonZeroFlops]  + totalFlops[PLNonZeroFlops] ) * 1.e-9;
+  logInfo(rank) << "Total calculated HW-GFLOP/s: " << (totalFlops[WPHardwareFlops] + totalFlops[DRHardwareFlops] + totalFlops[PLHardwareFlops]) * 1.e-9 / wallTime;
+  logInfo(rank) << "Total calculated NZ-GFLOP/s: " << (totalFlops[WPNonZeroFlops]  + totalFlops[DRNonZeroFlops]  + totalFlops[PLNonZeroFlops] ) * 1.e-9 / wallTime;
   logInfo(rank) << "WP calculated HW-GFLOP: " << (totalFlops[WPHardwareFlops]) * 1.e-9;
   logInfo(rank) << "WP calculated NZ-GFLOP: " << (totalFlops[WPNonZeroFlops])  * 1.e-9;
   logInfo(rank) << "DR calculated HW-GFLOP: " << (totalFlops[DRHardwareFlops]) * 1.e-9;

--- a/src/Monitoring/FlopCounter.cpp
+++ b/src/Monitoring/FlopCounter.cpp
@@ -42,6 +42,9 @@
 
 #include <fstream>
 
+long long libxsmm_num_total_flops = 0;
+long long pspamm_num_total_flops = 0;
+
 #include "Parallel/MPI.h"
 
 #include "FlopCounter.hpp"

--- a/src/Monitoring/FlopCounter.cpp
+++ b/src/Monitoring/FlopCounter.cpp
@@ -142,8 +142,10 @@ void FlopCounter::printFlops() {
   double* totalFlops = &flops[0];
 #endif
 
+#ifndef NDEBUG
   logInfo(rank) << "Total    libxsmm HW-GFLOP: " << totalFlops[Libxsmm] * 1.e-9;
   logInfo(rank) << "Total     pspamm HW-GFLOP: " << totalFlops[Pspamm] * 1.e-9;
+#endif
   logInfo(rank) << "Total calculated HW-GFLOP: " << (totalFlops[WPHardwareFlops] + totalFlops[DRHardwareFlops] + totalFlops[PLHardwareFlops]) * 1.e-9;
   logInfo(rank) << "Total calculated NZ-GFLOP: " << (totalFlops[WPNonZeroFlops]  + totalFlops[DRNonZeroFlops]  + totalFlops[PLNonZeroFlops] ) * 1.e-9;
   logInfo(rank) << "WP calculated HW-GFLOP: " << (totalFlops[WPHardwareFlops]) * 1.e-9;

--- a/src/Monitoring/FlopCounter.cpp
+++ b/src/Monitoring/FlopCounter.cpp
@@ -64,12 +64,18 @@ void FlopCounter::init(std::string outputFileNamePrefix) {
 void FlopCounter::printPerformance(double wallTime) {
   const int rank = seissol::MPI::mpi.rank();
   const int worldSize = seissol::MPI::mpi.size();
-  const long long flops = g_SeisSolHardwareFlopsLocal
+  const long long newTotalFlops = g_SeisSolHardwareFlopsLocal
                     + g_SeisSolHardwareFlopsNeighbor
                     + g_SeisSolHardwareFlopsOther
                     + g_SeisSolHardwareFlopsDynamicRupture
                     + g_SeisSolHardwareFlopsPlasticity;
-  const double gflopsPerSecond = flops * 1.e-9 / wallTime;
+  const long long diffFlops = newTotalFlops - recentTotalFlops;
+  recentTotalFlops = newTotalFlops;
+
+  const double diffTime = wallTime - recentWallTime;
+  recentWallTime = wallTime;
+
+  const double gflopsPerSecond = diffFlops * 1.e-9 / diffTime;
 
   double gflopsPerSecondOnRanks[worldSize];
   MPI_Gather(&gflopsPerSecond,

--- a/src/Monitoring/FlopCounter.hpp
+++ b/src/Monitoring/FlopCounter.hpp
@@ -64,8 +64,8 @@ class FlopCounter {
   long long g_SeisSolHardwareFlopsPlasticity = 0;
 
   void init(std::string outputFileNamePrefix);
-  void printPerformance(double wallTime);
-  void printFlops();
+  void printPerformanceUpdate(double wallTime);
+  void printPerformanceSummary(double wallTime);
 
   private:
   std::ofstream out;

--- a/src/Monitoring/FlopCounter.hpp
+++ b/src/Monitoring/FlopCounter.hpp
@@ -43,14 +43,14 @@
 
 #include <fstream>
 
+// floating point operations performed in the matrix kernels.
+// Remark: This variable is updated by the matrix kernels.
+extern long long libxsmm_num_total_flops;
+extern long long pspamm_num_total_flops;
+
 namespace seissol::monitoring {
 class FlopCounter {
   public:
-  //! floating point operations performed in the matrix kernels.
-  //!   Remark: This variable is updated by the matrix kernels.
-  long long libxsmm_num_total_flops = 0;
-  long long pspamm_num_total_flops = 0;
-
   // global variables for summing-up SeisSol internal counters
   long long g_SeisSolNonZeroFlopsLocal = 0;
   long long g_SeisSolHardwareFlopsLocal = 0;

--- a/src/Monitoring/FlopCounter.hpp
+++ b/src/Monitoring/FlopCounter.hpp
@@ -69,6 +69,8 @@ class FlopCounter {
 
   private:
   std::ofstream out;
+  long long recentTotalFlops = 0;
+  double recentWallTime = 0;
 };
 }
 

--- a/src/Monitoring/FlopCounter.hpp
+++ b/src/Monitoring/FlopCounter.hpp
@@ -49,28 +49,37 @@ extern long long libxsmm_num_total_flops;
 extern long long pspamm_num_total_flops;
 
 namespace seissol::monitoring {
-class FlopCounter {
+struct FlopCounter {
   public:
-  // global variables for summing-up SeisSol internal counters
-  long long g_SeisSolNonZeroFlopsLocal = 0;
-  long long g_SeisSolHardwareFlopsLocal = 0;
-  long long g_SeisSolNonZeroFlopsNeighbor = 0;
-  long long g_SeisSolHardwareFlopsNeighbor = 0;
-  long long g_SeisSolNonZeroFlopsOther = 0;
-  long long g_SeisSolHardwareFlopsOther = 0;
-  long long g_SeisSolNonZeroFlopsDynamicRupture = 0;
-  long long g_SeisSolHardwareFlopsDynamicRupture = 0;
-  long long g_SeisSolNonZeroFlopsPlasticity = 0;
-  long long g_SeisSolHardwareFlopsPlasticity = 0;
-
   void init(std::string outputFileNamePrefix);
   void printPerformanceUpdate(double wallTime);
   void printPerformanceSummary(double wallTime);
+  void incrementNonZeroFlopsLocal(long long update);
+  void incrementHardwareFlopsLocal(long long update);
+  void incrementNonZeroFlopsNeighbor(long long update);
+  void incrementHardwareFlopsNeighbor(long long update);
+  void incrementNonZeroFlopsOther(long long update);
+  void incrementHardwareFlopsOther(long long update);
+  void incrementNonZeroFlopsDynamicRupture(long long update);
+  void incrementHardwareFlopsDynamicRupture(long long update);
+  void incrementNonZeroFlopsPlasticity(long long update);
+  void incrementHardwareFlopsPlasticity(long long update);
 
   private:
   std::ofstream out;
-  long long recentTotalFlops = 0;
-  double recentWallTime = 0;
+  long long previousTotalFlops = 0;
+  double previousWallTime = 0;
+  // global variables for summing-up SeisSol internal counters
+  long long nonZeroFlopsLocal = 0;
+  long long hardwareFlopsLocal = 0;
+  long long nonZeroFlopsNeighbor = 0;
+  long long hardwareFlopsNeighbor = 0;
+  long long nonZeroFlopsOther = 0;
+  long long hardwareFlopsOther = 0;
+  long long nonZeroFlopsDynamicRupture = 0;
+  long long hardwareFlopsDynamicRupture = 0;
+  long long nonZeroFlopsPlasticity = 0;
+  long long hardwareFlopsPlasticity = 0;
 };
 }
 

--- a/src/Monitoring/FlopCounter.hpp
+++ b/src/Monitoring/FlopCounter.hpp
@@ -43,8 +43,8 @@
 
 #include <fstream>
 
-// floating point operations performed in the matrix kernels.
-// Remark: This variable is updated by the matrix kernels.
+// Floating point operations performed in the matrix kernels.
+// Remark: These variables are updated by the matrix kernels (subroutine.cpp) only in debug builds.
 extern long long libxsmm_num_total_flops;
 extern long long pspamm_num_total_flops;
 

--- a/src/Monitoring/FlopCounter.hpp
+++ b/src/Monitoring/FlopCounter.hpp
@@ -41,24 +41,35 @@
 #ifndef FLOPCOUNTER_HPP
 #define FLOPCOUNTER_HPP
 
-//! floating point operations performed in the matrix kernels.
-//!   Remark: This variable is updated by the matrix kernels.
-extern long long libxsmm_num_total_flops;
-extern long long pspamm_num_total_flops;
+#include <fstream>
 
-// global variables for summing-up SeisSol internal counters
-extern long long g_SeisSolNonZeroFlopsLocal;
-extern long long g_SeisSolHardwareFlopsLocal;
-extern long long g_SeisSolNonZeroFlopsNeighbor;
-extern long long g_SeisSolHardwareFlopsNeighbor;
-extern long long g_SeisSolNonZeroFlopsOther;
-extern long long g_SeisSolHardwareFlopsOther;
-extern long long g_SeisSolNonZeroFlopsDynamicRupture;
-extern long long g_SeisSolHardwareFlopsDynamicRupture;
-extern long long g_SeisSolNonZeroFlopsPlasticity;
-extern long long g_SeisSolHardwareFlopsPlasticity;
+namespace seissol::monitoring {
+class FlopCounter {
+  public:
+  //! floating point operations performed in the matrix kernels.
+  //!   Remark: This variable is updated by the matrix kernels.
+  long long libxsmm_num_total_flops = 0;
+  long long pspamm_num_total_flops = 0;
 
-void printPerformance(double wallTime);
-void printFlops();
+  // global variables for summing-up SeisSol internal counters
+  long long g_SeisSolNonZeroFlopsLocal = 0;
+  long long g_SeisSolHardwareFlopsLocal = 0;
+  long long g_SeisSolNonZeroFlopsNeighbor = 0;
+  long long g_SeisSolHardwareFlopsNeighbor = 0;
+  long long g_SeisSolNonZeroFlopsOther = 0;
+  long long g_SeisSolHardwareFlopsOther = 0;
+  long long g_SeisSolNonZeroFlopsDynamicRupture = 0;
+  long long g_SeisSolHardwareFlopsDynamicRupture = 0;
+  long long g_SeisSolNonZeroFlopsPlasticity = 0;
+  long long g_SeisSolHardwareFlopsPlasticity = 0;
+
+  void init(std::string outputFileNamePrefix);
+  void printPerformance(double wallTime);
+  void printFlops();
+
+  private:
+  std::ofstream out;
+};
+}
 
 #endif

--- a/src/ResultWriter/inioutput_seissol.f90
+++ b/src/ResultWriter/inioutput_seissol.f90
@@ -149,7 +149,7 @@ CONTAINS
         i_outputGroups = io%OutputGroups, &
         i_outputGroupsSize = size(io%OutputGroups), &
         freeSurfaceInterval = io%SurfaceOutputInterval, &
-        freeSurfaceFilename = trim(io%OutputFile) // c_null_char, &
+        outputFileNamePrefix = trim(io%OutputFile) // c_null_char, &
         xdmfWriterBackend = trim(io%xdmfWriterBackend) // c_null_char, &
         receiverFileName = trim(io%RFileName) // c_null_char, &
         receiverSamplingInterval = io%pickdt, &

--- a/src/SeisSol.h
+++ b/src/SeisSol.h
@@ -49,6 +49,7 @@
 #include "Checkpoint/Manager.h"
 #include "Initializer/time_stepping/LtsLayout.h"
 #include "Initializer/typedefs.hpp"
+#include "Monitoring/FlopCounter.hpp"
 #include "Parallel/Pin.h"
 #include "ResultWriter/AnalysisWriter.h"
 #include "ResultWriter/AsyncIO.h"
@@ -138,6 +139,9 @@ private:
 
   //! Input parameters
   std::shared_ptr<YAML::Node> m_inputParams;
+
+  //! Flop Counter
+  monitoring::FlopCounter m_flopCounter;
 private:
 	/**
 	 * Only one instance of this class should exist (private constructor).
@@ -256,6 +260,13 @@ public:
    writer::EnergyOutput& energyOutput() {
      return m_energyOutput;
    }
+
+  /**
+   * Get the flop counter
+   */
+  monitoring::FlopCounter& flopCounter() {
+    return m_flopCounter;
+  }
 
 	/**
 	 * Set the mesh reader

--- a/src/SeisSol.h
+++ b/src/SeisSol.h
@@ -41,29 +41,26 @@
 #ifndef SEISSOL_H
 #define SEISSOL_H
 
+#include <memory>
 #include <string>
 
 #include "utils/logger.h"
 
-#include "Solver/time_stepping/TimeManager.h"
-#include "Solver/Simulator.h"
-#include "Solver/FreeSurfaceIntegrator.h"
-#include "Initializer/typedefs.hpp"
-#include "Initializer/time_stepping/LtsLayout.h"
 #include "Checkpoint/Manager.h"
-#include "SourceTerm/Manager.h"
-#include "ResultWriter/PostProcessor.h"
-#include "ResultWriter/FreeSurfaceWriter.h"
-
-#include "ResultWriter/AsyncIO.h"
-#include "ResultWriter/WaveFieldWriter.h"
-#include "ResultWriter/FaultWriter.h"
-#include "ResultWriter/EnergyOutput.h"
-
-#include "ResultWriter/AnalysisWriter.h"
-#include <memory>
-
+#include "Initializer/time_stepping/LtsLayout.h"
+#include "Initializer/typedefs.hpp"
 #include "Parallel/Pin.h"
+#include "ResultWriter/AnalysisWriter.h"
+#include "ResultWriter/AsyncIO.h"
+#include "ResultWriter/EnergyOutput.h"
+#include "ResultWriter/FaultWriter.h"
+#include "ResultWriter/FreeSurfaceWriter.h"
+#include "ResultWriter/PostProcessor.h"
+#include "ResultWriter/WaveFieldWriter.h"
+#include "Solver/FreeSurfaceIntegrator.h"
+#include "Solver/Simulator.h"
+#include "Solver/time_stepping/TimeManager.h"
+#include "SourceTerm/Manager.h"
 
 class MeshReader;
 

--- a/src/Solver/Interoperability.cpp
+++ b/src/Solver/Interoperability.cpp
@@ -218,13 +218,13 @@ extern "C" {
   void c_interoperability_initializeIO(
 		  int numSides, int numBndGP, int refinement, int* outputMask, int* plasticityMask, double* outputRegionBounds,
 		  int* outputGroups, int outputGroupsSize,
-		  double freeSurfaceInterval, const char* freeSurfaceFilename, const char* xdmfWriterBackend,
+		  double freeSurfaceInterval, const char* outputFileNamePrefix, const char* xdmfWriterBackend,
       const char* receiverFileName, double receiverSamplingInterval, double receiverSyncInterval,
       bool isPlasticityEnabled, bool isEnergyTerminalOutputEnabled, double energySyncInterval) {
       auto outputGroupBounds = std::unordered_set<int>(outputGroups, outputGroups + outputGroupsSize);
     e_interoperability.initializeIO(numSides, numBndGP, refinement, outputMask, plasticityMask, outputRegionBounds,
                                     outputGroupBounds,
-                                    freeSurfaceInterval, freeSurfaceFilename, xdmfWriterBackend,
+                                    freeSurfaceInterval, outputFileNamePrefix, xdmfWriterBackend,
                                     receiverFileName, receiverSamplingInterval, receiverSyncInterval,
                                     isPlasticityEnabled, isEnergyTerminalOutputEnabled, energySyncInterval);
   }
@@ -871,7 +871,7 @@ seissol::Interoperability::initializeIO(int numSides, int numBndGP, int refineme
                                         int* outputMask,
                                         int* plasticityMask, double* outputRegionBounds,
                                         const std::unordered_set<int>& outputGroups,
-                                        double freeSurfaceInterval, const char* freeSurfaceFilename,
+                                        double freeSurfaceInterval, const char* outputFileNamePrefix,
                                         const char* xdmfWriterBackend,
                                         const char* receiverFileName, double receiverSamplingInterval,
                                         double receiverSyncInterval,
@@ -942,13 +942,13 @@ seissol::Interoperability::initializeIO(int numSides, int numBndGP, int refineme
 	seissol::SeisSol::main.freeSurfaceWriter().init(
 		seissol::SeisSol::main.meshReader(),
 		&seissol::SeisSol::main.freeSurfaceIntegrator(),
-		freeSurfaceFilename, freeSurfaceInterval, type);
+		outputFileNamePrefix, freeSurfaceInterval, type);
 
 
   auto& receiverWriter = seissol::SeisSol::main.receiverWriter();
   // Initialize receiver output
   receiverWriter.init(std::string(receiverFileName),
-                      std::string(freeSurfaceFilename),
+                      std::string(outputFileNamePrefix),
                       receiverSyncInterval,
                       receiverSamplingInterval);
   receiverWriter.addPoints(
@@ -972,14 +972,14 @@ seissol::Interoperability::initializeIO(int numSides, int numBndGP, int refineme
                     &m_ltsLut,
                     isPlasticityEnabled,
                     isEnergyTerminalOutputEnabled,
-                    freeSurfaceFilename,
+                    outputFileNamePrefix,
                     energySyncInterval);
 
-  seissol::SeisSol::main.flopCounter().init(freeSurfaceFilename);
+  seissol::SeisSol::main.flopCounter().init(outputFileNamePrefix);
 
 	seissol::SeisSol::main.analysisWriter().init(
 	    &seissol::SeisSol::main.meshReader(),
-	    freeSurfaceFilename);
+	    outputFileNamePrefix);
 }
 
 void seissol::Interoperability::initInitialConditions()

--- a/src/Solver/Interoperability.cpp
+++ b/src/Solver/Interoperability.cpp
@@ -975,6 +975,8 @@ seissol::Interoperability::initializeIO(int numSides, int numBndGP, int refineme
                     freeSurfaceFilename,
                     energySyncInterval);
 
+  seissol::SeisSol::main.flopCounter().init(freeSurfaceFilename);
+
 	seissol::SeisSol::main.analysisWriter().init(
 	    &seissol::SeisSol::main.meshReader(),
 	    freeSurfaceFilename);

--- a/src/Solver/Interoperability.h
+++ b/src/Solver/Interoperability.h
@@ -278,7 +278,7 @@ class seissol::Interoperability {
 
    void initializeIO(int numSides, int numBndGP, int refinement, int* outputMask,
                      int* plasticityMask, double* outputRegionBounds, const std::unordered_set<int>& outputGroups,
-                     double freeSurfaceInterval, const char* freeSurfaceFilename, const char* xdmfWriterBackend,
+                     double freeSurfaceInterval, const char* outputFileNamePrefix, const char* xdmfWriterBackend,
                      const char* receiverFileName, double receiverSamplingInterval, double receiverSyncInterval,
                      bool isPlasticityEnabled, bool isEnergyTerminalOutputEnabled, double energySyncInterval);
 

--- a/src/Solver/Simulator.cpp
+++ b/src/Solver/Simulator.cpp
@@ -139,7 +139,7 @@ void seissol::Simulator::simulate() {
     }
     upcomingTime = std::min(upcomingTime, m_checkPointTime + m_checkPointInterval);
 
-    seissol::SeisSol::main.flopCounter().printPerformance(stopwatch.split());
+    seissol::SeisSol::main.flopCounter().printPerformanceUpdate(stopwatch.split());
   }
 
   Modules::callSyncHook(m_currentTime, l_timeTolerance, true);
@@ -151,5 +151,5 @@ void seissol::Simulator::simulate() {
 
   seissol::SeisSol::main.analysisWriter().printAnalysis(m_currentTime);
 
-  seissol::SeisSol::main.flopCounter().printFlops();
+  seissol::SeisSol::main.flopCounter().printPerformanceSummary(wallTime);
 }

--- a/src/Solver/Simulator.cpp
+++ b/src/Solver/Simulator.cpp
@@ -139,7 +139,7 @@ void seissol::Simulator::simulate() {
     }
     upcomingTime = std::min(upcomingTime, m_checkPointTime + m_checkPointInterval);
 
-    printPerformance(stopwatch.split());
+    seissol::SeisSol::main.flopCounter().printPerformance(stopwatch.split());
   }
 
   Modules::callSyncHook(m_currentTime, l_timeTolerance, true);
@@ -151,5 +151,5 @@ void seissol::Simulator::simulate() {
 
   seissol::SeisSol::main.analysisWriter().printAnalysis(m_currentTime);
 
-  printFlops();
+  seissol::SeisSol::main.flopCounter().printFlops();
 }

--- a/src/Solver/f_ftoc_bind_interoperability.f90
+++ b/src/Solver/f_ftoc_bind_interoperability.f90
@@ -292,7 +292,7 @@ module f_ftoc_bind_interoperability
 
     subroutine c_interoperability_initializeIO( &
         i_numSides, i_numBndGP, i_refinement, i_outputMask, i_plasticityMask, i_outputRegionBounds, i_outputGroups, i_outputGroupsSize, &
-        freeSurfaceInterval, freeSurfaceFilename, xdmfWriterBackend, &
+        freeSurfaceInterval, outputFileNamePrefix, xdmfWriterBackend, &
         receiverFileName, receiverSamplingInterval, receiverSyncInterval, &
         isPlasticityEnabled, isEnergyTerminalOutputEnabled, energySyncInterval) &
         bind( C, name='c_interoperability_initializeIO' )
@@ -308,7 +308,7 @@ module f_ftoc_bind_interoperability
       integer(kind=c_int), dimension(*), intent(in) :: i_outputGroups
       integer(kind=c_int), value :: i_outputGroupsSize
       real(kind=c_double), value                    :: freeSurfaceInterval
-      character(kind=c_char), dimension(*), intent(in) :: freeSurfaceFilename
+      character(kind=c_char), dimension(*), intent(in) :: outputFileNamePrefix
       character(kind=c_char), dimension(*), intent(in) :: xdmfWriterBackend
       character(kind=c_char), dimension(*), intent(in) :: receiverFileName
       real(kind=c_double), value                    :: receiverSamplingInterval

--- a/src/Solver/time_stepping/TimeCluster.cpp
+++ b/src/Solver/time_stepping/TimeCluster.cpp
@@ -516,10 +516,10 @@ void seissol::time_stepping::TimeCluster::computeNeighboringIntegration( seissol
                                                                                       table,
                                                                                       plasticity);
 
-    g_SeisSolNonZeroFlopsPlasticity +=
+    seissol::SeisSol::main.flopCounter().g_SeisSolNonZeroFlopsPlasticity +=
         i_layerData.getNumberOfCells() * m_flops_nonZero[static_cast<int>(ComputePart::PlasticityCheck)]
         + numAdjustedDofs * m_flops_nonZero[static_cast<int>(ComputePart::PlasticityYield)];
-    g_SeisSolHardwareFlopsPlasticity +=
+    seissol::SeisSol::main.flopCounter().g_SeisSolHardwareFlopsPlasticity +=
         i_layerData.getNumberOfCells() * m_flops_hardware[static_cast<int>(ComputePart::PlasticityCheck)]
         + numAdjustedDofs * m_flops_hardware[static_cast<int>(ComputePart::PlasticityYield)];
   }
@@ -642,8 +642,8 @@ void TimeCluster::predict() {
   computeLocalIntegration(*m_clusterData, resetBuffers);
   computeSources();
 
-  g_SeisSolNonZeroFlopsLocal += m_flops_nonZero[static_cast<int>(ComputePart::Local)];
-  g_SeisSolHardwareFlopsLocal += m_flops_hardware[static_cast<int>(ComputePart::Local)];
+  seissol::SeisSol::main.flopCounter().g_SeisSolNonZeroFlopsLocal += m_flops_nonZero[static_cast<int>(ComputePart::Local)];
+  seissol::SeisSol::main.flopCounter().g_SeisSolHardwareFlopsLocal += m_flops_hardware[static_cast<int>(ComputePart::Local)];
 }
 void TimeCluster::correct() {
   assert(state == ActorState::Predicted);
@@ -673,24 +673,24 @@ void TimeCluster::correct() {
   if (dynamicRuptureScheduler->hasDynamicRuptureFaces()) {
     if (dynamicRuptureScheduler->mayComputeInterior(ct.stepsSinceStart)) {
       computeDynamicRupture(*dynRupInteriorData);
-      g_SeisSolNonZeroFlopsDynamicRupture += m_flops_nonZero[static_cast<int>(ComputePart::DRFrictionLawInterior)];
-      g_SeisSolHardwareFlopsDynamicRupture += m_flops_hardware[static_cast<int>(ComputePart::DRFrictionLawInterior)];
+      seissol::SeisSol::main.flopCounter().g_SeisSolNonZeroFlopsDynamicRupture += m_flops_nonZero[static_cast<int>(ComputePart::DRFrictionLawInterior)];
+      seissol::SeisSol::main.flopCounter().g_SeisSolHardwareFlopsDynamicRupture += m_flops_hardware[static_cast<int>(ComputePart::DRFrictionLawInterior)];
       dynamicRuptureScheduler->setLastCorrectionStepsInterior(ct.stepsSinceStart);
     }
     if (layerType == Copy) {
       computeDynamicRupture(*dynRupCopyData);
-      g_SeisSolNonZeroFlopsDynamicRupture += m_flops_nonZero[static_cast<int>(ComputePart::DRFrictionLawCopy)];
-      g_SeisSolHardwareFlopsDynamicRupture += m_flops_hardware[static_cast<int>(ComputePart::DRFrictionLawCopy)];
+      seissol::SeisSol::main.flopCounter().g_SeisSolNonZeroFlopsDynamicRupture += m_flops_nonZero[static_cast<int>(ComputePart::DRFrictionLawCopy)];
+      seissol::SeisSol::main.flopCounter().g_SeisSolHardwareFlopsDynamicRupture += m_flops_hardware[static_cast<int>(ComputePart::DRFrictionLawCopy)];
       dynamicRuptureScheduler->setLastCorrectionStepsCopy((ct.stepsSinceStart));
     }
 
   }
   computeNeighboringIntegration(*m_clusterData, subTimeStart);
 
-  g_SeisSolNonZeroFlopsNeighbor += m_flops_nonZero[static_cast<int>(ComputePart::Neighbor)];
-  g_SeisSolHardwareFlopsNeighbor += m_flops_hardware[static_cast<int>(ComputePart::Neighbor)];
-  g_SeisSolNonZeroFlopsDynamicRupture += m_flops_nonZero[static_cast<int>(ComputePart::DRNeighbor)];
-  g_SeisSolHardwareFlopsDynamicRupture += m_flops_hardware[static_cast<int>(ComputePart::DRNeighbor)];
+  seissol::SeisSol::main.flopCounter().g_SeisSolNonZeroFlopsNeighbor += m_flops_nonZero[static_cast<int>(ComputePart::Neighbor)];
+  seissol::SeisSol::main.flopCounter().g_SeisSolHardwareFlopsNeighbor += m_flops_hardware[static_cast<int>(ComputePart::Neighbor)];
+  seissol::SeisSol::main.flopCounter().g_SeisSolNonZeroFlopsDynamicRupture += m_flops_nonZero[static_cast<int>(ComputePart::DRNeighbor)];
+  seissol::SeisSol::main.flopCounter().g_SeisSolHardwareFlopsDynamicRupture += m_flops_hardware[static_cast<int>(ComputePart::DRNeighbor)];
 
   // First cluster calls fault receiver output
   // Call fault output only if both interior and copy parts of DR were computed

--- a/src/Solver/time_stepping/TimeCluster.cpp
+++ b/src/Solver/time_stepping/TimeCluster.cpp
@@ -516,12 +516,12 @@ void seissol::time_stepping::TimeCluster::computeNeighboringIntegration( seissol
                                                                                       table,
                                                                                       plasticity);
 
-    seissol::SeisSol::main.flopCounter().g_SeisSolNonZeroFlopsPlasticity +=
+    seissol::SeisSol::main.flopCounter().incrementNonZeroFlopsPlasticity()
         i_layerData.getNumberOfCells() * m_flops_nonZero[static_cast<int>(ComputePart::PlasticityCheck)]
-        + numAdjustedDofs * m_flops_nonZero[static_cast<int>(ComputePart::PlasticityYield)];
-    seissol::SeisSol::main.flopCounter().g_SeisSolHardwareFlopsPlasticity +=
+        + numAdjustedDofs * m_flops_nonZero[static_cast<int>(ComputePart::PlasticityYield)]);
+    seissol::SeisSol::main.flopCounter().incrementHardwareFlopsPlasticity(
         i_layerData.getNumberOfCells() * m_flops_hardware[static_cast<int>(ComputePart::PlasticityCheck)]
-        + numAdjustedDofs * m_flops_hardware[static_cast<int>(ComputePart::PlasticityYield)];
+        + numAdjustedDofs * m_flops_hardware[static_cast<int>(ComputePart::PlasticityYield)]);
   }
 
   device.api->synchDevice();
@@ -642,8 +642,8 @@ void TimeCluster::predict() {
   computeLocalIntegration(*m_clusterData, resetBuffers);
   computeSources();
 
-  seissol::SeisSol::main.flopCounter().g_SeisSolNonZeroFlopsLocal += m_flops_nonZero[static_cast<int>(ComputePart::Local)];
-  seissol::SeisSol::main.flopCounter().g_SeisSolHardwareFlopsLocal += m_flops_hardware[static_cast<int>(ComputePart::Local)];
+  seissol::SeisSol::main.flopCounter().incrementNonZeroFlopsLocal(m_flops_nonZero[static_cast<int>(ComputePart::Local)]);
+  seissol::SeisSol::main.flopCounter().incrementHardwareFlopsLocal(m_flops_hardware[static_cast<int>(ComputePart::Local)]);
 }
 void TimeCluster::correct() {
   assert(state == ActorState::Predicted);
@@ -673,24 +673,24 @@ void TimeCluster::correct() {
   if (dynamicRuptureScheduler->hasDynamicRuptureFaces()) {
     if (dynamicRuptureScheduler->mayComputeInterior(ct.stepsSinceStart)) {
       computeDynamicRupture(*dynRupInteriorData);
-      seissol::SeisSol::main.flopCounter().g_SeisSolNonZeroFlopsDynamicRupture += m_flops_nonZero[static_cast<int>(ComputePart::DRFrictionLawInterior)];
-      seissol::SeisSol::main.flopCounter().g_SeisSolHardwareFlopsDynamicRupture += m_flops_hardware[static_cast<int>(ComputePart::DRFrictionLawInterior)];
+      seissol::SeisSol::main.flopCounter().incrementNonZeroFlopsDynamicRupture(m_flops_nonZero[static_cast<int>(ComputePart::DRFrictionLawInterior)]);
+      seissol::SeisSol::main.flopCounter().incrementHardwareFlopsDynamicRupture(m_flops_hardware[static_cast<int>(ComputePart::DRFrictionLawInterior)]);
       dynamicRuptureScheduler->setLastCorrectionStepsInterior(ct.stepsSinceStart);
     }
     if (layerType == Copy) {
       computeDynamicRupture(*dynRupCopyData);
-      seissol::SeisSol::main.flopCounter().g_SeisSolNonZeroFlopsDynamicRupture += m_flops_nonZero[static_cast<int>(ComputePart::DRFrictionLawCopy)];
-      seissol::SeisSol::main.flopCounter().g_SeisSolHardwareFlopsDynamicRupture += m_flops_hardware[static_cast<int>(ComputePart::DRFrictionLawCopy)];
+      seissol::SeisSol::main.flopCounter().incrementNonZeroFlopsDynamicRupture(m_flops_nonZero[static_cast<int>(ComputePart::DRFrictionLawCopy)]);
+      seissol::SeisSol::main.flopCounter().incrementHardwareFlopsDynamicRupture(m_flops_hardware[static_cast<int>(ComputePart::DRFrictionLawCopy)]);
       dynamicRuptureScheduler->setLastCorrectionStepsCopy((ct.stepsSinceStart));
     }
 
   }
   computeNeighboringIntegration(*m_clusterData, subTimeStart);
 
-  seissol::SeisSol::main.flopCounter().g_SeisSolNonZeroFlopsNeighbor += m_flops_nonZero[static_cast<int>(ComputePart::Neighbor)];
-  seissol::SeisSol::main.flopCounter().g_SeisSolHardwareFlopsNeighbor += m_flops_hardware[static_cast<int>(ComputePart::Neighbor)];
-  seissol::SeisSol::main.flopCounter().g_SeisSolNonZeroFlopsDynamicRupture += m_flops_nonZero[static_cast<int>(ComputePart::DRNeighbor)];
-  seissol::SeisSol::main.flopCounter().g_SeisSolHardwareFlopsDynamicRupture += m_flops_hardware[static_cast<int>(ComputePart::DRNeighbor)];
+  seissol::SeisSol::main.flopCounter().incrementNonZeroFlopsNeighbor(m_flops_nonZero[static_cast<int>(ComputePart::Neighbor)]);
+  seissol::SeisSol::main.flopCounter().incrementHardwareFlopsNeighbor(m_flops_hardware[static_cast<int>(ComputePart::Neighbor)]);
+  seissol::SeisSol::main.flopCounter().incrementNonZeroFlopsDynamicRupture(m_flops_nonZero[static_cast<int>(ComputePart::DRNeighbor)]);
+  seissol::SeisSol::main.flopCounter().incrementHardwareFlopsDynamicRupture(m_flops_hardware[static_cast<int>(ComputePart::DRNeighbor)]);
 
   // First cluster calls fault receiver output
   // Call fault output only if both interior and copy parts of DR were computed

--- a/src/Solver/time_stepping/TimeCluster.cpp
+++ b/src/Solver/time_stepping/TimeCluster.cpp
@@ -516,7 +516,7 @@ void seissol::time_stepping::TimeCluster::computeNeighboringIntegration( seissol
                                                                                       table,
                                                                                       plasticity);
 
-    seissol::SeisSol::main.flopCounter().incrementNonZeroFlopsPlasticity()
+    seissol::SeisSol::main.flopCounter().incrementNonZeroFlopsPlasticity(
         i_layerData.getNumberOfCells() * m_flops_nonZero[static_cast<int>(ComputePart::PlasticityCheck)]
         + numAdjustedDofs * m_flops_nonZero[static_cast<int>(ComputePart::PlasticityYield)]);
     seissol::SeisSol::main.flopCounter().incrementHardwareFlopsPlasticity(


### PR DESCRIPTION
* Write Flop Counter per node to csv file for detailed analysis.
* Compute current performance (since last syncpoint) instead of average since the beginning. This way you better see changes in performance.
* Better output to stdout.