### PR TITLE
Fix broken link in cookbook_overview.rst

### DIFF
--- a/Documentation/cookbook_overview.rst
+++ b/Documentation/cookbook_overview.rst
@@ -22,7 +22,7 @@ Prerequisites
 ~~~~~~~~~~~~~
 
 Before you begin any of the examples, you will need to install the latest
-SeisSol from (https://github.com/SeisSol/SeisSol). The instruction can be found at https://seissol.readthedocs.io/en/latest/compilation.html. All geometry and
+SeisSol from (https://github.com/SeisSol/SeisSol). The instruction can be found at https://seissol.readthedocs.io/en/latest/compiling-seissol.html. All geometry and
 tetrahedral meshes are generated using free software Gmsh (http://gmsh.info/).
 If you do not wish to create your own mesh at this time, the meshes are
 also provided as part of the example. The ParaView visualization package


### PR DESCRIPTION
The link https://seissol.readthedocs.io/en/latest/compilation.html is broken, should it perhaps point to https://seissol.readthedocs.io/en/latest/compiling-seissol.html ?