### PR TITLE
Remove exclusive_scan due to bad complier support

### DIFF
--- a/src/Parallel/MPI.h
+++ b/src/Parallel/MPI.h
@@ -158,7 +158,10 @@ class MPI : public MPIBasic {
     auto lengths = collect(length);
 
     std::vector<int> displacements(commSize);
-    std::exclusive_scan(lengths.begin(), lengths.end(), displacements.begin(), 0);
+    displacements[0] = 0;
+    for (int i = 1; i < displacements.size(); ++i) {
+      displacements[i] = displacements[i-1] + lengths[i-1];
+    }
 
     const auto recvBufferSize = std::accumulate(lengths.begin(), lengths.end(), 0);
     std::vector<InternalType> recvBuffer(recvBufferSize);


### PR DESCRIPTION
Exclusive_scan has pretty bad compiler support, e.g. does not work on Frontera (Icc 19.1)