### PR TITLE
Add possibility to output volume energies less frequently than fault energies

### DIFF
--- a/Documentation/behind_firewall.rst
+++ b/Documentation/behind_firewall.rst
@@ -114,11 +114,16 @@ where ddddd is an arbitrary port number with 5 digits.
 
     ~/.local/bin/proxy --port 8899
 
-4. Login to the HPC cluster (e.g. `ssh supermucNG`). Pip can be used with
+4. Login to the HPC cluster (e.g. `ssh supermucNG`). 
+Check that you do not get: `Warning: remote port forwarding failed for listen port ddddd`.
+In this case you would need to change ddddd to a different port.
+Note that the problem might also be you have already an opened connection to the HPC cluster.
+
+Once connected to the HPC cluster, pip can be used with
 
 ::
 
-    pip install <package name> --user --proxy localhost:ddddd
+    pip install <package name> --user --proxy http://localhost:ddddd/
 
 where ddddd is your arbitrary port number.
 

--- a/Documentation/energy-output.rst
+++ b/Documentation/energy-output.rst
@@ -42,6 +42,7 @@ Configuration
     EnergyOutput = 1
     EnergyTerminalOutput = 1
     EnergyOutputInterval = 0.05
+    ComputeVolumeEnergiesEveryOutput = 4 ! Compute volume energies only once every ComputeVolumeEnergiesEveryOutput * EnergyOutputInterval 
     /
 
 Energy output
@@ -63,3 +64,25 @@ Output interval
 ~~~~~~~~~~~~~~~~
 The output interval is controlled by EnergyOutputInterval.
 If the output interval is not specified, the energy will be computed at the start of the simulation and at the end of the simulation.
+
+
+Postprocessing and plotting
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The code below suggests a way to process and plot variables of the energy output file:
+
+.. conde-block:: python
+	import pandas as pd
+	import numpy as np
+	import matplotlib.pylab as plt
+
+	df = pd.read_csv("prefix-energy.csv")
+	df = df.pivot_table(index="time", columns="variable", values="measurement")
+	df["seismic_moment_rate"] = np.gradient(df["seismic_moment"], df.index[1])
+	df.plot(y="seismic_moment_rate", use_index=True)
+
+	# if ComputeVolumeEnergiesEveryOutput > 1
+	volume_output = df.dropna()
+	volume_output.plot(y="elastic_energy", use_index=True)
+
+	plt.show()

--- a/Documentation/parameters.par
+++ b/Documentation/parameters.par
@@ -137,7 +137,7 @@ xdmfWriterBackend = 'posix' ! (optional) The backend used in fault, wavefield,
 EnergyOutput = 1 ! Computation of energy, written in csv file
 EnergyTerminalOutput = 1 ! Write energy to standard output
 EnergyOutputInterval = 0.05
-
+ComputeVolumeEnergiesEveryOutput = 4 ! Compute volume energies only once every ComputeVolumeEnergiesEveryOutput * EnergyOutputInterval 
 /
            
 &AbortCriteria

--- a/postprocessing/validation/compare-energies.py
+++ b/postprocessing/validation/compare-energies.py
@@ -21,6 +21,12 @@ if __name__ == "__main__":
         "seismic_moment",
     ]
     energy = pd.read_csv(args.energy)
+
+    if 'variable' in energy:
+        # the format of the energy output changed following PR #773 (02.2023), allowing 
+        # to compute volume energies less frequently
+        energy = energy.pivot_table(index="time", columns="variable", values="measurement")
+
     energy = energy[relevant_quantities]
     energy_ref = pd.read_csv(args.energy_ref)
     energy_ref = energy_ref[relevant_quantities]

--- a/src/Numerical_aux/typesdef.f90
+++ b/src/Numerical_aux/typesdef.f90
@@ -970,6 +970,7 @@ MODULE TypesDef
      character(len=64)                      :: xdmfWriterBackend                !< Check point backend
      logical                                :: isEnergyTerminalOutputEnabled    !< Whether energy output should be written to terminal
      real                                   :: EnergyOutputInterval
+     integer                                :: computeVolumeEnergiesEveryOutput !< computing volume energies each EnergyOutputInterval*computeVolumeEnergyEveryOutput
      logical                                :: ReceiverComputeRotation                  !< Whether the rotation of the velocity field should be computed
 
   END TYPE tInputOutput

--- a/src/Reader/readpar.f90
+++ b/src/Reader/readpar.f90
@@ -2283,6 +2283,7 @@ ALLOCATE( SpacePositionx(nDirac), &
       character(LEN=64)                :: xdmfWriterBackend
       INTEGER                          :: EnergyOutput
       INTEGER                          :: EnergyTerminalOutput
+      INTEGER                          :: computeVolumeEnergiesEveryOutput
       real                             :: EnergyOutputInterval
       INTEGER                          :: ReceiverComputeRotation
 
@@ -2293,7 +2294,7 @@ ALLOCATE( SpacePositionx(nDirac), &
                                                 checkPointInterval, checkPointFile, checkPointBackend, OutputRegionBounds, OutputGroups, IntegrationMask, &
                                                 SurfaceOutput, SurfaceOutputRefinement, SurfaceOutputInterval, xdmfWriterBackend, &
                                                 ReceiverOutputInterval, nRecordPoints, &
-                                                EnergyOutput, EnergyTerminalOutput, EnergyOutputInterval, ReceiverComputeRotation
+                                                EnergyOutput, EnergyTerminalOutput, EnergyOutputInterval, computeVolumeEnergiesEveryOutput, ReceiverComputeRotation
 
               !------------------------------------------------------------------------
     !
@@ -2335,6 +2336,7 @@ ALLOCATE( SpacePositionx(nDirac), &
       EnergyOutput = 0
       EnergyTerminalOutput = 0
       EnergyOutputInterval = -1.0
+      computeVolumeEnergiesEveryOutput = 1
       READ(IO%UNIT%FileIn, IOSTAT=readStat, nml = Output)
 
     IF (readStat.NE.0) THEN
@@ -2620,6 +2622,7 @@ ALLOCATE( SpacePositionx(nDirac), &
             IO%EnergyOutputInterval = -1.0
         end if
         IO%isEnergyTerminalOutputEnabled = EnergyTerminalOutput == 1
+        IO%computeVolumeEnergiesEveryOutput = computeVolumeEnergiesEveryOutput
         IO%energyOutputInterval = EnergyOutputInterval
 
       IF(EQN%DR.NE.0) THEN

--- a/src/ResultWriter/EnergyOutput.cpp
+++ b/src/ResultWriter/EnergyOutput.cpp
@@ -405,29 +405,35 @@ void EnergyOutput::printEnergies() {
         100.0 * energiesStorage.plasticMoment() /
         (energiesStorage.plasticMoment() + energiesStorage.seismicMoment());
 
-    if (totalElasticEnergy) {
-      logInfo(rank) << "Elastic energy (total, % kinematic, % potential): " << totalElasticEnergy
-                    << " ," << ratioElasticKinematic << " ," << ratioElasticPotential;
+    if (OutputId % computeVolumeEnergiesEveryOutput == 0) {
+        if (totalElasticEnergy) {
+          logInfo(rank) << "Elastic energy (total, % kinematic, % potential): " << totalElasticEnergy
+                        << " ," << ratioElasticKinematic << " ," << ratioElasticPotential;
+        }
+        if (totalAcousticEnergy) {
+          logInfo(rank) << "Acoustic energy (total, % kinematic, % potential): " << totalAcousticEnergy
+                        << " ," << ratioAcousticKinematic << " ," << ratioAcousticPotential;
+        }
+        if (energiesStorage.gravitationalEnergy()) {
+          logInfo(rank) << "Gravitational energy:" << energiesStorage.gravitationalEnergy();
+        }
+        if (energiesStorage.plasticMoment()) {
+          logInfo(rank) << "Plastic moment (value, equivalent Mw, % total moment):"
+                        << energiesStorage.plasticMoment() << " ,"
+                        << 2.0 / 3.0 * std::log10(energiesStorage.plasticMoment()) - 6.07 << " ,"
+                        << ratioPlasticMoment;
+        }
+    } else {
+          logInfo(rank) << "Volume energies skipped at this step" << energiesStorage.elasticEnergy();
     }
-    if (totalAcousticEnergy) {
-      logInfo(rank) << "Acoustic energy (total, % kinematic, % potential): " << totalAcousticEnergy
-                    << " ," << ratioAcousticKinematic << " ," << ratioAcousticPotential;
-    }
-    if (energiesStorage.gravitationalEnergy()) {
-      logInfo(rank) << "Gravitational energy:" << energiesStorage.gravitationalEnergy();
-    }
+
     if (totalFrictionalWork) {
       logInfo(rank) << "Frictional work (total, % static, % radiated): " << totalFrictionalWork
                     << " ," << ratioFrictionalStatic << " ," << ratioFrictionalRadiated;
       logInfo(rank) << "Seismic moment (without plasticity):" << energiesStorage.seismicMoment()
                     << " Mw:" << 2.0 / 3.0 * std::log10(energiesStorage.seismicMoment()) - 6.07;
     }
-    if (energiesStorage.plasticMoment()) {
-      logInfo(rank) << "Plastic moment (value, equivalent Mw, % total moment):"
-                    << energiesStorage.plasticMoment() << " ,"
-                    << 2.0 / 3.0 * std::log10(energiesStorage.plasticMoment()) - 6.07 << " ,"
-                    << ratioPlasticMoment;
-    }
+
     if (!std::isfinite(totalElasticEnergy + totalAcousticEnergy)) {
       logError() << "Detected Inf/NaN in energies. Aborting.";
     }

--- a/src/ResultWriter/EnergyOutput.h
+++ b/src/ResultWriter/EnergyOutput.h
@@ -51,6 +51,7 @@ class EnergyOutput : public Module {
             seissol::initializers::Lut* newLtsLut,
             bool newIsPlasticityEnabled,
             bool newIsTerminalOutputEnabled,
+            int newComputeVolumeEnergiesEveryOutput,
             const std::string& outputFileNamePrefix,
             double newSyncPointInterval);
 
@@ -67,6 +68,8 @@ class EnergyOutput : public Module {
 
   void computeDynamicRuptureEnergies();
 
+  void computeVolumeEnergies();
+
   void computeEnergies();
 
   void reduceEnergies();
@@ -81,6 +84,8 @@ class EnergyOutput : public Module {
   bool isTerminalOutputEnabled = false;
   bool isFileOutputEnabled = false;
   bool isPlasticityEnabled = false;
+  int computeVolumeEnergiesEveryOutput = 1;
+  int OutputId = 0;
 
   std::string outputFileName;
   std::ofstream out;

--- a/src/ResultWriter/EnergyOutput.h
+++ b/src/ResultWriter/EnergyOutput.h
@@ -80,12 +80,14 @@ class EnergyOutput : public Module {
 
   void writeEnergies(double time);
 
+  bool shouldComputeVolumeEnergies() const;
+
   bool isEnabled = false;
   bool isTerminalOutputEnabled = false;
   bool isFileOutputEnabled = false;
   bool isPlasticityEnabled = false;
   int computeVolumeEnergiesEveryOutput = 1;
-  int OutputId = 0;
+  int outputId = 0;
 
   std::string outputFileName;
   std::ofstream out;

--- a/src/ResultWriter/inioutput_seissol.f90
+++ b/src/ResultWriter/inioutput_seissol.f90
@@ -156,6 +156,7 @@ CONTAINS
         receiverSyncInterval = min(disc%endTime, io%ReceiverOutputInterval), &
         isPlasticityEnabled = logical(EQN%Plasticity == 1, 1), &
         isEnergyTerminalOutputEnabled = logical(IO%isEnergyTerminalOutputEnabled, 1), &
+        computeVolumeEnergiesEveryOutput = IO%computeVolumeEnergiesEveryOutput, &
         energySyncInterval = IO%EnergyOutputInterval, &
         receiverComputeRotation = logical(IO%ReceiverComputeRotation, 1))
 

--- a/src/Solver/Interoperability.cpp
+++ b/src/Solver/Interoperability.cpp
@@ -222,13 +222,15 @@ extern "C" {
 		  int* outputGroups, int outputGroupsSize,
 		  double freeSurfaceInterval, const char* outputFileNamePrefix, const char* xdmfWriterBackend,
       const char* receiverFileName, double receiverSamplingInterval, double receiverSyncInterval,
-      bool isPlasticityEnabled, bool isEnergyTerminalOutputEnabled, double energySyncInterval, bool receiverComputeRotation) {
+      bool isPlasticityEnabled, bool isEnergyTerminalOutputEnabled, int computeVolumeEnergiesEveryOutput,
+      double energySyncInterval, bool receiverComputeRotation) {
       auto outputGroupBounds = std::unordered_set<int>(outputGroups, outputGroups + outputGroupsSize);
     e_interoperability.initializeIO(numSides, numBndGP, refinement, outputMask, plasticityMask, outputRegionBounds,
                                     outputGroupBounds,
                                     freeSurfaceInterval, outputFileNamePrefix, xdmfWriterBackend,
                                     receiverFileName, receiverSamplingInterval, receiverSyncInterval,
-                                    isPlasticityEnabled, isEnergyTerminalOutputEnabled, energySyncInterval, receiverComputeRotation);
+                                    isPlasticityEnabled, isEnergyTerminalOutputEnabled, computeVolumeEnergiesEveryOutput,
+                                    energySyncInterval, receiverComputeRotation);
   }
 
   void c_interoperability_projectInitialField() {
@@ -882,6 +884,7 @@ seissol::Interoperability::initializeIO(int numSides, int numBndGP, int refineme
                                         const char* receiverFileName, double receiverSamplingInterval,
                                         double receiverSyncInterval,
                                         bool isPlasticityEnabled, bool isEnergyTerminalOutputEnabled,
+                                        int computeVolumeEnergiesEveryOutput,
                                         double energySyncInterval, bool receiverComputeRotation)
 {
   auto type = writer::backendType(xdmfWriterBackend);
@@ -979,6 +982,7 @@ seissol::Interoperability::initializeIO(int numSides, int numBndGP, int refineme
                     &m_ltsLut,
                     isPlasticityEnabled,
                     isEnergyTerminalOutputEnabled,
+                    computeVolumeEnergiesEveryOutput,
                     outputFileNamePrefix,
                     energySyncInterval);
 

--- a/src/Solver/Interoperability.h
+++ b/src/Solver/Interoperability.h
@@ -281,8 +281,8 @@ class seissol::Interoperability {
                      int* plasticityMask, double* outputRegionBounds, const std::unordered_set<int>& outputGroups,
                      double freeSurfaceInterval, const char* outputFileNamePrefix, const char* xdmfWriterBackend,
                      const char* receiverFileName, double receiverSamplingInterval, double receiverSyncInterval,
-                     bool isPlasticityEnabled, bool isEnergyTerminalOutputEnabled, double energySyncInterval,
-                     bool receiverComputeRotation);
+                     bool isPlasticityEnabled, bool isEnergyTerminalOutputEnabled, int computeVolumeEnergiesEveryOutput, 
+                     double energySyncInterval, bool receiverComputeRotation);
 
   /**
    * Returns (possibly multiple) initial conditions

--- a/src/Solver/f_ftoc_bind_interoperability.f90
+++ b/src/Solver/f_ftoc_bind_interoperability.f90
@@ -284,7 +284,7 @@ module f_ftoc_bind_interoperability
         i_numSides, i_numBndGP, i_refinement, i_outputMask, i_plasticityMask, i_outputRegionBounds, i_outputGroups, i_outputGroupsSize, &
         freeSurfaceInterval, outputFileNamePrefix, xdmfWriterBackend, &
         receiverFileName, receiverSamplingInterval, receiverSyncInterval, &
-        isPlasticityEnabled, isEnergyTerminalOutputEnabled, energySyncInterval, receiverComputeRotation) &
+        isPlasticityEnabled, isEnergyTerminalOutputEnabled, computeVolumeEnergiesEveryOutput, energySyncInterval, receiverComputeRotation) &
         bind( C, name='c_interoperability_initializeIO' )
       use iso_c_binding
       implicit none
@@ -305,6 +305,7 @@ module f_ftoc_bind_interoperability
       real(kind=c_double), value                    :: receiverSyncInterval
       logical(kind=c_bool), value :: isPlasticityEnabled
       logical(kind=c_bool), value :: isEnergyTerminalOutputEnabled
+      integer(kind=c_int), value :: computeVolumeEnergiesEveryOutput
       real(kind=c_double), value :: energySyncInterval
       logical(kind=c_bool), value :: receiverComputeRotation
 

--- a/src/Solver/time_stepping/GhostTimeCluster.cpp
+++ b/src/Solver/time_stepping/GhostTimeCluster.cpp
@@ -134,7 +134,7 @@ void GhostTimeCluster::reset() {
 
   void GhostTimeCluster::printTimeoutMessage(std::chrono::seconds timeSinceLastUpdate) {
     const auto rank = MPI::mpi.rank();
-    logWarning(rank)
+    logError()
         << "Ghost: No update since " << timeSinceLastUpdate.count()
         << "[s] for global cluster " << globalClusterId
         << " with other cluster id " << otherGlobalClusterId
@@ -145,7 +145,7 @@ void GhostTimeCluster::reset() {
         << " mayCorrect (steps) = " << AbstractTimeCluster::mayCorrect()
         << " maySync = " << maySync();
     for (auto& neighbor : neighbors) {
-      logWarning(rank)
+      logError()
         << "Neighbor with rate = " << neighbor.ct.timeStepRate
         << "PredTime = " << neighbor.ct.predictionTime
         << "CorrTime = " << neighbor.ct.correctionTime


### PR DESCRIPTION
- Add parameter `ComputeVolumeEnergiesEveryOutput` to compute and print volume energies only once every ComputeVolumeEnergiesEveryOutput * EnergyOutputInterval.
(most useful when the Moment rate is needed at a high sampling rate, or when running seissol GPU).
Note that this leads to a change in the format of the prefix-enery.csv files
- Fix the documentation of pip behind proxy.