### PR TITLE
Add clustering writer

### DIFF
--- a/src/Initializer/MemoryManager.h
+++ b/src/Initializer/MemoryManager.h
@@ -83,6 +83,7 @@
 #include <Initializer/LTS.h>
 #include <Initializer/tree/LTSTree.hpp>
 #include <Initializer/DynamicRupture.h>
+#include <Initializer/InputAux.hpp>
 #include <Initializer/Boundary.h>
 #include <Initializer/ParameterDB.h>
 #include <Initializer/time_stepping/LtsParameters.h>
@@ -358,11 +359,7 @@ class seissol::initializers::MemoryManager {
     }
 
     std::string getOutputPrefix() const {
-      const auto outputDirectory = (*m_inputParams)["output"]["outputfile"];
-      if (!outputDirectory) {
-          logError() << "No outputfile given.";
-      }
-      return outputDirectory.as<std::string>();
+      return getUnsafe<std::string>((*m_inputParams)["output"], "outputfile");
     }
 
 #ifdef ACL_DEVICE

--- a/src/Initializer/MemoryManager.h
+++ b/src/Initializer/MemoryManager.h
@@ -357,6 +357,14 @@ class seissol::initializers::MemoryManager {
       ltsParameters = std::make_shared<time_stepping::LtsParameters>(time_stepping::readLtsParametersFromYaml(m_inputParams));
     }
 
+    std::string getOutputPrefix() const {
+      const auto outputDirectory = (*m_inputParams)["output"]["outputfile"];
+      if (!outputDirectory) {
+          logError() << "No outputfile given.";
+      }
+      return outputDirectory.as<std::string>();
+    }
+
 #ifdef ACL_DEVICE
   void recordExecutionPaths(bool usePlasticity);
 

--- a/src/Parallel/MPI.h
+++ b/src/Parallel/MPI.h
@@ -104,7 +104,7 @@ class MPI : public MPIBasic {
   void setComm(MPI_Comm comm);
 
   template <typename T>
-  MPI_Datatype castToMpiType() {
+  MPI_Datatype castToMpiType() const {
     if constexpr (std::is_same_v<T, double>) {
       return MPI_DOUBLE;
     } else if constexpr (std::is_same_v<T, float>) {
@@ -127,7 +127,7 @@ class MPI : public MPIBasic {
    * Method supports only basic types
    */
   template <typename T>
-  auto collect(T value, std::optional<MPI_Comm> comm = {}) {
+  auto collect(T value, std::optional<MPI_Comm> comm = {}) const {
     auto collect = std::vector<T>(m_size);
     auto type = castToMpiType<T>();
     if (not comm.has_value()) {
@@ -145,7 +145,7 @@ class MPI : public MPIBasic {
    */
   template <typename ContainerType>
   std::vector<ContainerType> collectContainer(const ContainerType& container,
-                                              std::optional<MPI_Comm> comm = {}) {
+                                              std::optional<MPI_Comm> comm = {}) const {
     using InternalType = typename ContainerType::value_type;
 
     if (not comm.has_value()) {
@@ -159,7 +159,7 @@ class MPI : public MPIBasic {
 
     std::vector<int> displacements(commSize);
     displacements[0] = 0;
-    for (int i = 1; i < displacements.size(); ++i) {
+    for (unsigned i = 1; i < displacements.size(); ++i) {
       displacements[i] = displacements[i-1] + lengths[i-1];
     }
 

--- a/src/Parallel/MPI.h
+++ b/src/Parallel/MPI.h
@@ -159,7 +159,7 @@ class MPI : public MPIBasic {
 
     std::vector<int> displacements(commSize);
     displacements[0] = 0;
-    for (unsigned i = 1; i < displacements.size(); ++i) {
+    for (std::size_t i = 1; i < displacements.size(); ++i) {
       displacements[i] = displacements[i-1] + lengths[i-1];
     }
 

--- a/src/ResultWriter/ClusteringWriter.cpp
+++ b/src/ResultWriter/ClusteringWriter.cpp
@@ -1,0 +1,73 @@
+#include "ClusteringWriter.h"
+
+#include <filesystem>
+#include <fstream>
+
+#include <Parallel/MPI.h>
+namespace seissol::writer {
+
+ClusteringWriter::ClusteringWriter(const std::string& outputPrefix) : outputPrefix(outputPrefix) {
+
+}
+
+void ClusteringWriter::addCluster(unsigned profilingId,
+                                  unsigned localClusterId,
+                                  LayerType layerType,
+                                  unsigned size,
+                                  unsigned dynRupSize) {
+  clusteringInformation.profilingIds.push_back(profilingId);
+  clusteringInformation.localClusterIds.push_back(localClusterId);
+  clusteringInformation.layerTypes.push_back(layerType);
+  clusteringInformation.sizes.push_back(size);
+  clusteringInformation.dynamicRuptureSizes.push_back(dynRupSize);
+}
+
+void ClusteringWriter::write() const {
+  using namespace std::filesystem;
+  const auto& mpi = MPI::mpi;
+
+  const auto localRanks = mpi.collect(mpi.sharedMemMpiRank());
+  const auto profilingIds = mpi.collectContainer(clusteringInformation.profilingIds);
+  const auto localClusterIds = mpi.collectContainer(clusteringInformation.localClusterIds);
+  const auto layerTypes = mpi.collectContainer(clusteringInformation.layerTypes);
+  const auto sizes = mpi.collectContainer(clusteringInformation.sizes);
+  const auto dynamicRuptureSizes = mpi.collectContainer(clusteringInformation.dynamicRuptureSizes);
+
+  if (mpi.rank() == 0) {
+
+    auto filepath = path(outputPrefix);
+    filepath += path("-clustering.csv");
+
+    auto fileStream = std::fstream(filepath, std::ios::out);
+
+    fileStream << "profilingId,localId,layerType,size,dynamicRuptureSize,rank,localRank\n";
+
+    for (int rank = 0; rank < mpi.size(); ++rank) {
+      const auto localRank = localRanks[rank];
+      const auto& curProfilingIds = profilingIds[rank];
+      const auto& curLocalClusterIds = localClusterIds[rank];
+      const auto& curLayerTypes = layerTypes[rank];
+      const auto& curSizes = sizes[rank];
+      const auto& curDynamicRuptureSizes = dynamicRuptureSizes[rank];
+
+      for (unsigned i = 0; i < curProfilingIds.size(); ++i) {
+        const auto layerType = static_cast<LayerType>(curLayerTypes[i]);
+        const auto layerTypeStr = layerType == Interior ? "Interior" : "Copy";
+            fileStream
+            << curProfilingIds[i] << ","
+            << curLocalClusterIds[i] << ","
+            << layerTypeStr << ","
+            << curSizes[i] << ","
+            << curDynamicRuptureSizes[i] << ","
+            << rank << ","
+            << localRank << "\n";
+      }
+
+    }
+
+    fileStream.close();
+
+  }
+}
+
+} // namespace seissol::writer

--- a/src/ResultWriter/ClusteringWriter.cpp
+++ b/src/ResultWriter/ClusteringWriter.cpp
@@ -38,7 +38,7 @@ void ClusteringWriter::write() const {
     auto filepath = path(outputPrefix);
     filepath += path("-clustering.csv");
 
-    auto fileStream = std::fstream(filepath, std::ios::out);
+    auto fileStream = std::ofstream(filepath, std::ios::out);
 
     fileStream << "profilingId,localId,layerType,size,dynamicRuptureSize,rank,localRank\n";
 
@@ -50,8 +50,11 @@ void ClusteringWriter::write() const {
       const auto& curSizes = sizes[rank];
       const auto& curDynamicRuptureSizes = dynamicRuptureSizes[rank];
 
-      for (unsigned i = 0; i < curProfilingIds.size(); ++i) {
+      for (std::size_t i = 0; i < curProfilingIds.size(); ++i) {
         const auto layerType = static_cast<LayerType>(curLayerTypes[i]);
+        if (layerType != LayerType::Interior && layerType != LayerType::Copy) {
+          logError() << "Encountered illegal layer type in ClusteringWriter.";
+        }
         const auto layerTypeStr = layerType == Interior ? "Interior" : "Copy";
             fileStream
             << curProfilingIds[i] << ","

--- a/src/ResultWriter/ClusteringWriter.h
+++ b/src/ResultWriter/ClusteringWriter.h
@@ -1,0 +1,39 @@
+#ifndef SEISSOL_CLUSTERINGWRITER_H
+#define SEISSOL_CLUSTERINGWRITER_H
+
+#include <string>
+#include <vector>
+#include <type_traits>
+#include "Initializer/tree/Layer.hpp"
+
+namespace seissol::writer {
+
+class ClusteringWriter {
+public:
+  ClusteringWriter(const std::string& outputPrefix);
+    void addCluster(unsigned profilingId,
+                    unsigned localClusterId,
+                    LayerType layerType,
+                    unsigned size,
+                    unsigned dynRupSize);
+    void write() const;
+
+  // SoA that contains info about clusters
+  struct ClusteringInformation {
+    std::vector<int> ranks;
+    std::vector<int> localRanks;
+    std::vector<int> profilingIds;
+    std::vector<int> localClusterIds;
+    std::vector<std::underlying_type<LayerType>::type> layerTypes;
+    std::vector<unsigned> sizes;
+    std::vector<unsigned> dynamicRuptureSizes;
+  };
+
+private:
+  std::string outputPrefix;
+  ClusteringInformation clusteringInformation;
+};
+
+} // namespace seissol::writer
+
+#endif // SEISSOL_CLUSTERINGWRITER_H

--- a/src/SeisSol.cpp
+++ b/src/SeisSol.cpp
@@ -170,13 +170,8 @@ bool seissol::SeisSol::init(int argc, char* argv[]) {
 
   m_memoryManager->setInputParams(m_inputParams);
 
-  if (auto outputDirectory = (*m_inputParams)["output"]["outputfile"]) {
-    writer::ThreadsPinningWriter pinningWriter(outputDirectory.as<std::string>());
-    pinningWriter.write(pinning);
-  }
-  else {
-    logError() << "no output path given";
-  }
+  writer::ThreadsPinningWriter pinningWriter(m_memoryManager->getOutputPrefix());
+  pinningWriter.write(pinning);
 
   return true;
 }

--- a/src/Solver/time_stepping/TimeCluster.cpp
+++ b/src/Solver/time_stepping/TimeCluster.cpp
@@ -94,6 +94,7 @@
 extern seissol::Interoperability e_interoperability;
 
 seissol::time_stepping::TimeCluster::TimeCluster(unsigned int i_clusterId, unsigned int i_globalClusterId,
+                                                 unsigned int profilingId,
                                                  bool usePlasticity,
                                                  LayerType layerType, double maxTimeStepSize,
                                                  long timeStepRate, bool printProgress,
@@ -132,6 +133,7 @@ seissol::time_stepping::TimeCluster::TimeCluster(unsigned int i_clusterId, unsig
     printProgress(printProgress),
     m_clusterId(i_clusterId),
     m_globalClusterId(i_globalClusterId),
+    m_profilingId(profilingId),
     dynamicRuptureScheduler(dynamicRuptureScheduler)
 {
     // assert all pointers are valid
@@ -281,7 +283,7 @@ void seissol::time_stepping::TimeCluster::computeDynamicRupture( seissol::initia
   LIKWID_MARKER_STOP("computeDynamicRuptureFrictionLaw");
   }
 
-  m_loopStatistics->end(m_regionComputeDynamicRupture, layerData.getNumberOfCells(), m_globalClusterId);
+  m_loopStatistics->end(m_regionComputeDynamicRupture, layerData.getNumberOfCells(), m_profilingId);
 }
 #else
 
@@ -330,7 +332,7 @@ void seissol::time_stepping::TimeCluster::computeDynamicRupture( seissol::initia
                              m_dynamicRuptureKernel.timeWeights);
     device.api->popLastProfilingMark();
   }
-  m_loopStatistics->end(m_regionComputeDynamicRupture, layerData.getNumberOfCells(), m_globalClusterId);
+  m_loopStatistics->end(m_regionComputeDynamicRupture, layerData.getNumberOfCells(), m_profilingId);
 }
 #endif
 
@@ -441,7 +443,7 @@ void seissol::time_stepping::TimeCluster::computeLocalIntegration(seissol::initi
     }
   }
 
-  m_loopStatistics->end(m_regionComputeLocalIntegration, i_layerData.getNumberOfCells(), m_globalClusterId);
+  m_loopStatistics->end(m_regionComputeLocalIntegration, i_layerData.getNumberOfCells(), m_profilingId);
 }
 #else // ACL_DEVICE
 void seissol::time_stepping::TimeCluster::computeLocalIntegration(
@@ -567,7 +569,7 @@ void seissol::time_stepping::TimeCluster::computeLocalIntegration(
     device.api->syncGraph(computeGraphHandle);
   }
 
-  m_loopStatistics->end(m_regionComputeLocalIntegration, i_layerData.getNumberOfCells(), m_globalClusterId);
+  m_loopStatistics->end(m_regionComputeLocalIntegration, i_layerData.getNumberOfCells(), m_profilingId);
   device.api->popLastProfilingMark();
 }
 #endif // ACL_DEVICE
@@ -643,7 +645,7 @@ void seissol::time_stepping::TimeCluster::computeNeighboringIntegration( seissol
 
   device.api->syncDefaultStreamWithHost();
   device.api->popLastProfilingMark();
-  m_loopStatistics->end(m_regionComputeNeighboringIntegration, i_layerData.getNumberOfCells(), m_globalClusterId);
+  m_loopStatistics->end(m_regionComputeNeighboringIntegration, i_layerData.getNumberOfCells(), m_profilingId);
 }
 #endif // ACL_DEVICE
 

--- a/src/Solver/time_stepping/TimeCluster.h
+++ b/src/Solver/time_stepping/TimeCluster.h
@@ -340,7 +340,7 @@ private:
           i_layerData.getNumberOfCells() * m_flops_hardware[static_cast<int>(ComputePart::PlasticityCheck)] +
           numberOTetsWithPlasticYielding * m_flops_hardware[static_cast<int>(ComputePart::PlasticityYield)];
 
-      m_loopStatistics->end(m_regionComputeNeighboringIntegration, i_layerData.getNumberOfCells(), m_globalClusterId);
+      m_loopStatistics->end(m_regionComputeNeighboringIntegration, i_layerData.getNumberOfCells(), m_profilingId);
 
       return {nonZeroFlopsPlasticity, hardwareFlopsPlasticity};
     }
@@ -376,6 +376,9 @@ private:
   //! global cluster cluster id
   const unsigned int m_globalClusterId;
 
+  //! id used to identify this cluster (including layer type) when profiling
+  const unsigned int m_profilingId;
+
   DynamicRuptureScheduler* dynamicRuptureScheduler;
 
   void printTimeoutMessage(std::chrono::seconds timeSinceLastUpdate) override;
@@ -390,7 +393,7 @@ public:
    * @param i_globalClusterId global id of this cluster.
    * @param usePlasticity true if using plasticity
    **/
-  TimeCluster(unsigned int i_clusterId, unsigned int i_globalClusterId, bool usePlasticity,
+  TimeCluster(unsigned int i_clusterId, unsigned int i_globalClusterId, unsigned int profilingId, bool usePlasticity,
               LayerType layerType, double maxTimeStepSize,
               long timeStepRate, bool printProgress,
               DynamicRuptureScheduler* dynamicRuptureScheduler, CompoundGlobalData i_globalData,

--- a/src/Solver/time_stepping/TimeManager.cpp
+++ b/src/Solver/time_stepping/TimeManager.cpp
@@ -117,6 +117,7 @@ void seissol::time_stepping::TimeManager::addClusters(TimeStepping& i_timeSteppi
       clusters.push_back(std::make_unique<TimeCluster>(
           localClusterId,
           l_globalClusterId,
+          profilingId,
           usePlasticity,
           type,
           timeStepSize,

--- a/src/Solver/time_stepping/TimeManager.cpp
+++ b/src/Solver/time_stepping/TimeManager.cpp
@@ -46,6 +46,7 @@
 #include <Initializer/preProcessorMacros.fpp>
 #include <Initializer/time_stepping/common.hpp>
 #include "SeisSol.h"
+#include <ResultWriter/ClusteringWriter.h>
 
 extern seissol::Interoperability e_interoperability;
 
@@ -73,6 +74,8 @@ void seissol::time_stepping::TimeManager::addClusters(TimeStepping& i_timeSteppi
 
   // store the time stepping
   m_timeStepping = i_timeStepping;
+
+  auto clusteringWriter = writer::ClusteringWriter(memoryManager.getOutputPrefix());
 
   bool foundDynamicRuptureCluster = false;
 
@@ -107,6 +110,10 @@ void seissol::time_stepping::TimeManager::addClusters(TimeStepping& i_timeSteppi
       // We print progress only if it is the cluster with the largest time step on each rank.
       // This does not mean that it is the largest cluster globally!
       const bool printProgress = (localClusterId == m_timeStepping.numberOfLocalClusters - 1) && (type == Interior);
+      const auto profilingId = l_globalClusterId + offsetMonitoring;
+      auto* layerData = &memoryManager.getLtsTree()->child(localClusterId).child(type);
+      auto* dynRupInteriorData = &dynRupTree.child(Interior);
+      auto* dynRupCopyData = &dynRupTree.child(Copy);
       clusters.push_back(std::make_unique<TimeCluster>(
           localClusterId,
           l_globalClusterId,
@@ -117,16 +124,22 @@ void seissol::time_stepping::TimeManager::addClusters(TimeStepping& i_timeSteppi
           printProgress,
           drScheduler.get(),
           globalData,
-          &memoryManager.getLtsTree()->child(localClusterId).child(type),
-          &dynRupTree.child(Interior),
-          &dynRupTree.child(Copy),
+          layerData,
+          dynRupInteriorData,
+          dynRupCopyData,
           memoryManager.getLts(),
           memoryManager.getDynamicRupture(),
           memoryManager.getFrictionLaw(),
           memoryManager.getFaultOutputManager(),
           &m_loopStatistics,
-          &actorStateStatisticsManager.addCluster(l_globalClusterId + offsetMonitoring))
+          &actorStateStatisticsManager.addCluster(profilingId))
       );
+
+      auto clusterSize = layerData->getNumberOfCells();
+      auto dynRupSize = type == Copy ? dynRupCopyData->getNumberOfCells()
+                                     : dynRupInteriorData->getNumberOfCells();
+      // Add writer to output
+      clusteringWriter.addCluster(profilingId, localClusterId, type, clusterSize, dynRupSize);
     }
     auto& interior = clusters[clusters.size() - 1];
     auto& copy = clusters[clusters.size() - 2];
@@ -153,6 +166,7 @@ void seissol::time_stepping::TimeManager::addClusters(TimeStepping& i_timeSteppi
         );
       }
     }
+
 
 #ifdef USE_MPI
     // Create ghost time clusters for MPI
@@ -184,6 +198,8 @@ void seissol::time_stepping::TimeManager::addClusters(TimeStepping& i_timeSteppi
     }
 #endif
   }
+
+  clusteringWriter.write();
 
   // Sort clusters by time step size in increasing order
   auto rateSorter = [](const auto& a, const auto& b) {
@@ -218,6 +234,7 @@ void seissol::time_stepping::TimeManager::addClusters(TimeStepping& i_timeSteppi
   } else {
     communicationManager = std::make_unique<SerialCommunicationManager>(std::move(ghostClusters));
   }
+
 }
 
 void seissol::time_stepping::TimeManager::setFaultOutputManager(seissol::dr::output::OutputManager* faultOutputManager) {

--- a/src/Solver/time_stepping/TimeManager.cpp
+++ b/src/Solver/time_stepping/TimeManager.cpp
@@ -136,9 +136,9 @@ void seissol::time_stepping::TimeManager::addClusters(TimeStepping& i_timeSteppi
           &actorStateStatisticsManager.addCluster(profilingId))
       );
 
-      auto clusterSize = layerData->getNumberOfCells();
-      auto dynRupSize = type == Copy ? dynRupCopyData->getNumberOfCells()
-                                     : dynRupInteriorData->getNumberOfCells();
+      const auto clusterSize = layerData->getNumberOfCells();
+      const auto dynRupSize = type == Copy ? dynRupCopyData->getNumberOfCells()
+                                           : dynRupInteriorData->getNumberOfCells();
       // Add writer to output
       clusteringWriter.addCluster(profilingId, localClusterId, type, clusterSize, dynRupSize);
     }

--- a/src/sources.cmake
+++ b/src/sources.cmake
@@ -64,6 +64,7 @@ src/Checkpoint/posix/Wavefield.cpp
 src/Checkpoint/posix/Fault.cpp
 src/ResultWriter/AnalysisWriter.cpp
 src/ResultWriter/MiniSeisSolWriter.cpp
+src/ResultWriter/ClusteringWriter.cpp
 src/ResultWriter/ThreadsPinningWriter.cpp
 src/ResultWriter/FreeSurfaceWriterExecutor.cpp
 src/ResultWriter/PostProcessor.cpp


### PR DESCRIPTION
This PR adds a writer that outputs information about the (local) clusters, including their id, size, number of dynamic rupture faces, etc.
Furthermore, it uses a "profilingid" for the loop information, which allows us to differentiate between the costs of computing copy and interior clusters.
This is useful, as copy clusters are typically quite small and thus have larger loops which do not gain that much from shared memory parallelization. 