### PR TITLE
Fixed `0` byte allocation in sycl (dr)

### DIFF
--- a/auto_tuning/proxy/src/proxy_seissol_device_integrators.hpp
+++ b/auto_tuning/proxy/src/proxy_seissol_device_integrators.hpp
@@ -206,6 +206,8 @@ namespace proxy::device {
       assert(device.api->isCircularStreamsJoinedWithDefault() &&
              "circular streams must be joined with the default stream");
 
+      device.api->streamEndCapture();
+
       computeGraphHandle = device.api->getLastGraphHandle();
       layer.updateDeviceComputeGraphHandle(computeGraphKey, computeGraphHandle);
       device.api->syncDefaultStreamWithHost();

--- a/src/DynamicRupture/FrictionLaws/GpuImpl/FrictionSolverDetails.cpp
+++ b/src/DynamicRupture/FrictionLaws/GpuImpl/FrictionSolverDetails.cpp
@@ -7,6 +7,9 @@ FrictionSolverDetails::FrictionSolverDetails(dr::DRParameters* drParameters)
     : FrictionSolverInterface(drParameters) {}
 
 FrictionSolverDetails::~FrictionSolverDetails() {
+  if (maxClusterSize == 0)
+    return;
+
   free(faultStresses, queue);
   free(tractionResults, queue);
   free(stateVariableBuffer, queue);
@@ -22,6 +25,9 @@ void FrictionSolverDetails::initSyclQueue() {
 }
 
 void FrictionSolverDetails::allocateAuxiliaryMemory() {
+  if (maxClusterSize == 0)
+    return;
+
   faultStresses = static_cast<FaultStresses*>(
       sycl::malloc_shared(maxClusterSize * sizeof(FaultStresses), queue));
 
@@ -51,6 +57,9 @@ void FrictionSolverDetails::allocateAuxiliaryMemory() {
 }
 
 void FrictionSolverDetails::copyStaticDataToDevice() {
+  if (maxClusterSize == 0)
+    return;
+
   {
     constexpr auto dim0 = misc::dimSize<init::resample, 0>();
     constexpr auto dim1 = misc::dimSize<init::resample, 1>();

--- a/src/DynamicRupture/FrictionLaws/GpuImpl/RateAndState.h
+++ b/src/DynamicRupture/FrictionLaws/GpuImpl/RateAndState.h
@@ -17,6 +17,9 @@ class RateAndStateBase : public BaseFrictionSolver<RateAndStateBase<Derived, TPM
         tpMethod(TPMethod(drParameters)) {}
 
   ~RateAndStateBase() {
+    if (this->maxClusterSize == 0)
+      return;
+
     sycl::free(initialVariables.absoluteShearTraction, this->queue);
     sycl::free(initialVariables.localSlipRate, this->queue);
     sycl::free(initialVariables.normalStress, this->queue);
@@ -26,6 +29,8 @@ class RateAndStateBase : public BaseFrictionSolver<RateAndStateBase<Derived, TPM
 
   void allocateAuxiliaryMemory() override {
     FrictionSolverDetails::allocateAuxiliaryMemory();
+    if (this->maxClusterSize == 0)
+      return;
 
     {
       using gpPointType = real(*)[misc::numPaddedPoints];

--- a/src/hip.cmake
+++ b/src/hip.cmake
@@ -31,7 +31,7 @@ if (IS_NVCC_PLATFORM)
                     --compiler-options -fPIC;
                     -DCUDA_UNDERHOOD)
 else()
-    set(SEISSOL_HIPCC ${SEISSOL_HIPCC} --amdgpu-target=${DEVICE_ARCH})
+    set(SEISSOL_HIPCC ${SEISSOL_HIPCC} --offload-arch=${DEVICE_ARCH})
 endif()
 
 


### PR DESCRIPTION
* fixed warning in rocm@5.4>= (--offload-arch)