### PR TITLE
Improve profiling

### DIFF
--- a/Documentation/parameters.par
+++ b/Documentation/parameters.par
@@ -149,7 +149,9 @@ xdmfWriterBackend = 'posix' ! (optional) The backend used in fault, wavefield,
 EnergyOutput = 1 ! Computation of energy, written in csv file
 EnergyTerminalOutput = 1 ! Write energy to standard output
 EnergyOutputInterval = 0.05
-ComputeVolumeEnergiesEveryOutput = 4 ! Compute volume energies only once every ComputeVolumeEnergiesEveryOutput * EnergyOutputInterval 
+ComputeVolumeEnergiesEveryOutput = 4 ! Compute volume energies only once every ComputeVolumeEnergiesEveryOutput * EnergyOutputInterval
+
+LoopStatisticsNetcdfOutput = 0 ! Writes detailed loop statistics. Warning: Produces terabytes of data!
 /
            
 &AbortCriteria

--- a/src/Initializer/MemoryManager.h
+++ b/src/Initializer/MemoryManager.h
@@ -362,6 +362,10 @@ class seissol::initializers::MemoryManager {
       return getUnsafe<std::string>((*m_inputParams)["output"], "outputfile");
     }
 
+    bool isLoopStatisticsNetcdfOutputOn() const {
+      return getWithDefault((*m_inputParams)["output"], "loopstatisticsnetcdfoutput", false);
+    }
+
 #ifdef ACL_DEVICE
   void recordExecutionPaths(bool usePlasticity);
 

--- a/src/Monitoring/LoopStatistics.cpp
+++ b/src/Monitoring/LoopStatistics.cpp
@@ -214,9 +214,9 @@ void seissol::LoopStatistics::writeSamples() {
       ss << loopStatFile << m_regions[region] << ".nc";
       std::string fileName = ss.str();
       
-      int nSamples = m_times[region].size();
-      int sampleOffset;
-      MPI_Scan(&nSamples, &sampleOffset, 1, MPI_INT, MPI_SUM, seissol::MPI::mpi.comm());
+      long nSamples = m_times[region].size();
+      long sampleOffset;
+      MPI_Scan(&nSamples, &sampleOffset, 1, MPI_LONG, MPI_SUM, seissol::MPI::mpi.comm());
       
       int ncid, stat;
       stat = nc_create_par(fileName.c_str(),
@@ -267,7 +267,7 @@ void seissol::LoopStatistics::writeSamples() {
         check_err(stat, __LINE__, __FILE__);
       }
 
-      stat = nc_def_var(ncid, "offset", NC_INT, 1, &rankdim, &offsetid);
+      stat = nc_def_var(ncid, "offset", NC_INT64, 1, &rankdim, &offsetid);
       check_err(stat, __LINE__, __FILE__);
       stat = nc_def_var(ncid, "sample", sampletyp, 1, &sampledim, &sampleid);
       check_err(stat, __LINE__, __FILE__);
@@ -277,8 +277,8 @@ void seissol::LoopStatistics::writeSamples() {
       stat = nc_var_par_access(ncid, offsetid, NC_COLLECTIVE); check_err(stat,__LINE__,__FILE__);
       stat = nc_var_par_access(ncid, sampleid, NC_COLLECTIVE); check_err(stat,__LINE__,__FILE__);
   
-      size_t start, count;
-      int offsetData[2];
+      std::size_t start, count;
+      long offsetData[2];
       if (seissol::MPI::mpi.rank() == 0) {
         start = 0;
         count = 2;        
@@ -288,7 +288,8 @@ void seissol::LoopStatistics::writeSamples() {
         count = 1;
       }
       offsetData[count-1] = sampleOffset;
-      stat = nc_put_vara_int(ncid, offsetid, &start, &count, offsetData);
+
+      stat = nc_put_vara_long(ncid, offsetid, &start, &count, offsetData);
       check_err(stat, __LINE__, __FILE__);
 
       start = sampleOffset-nSamples;

--- a/src/Monitoring/LoopStatistics.cpp
+++ b/src/Monitoring/LoopStatistics.cpp
@@ -206,8 +206,8 @@ template <> struct type2nc<uint64_t> {
 void seissol::LoopStatistics::writeSamples(const std::string& outputPrefix, bool isLoopStatisticsNetcdfOutputOn) {
   if (isLoopStatisticsNetcdfOutputOn) {
     const auto loopStatFile = outputPrefix + "-loopStat-";
-#if defined(USE_NETCDF) && defined(USE_MPI)
     const auto rank = MPI::mpi.rank();
+#if defined(USE_NETCDF) && defined(USE_MPI)
     logInfo(rank) << "Starting to write loop statistics samples to disk.";
     unsigned nRegions = m_times.size();
     for (unsigned region = 0; region < nRegions; ++region) {

--- a/src/Monitoring/LoopStatistics.cpp
+++ b/src/Monitoring/LoopStatistics.cpp
@@ -219,30 +219,59 @@ void seissol::LoopStatistics::writeSamples() {
       MPI_Scan(&nSamples, &sampleOffset, 1, MPI_INT, MPI_SUM, seissol::MPI::mpi.comm());
       
       int ncid, stat;
-      stat = nc_create_par(fileName.c_str(), NC_MPIIO | NC_CLOBBER | NC_NETCDF4, seissol::MPI::mpi.comm(), MPI_INFO_NULL, &ncid); check_err(stat,__LINE__,__FILE__);
-      
+      stat = nc_create_par(fileName.c_str(),
+                           NC_MPIIO | NC_CLOBBER | NC_NETCDF4,
+                           seissol::MPI::mpi.comm(),
+                           MPI_INFO_NULL,
+                           &ncid);
+      check_err(stat, __LINE__, __FILE__);
+
       int sampledim, rankdim, timespectyp, sampletyp, offsetid, sampleid;
-      
-      stat = nc_def_dim(ncid, "rank", 1+seissol::MPI::mpi.size(), &rankdim);             check_err(stat,__LINE__,__FILE__);
-      stat = nc_def_dim(ncid, "sample", NC_UNLIMITED, &sampledim); check_err(stat,__LINE__,__FILE__);
 
-      stat = nc_def_compound(ncid, sizeof(timespec), "timespec", &timespectyp); check_err(stat,__LINE__,__FILE__);
+      stat = nc_def_dim(ncid, "rank", 1 + seissol::MPI::mpi.size(), &rankdim);
+      check_err(stat, __LINE__, __FILE__);
+      stat = nc_def_dim(ncid, "sample", NC_UNLIMITED, &sampledim);
+      check_err(stat, __LINE__, __FILE__);
+
+      stat = nc_def_compound(ncid, sizeof(timespec), "timespec", &timespectyp);
+      check_err(stat, __LINE__, __FILE__);
       {
-        stat = nc_insert_compound(ncid, timespectyp, "sec", NC_COMPOUND_OFFSET(timespec,tv_sec), type2nc<decltype(timespec::tv_sec)>::type); check_err(stat,__LINE__,__FILE__);
-        stat = nc_insert_compound(ncid, timespectyp, "nsec", NC_COMPOUND_OFFSET(timespec,tv_nsec), type2nc<decltype(timespec::tv_nsec)>::type); check_err(stat,__LINE__,__FILE__);
+        stat = nc_insert_compound(ncid,
+                                  timespectyp,
+                                  "sec",
+                                  NC_COMPOUND_OFFSET(timespec, tv_sec),
+                                  type2nc<decltype(timespec::tv_sec)>::type);
+        check_err(stat, __LINE__, __FILE__);
+        stat = nc_insert_compound(ncid,
+                                  timespectyp,
+                                  "nsec",
+                                  NC_COMPOUND_OFFSET(timespec, tv_nsec),
+                                  type2nc<decltype(timespec::tv_nsec)>::type);
+        check_err(stat, __LINE__, __FILE__);
       }
 
-      stat = nc_def_compound(ncid, sizeof(Sample), "Sample", &sampletyp); check_err(stat,__LINE__,__FILE__);
+      stat = nc_def_compound(ncid, sizeof(Sample), "Sample", &sampletyp);
+      check_err(stat, __LINE__, __FILE__);
       {
-        stat = nc_insert_compound(ncid, sampletyp, "begin", NC_COMPOUND_OFFSET(Sample,begin), timespectyp); check_err(stat,__LINE__,__FILE__);
-        stat = nc_insert_compound(ncid, sampletyp, "end", NC_COMPOUND_OFFSET(Sample,end), timespectyp); check_err(stat,__LINE__,__FILE__);
-        stat = nc_insert_compound(ncid, sampletyp, "loopLength", NC_COMPOUND_OFFSET(Sample,numIters), NC_UINT); check_err(stat,__LINE__,__FILE__);
-        stat = nc_insert_compound(ncid, sampletyp, "subRegion", NC_COMPOUND_OFFSET(Sample,subRegion), NC_UINT); check_err(stat,__LINE__,__FILE__);
+        stat = nc_insert_compound(
+            ncid, sampletyp, "begin", NC_COMPOUND_OFFSET(Sample, begin), timespectyp);
+        check_err(stat, __LINE__, __FILE__);
+        stat = nc_insert_compound(
+            ncid, sampletyp, "end", NC_COMPOUND_OFFSET(Sample, end), timespectyp);
+        check_err(stat, __LINE__, __FILE__);
+        stat = nc_insert_compound(
+            ncid, sampletyp, "loopLength", NC_COMPOUND_OFFSET(Sample, numIters), NC_UINT);
+        check_err(stat, __LINE__, __FILE__);
+        stat = nc_insert_compound(
+            ncid, sampletyp, "subRegion", NC_COMPOUND_OFFSET(Sample, subRegion), NC_UINT);
+        check_err(stat, __LINE__, __FILE__);
       }
-      
-      stat = nc_def_var(ncid, "offset", NC_INT,   1, &rankdim,   &offsetid); check_err(stat,__LINE__,__FILE__);
-      stat = nc_def_var(ncid, "sample", sampletyp, 1, &sampledim, &sampleid); check_err(stat,__LINE__,__FILE__);
-      
+
+      stat = nc_def_var(ncid, "offset", NC_INT, 1, &rankdim, &offsetid);
+      check_err(stat, __LINE__, __FILE__);
+      stat = nc_def_var(ncid, "sample", sampletyp, 1, &sampledim, &sampleid);
+      check_err(stat, __LINE__, __FILE__);
+
       stat = nc_enddef(ncid); check_err(stat,__LINE__,__FILE__);
       
       stat = nc_var_par_access(ncid, offsetid, NC_COLLECTIVE); check_err(stat,__LINE__,__FILE__);
@@ -259,12 +288,14 @@ void seissol::LoopStatistics::writeSamples() {
         count = 1;
       }
       offsetData[count-1] = sampleOffset;
-      stat = nc_put_vara_int(ncid, offsetid, &start, &count, offsetData);  check_err(stat,__LINE__,__FILE__);
-      
+      stat = nc_put_vara_int(ncid, offsetid, &start, &count, offsetData);
+      check_err(stat, __LINE__, __FILE__);
+
       start = sampleOffset-nSamples;
       count = nSamples;
-      stat = nc_put_vara(ncid, sampleid, &start, &count, m_times[region].data());  check_err(stat,__LINE__,__FILE__);      
-      
+      stat = nc_put_vara(ncid, sampleid, &start, &count, m_times[region].data());
+      check_err(stat, __LINE__, __FILE__);
+
       stat = nc_close(ncid); check_err(stat,__LINE__,__FILE__);
     }
 #else

--- a/src/Monitoring/LoopStatistics.h
+++ b/src/Monitoring/LoopStatistics.h
@@ -96,7 +96,7 @@ public:
   void printSummary(MPI_Comm comm);
 #endif
 
-  void writeSamples();
+  void writeSamples(const std::string& outputPrefix, bool isLoopStatisticsNetcdfOutputOn);
   
 private:
   struct Sample {

--- a/src/Reader/readpar.f90
+++ b/src/Reader/readpar.f90
@@ -2298,6 +2298,7 @@ ALLOCATE( SpacePositionx(nDirac), &
       INTEGER                          :: EnergyTerminalOutput
       INTEGER                          :: computeVolumeEnergiesEveryOutput
       real                             :: EnergyOutputInterval
+      INTEGER                          :: LoopStatisticsNetcdfOutput
       INTEGER                          :: ReceiverComputeRotation
 
       NAMELIST                         /Output/ OutputFile, Rotation, iOutputMask, iPlasticityMask, iOutputMaskMaterial, &
@@ -2307,7 +2308,8 @@ ALLOCATE( SpacePositionx(nDirac), &
                                                 checkPointInterval, checkPointFile, checkPointBackend, OutputRegionBounds, OutputGroups, IntegrationMask, &
                                                 SurfaceOutput, SurfaceOutputRefinement, SurfaceOutputInterval, xdmfWriterBackend, &
                                                 ReceiverOutputInterval, nRecordPoints, &
-                                                EnergyOutput, EnergyTerminalOutput, EnergyOutputInterval, computeVolumeEnergiesEveryOutput, ReceiverComputeRotation
+                                                EnergyOutput, EnergyTerminalOutput, EnergyOutputInterval, computeVolumeEnergiesEveryOutput, ReceiverComputeRotation, &
+                                                LoopStatisticsNetcdfOutput
 
               !------------------------------------------------------------------------
     !

--- a/src/Solver/Simulator.cpp
+++ b/src/Solver/Simulator.cpp
@@ -147,7 +147,11 @@ void seissol::Simulator::simulate() {
   double wallTime = stopwatch.split();
   logInfo(seissol::MPI::mpi.rank()) << "Elapsed time (via clock_gettime):" << wallTime << "seconds.";
 
-  seissol::SeisSol::main.timeManager().printComputationTime();
+  const auto& memoryManager = SeisSol::main.getMemoryManager();
+  const bool isLoopStatisticsNetcdfOutputOn = memoryManager.isLoopStatisticsNetcdfOutputOn();
+  const auto& outputPrefix = memoryManager.getOutputPrefix();
+  seissol::SeisSol::main.timeManager().printComputationTime(outputPrefix,
+                                                            isLoopStatisticsNetcdfOutputOn);
 
   seissol::SeisSol::main.analysisWriter().printAnalysis(m_currentTime);
 

--- a/src/Solver/time_stepping/TimeCluster.cpp
+++ b/src/Solver/time_stepping/TimeCluster.cpp
@@ -229,6 +229,7 @@ void seissol::time_stepping::TimeCluster::computeSources() {
 
 #ifndef ACL_DEVICE
 void seissol::time_stepping::TimeCluster::computeDynamicRupture( seissol::initializers::Layer&  layerData ) {
+  if (layerData.getNumberOfCells() == 0) return;
   SCOREP_USER_REGION_DEFINE(myRegionHandle)
   SCOREP_USER_REGION_BEGIN(myRegionHandle, "computeDynamicRuptureSpaceTimeInterpolation", SCOREP_USER_REGION_TYPE_COMMON )
 
@@ -744,6 +745,8 @@ void TimeCluster::handleAdvancedCorrectionTimeMessage(const NeighborCluster&) {
 }
 void TimeCluster::predict() {
   assert(state == ActorState::Corrected);
+  if (m_clusterData->getNumberOfCells() == 0) return;
+
   bool resetBuffers = true;
   for (auto& neighbor : neighbors) {
       if (neighbor.ct.timeStepRate > ct.timeStepRate
@@ -755,8 +758,6 @@ void TimeCluster::predict() {
     resetBuffers = true;
   }
 
-  // These methods compute the receivers/sources for both interior and copy cluster
-  // and are called in actors for both copy AND interior.
   writeReceivers();
   computeLocalIntegration(*m_clusterData, resetBuffers);
   computeSources();

--- a/src/Solver/time_stepping/TimeCluster.h
+++ b/src/Solver/time_stepping/TimeCluster.h
@@ -256,6 +256,7 @@ private:
     template<bool usePlasticity>
     std::pair<long, long> computeNeighboringIntegrationImplementation(seissol::initializers::Layer& i_layerData,
                                                                       double subTimeStart) {
+      if (i_layerData.getNumberOfCells() == 0) return {0,0};
       SCOREP_USER_REGION( "computeNeighboringIntegration", SCOREP_USER_REGION_TYPE_FUNCTION )
 
       m_loopStatistics->begin(m_regionComputeNeighboringIntegration);

--- a/src/Solver/time_stepping/TimeManager.cpp
+++ b/src/Solver/time_stepping/TimeManager.cpp
@@ -4,21 +4,21 @@
  *
  * @author Alex Breuer (breuer AT mytum.de, http://www5.in.tum.de/wiki/index.php/Dipl.-Math._Alexander_Breuer)
  * @author Sebastian Rettenberger (sebastian.rettenberger @ tum.de, http://www5.in.tum.de/wiki/index.php/Sebastian_Rettenberger)
- * 
+ *
  * @section LICENSE
  * Copyright (c) 2013-2015, SeisSol Group
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
- * 
+ *
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- * 
+ *
  * 3. Neither the name of the copyright holder nor the names of its
  *    contributors may be used to endorse or promote products derived from this
  *    software without specific prior written permission.
@@ -328,13 +328,14 @@ void seissol::time_stepping::TimeManager::advanceInTime(const double &synchroniz
 #endif
 }
 
-void seissol::time_stepping::TimeManager::printComputationTime()
-{
+void seissol::time_stepping::TimeManager::printComputationTime(
+    const std::string& outputPrefix, bool isLoopStatisticsNetcdfOutputOn) {
   actorStateStatisticsManager.addToLoopStatistics(m_loopStatistics);
 #ifdef USE_MPI
   m_loopStatistics.printSummary(MPI::mpi.comm());
 #endif
-  m_loopStatistics.writeSamples();
+
+  m_loopStatistics.writeSamples(outputPrefix, isLoopStatisticsNetcdfOutputOn);
 }
 
 double seissol::time_stepping::TimeManager::getTimeTolerance() {

--- a/src/Solver/time_stepping/TimeManager.h
+++ b/src/Solver/time_stepping/TimeManager.h
@@ -184,7 +184,7 @@ class seissol::time_stepping::TimeManager {
      **/
     void setInitialTimes( double i_time = 0 );
 
-    void printComputationTime();
+    void printComputationTime(const std::string& outputPrefix, bool isLoopStatisticsNetcdfOutputOn);
 };
 
 #endif


### PR DESCRIPTION
This PR has the following improvements for the profiling:

- Skip loops of size zero, arising from clusters with size 0 (may improve performance slightly, handled differently for predict/correct due DR scheduling, not done for some GPU kernels)
- Fix time spent in DR (last PR did not work, missed an MPI_Reduce)
-  Use int64 as offset for nc files, required for long, large-scale simulations
- Add config option in parameters.par, use better output name

The profiling is not documented on purpose, as it should not used by non-developers. I'll add some analysis scripts later (with documentation).

@ravil-mobile I didn't add skipping of zero-sized loops for all kernels for GPUs. The profiling works without this but you might add this later to improve performance slightly.
