### PR TITLE
Change slipRateOutputType to 0 when using a friction law with imposed slip rate 

### DIFF
--- a/src/DynamicRupture/Parameters.h
+++ b/src/DynamicRupture/Parameters.h
@@ -64,8 +64,9 @@ inline std::unique_ptr<DRParameters> readParametersFromYaml(std::shared_ptr<YAML
     if (((drParameters->frictionLawType == FrictionLawType::ImposedSlipRatesYoffe) or
          (drParameters->frictionLawType == FrictionLawType::ImposedSlipRatesGaussian)) and
         (drParameters->slipRateOutputType == 1)) {
-      logWarning() << "SlipRateOutputType=1 is incompatible with imposed slip rates friction laws, "
-                      "switching to SlipRateOutputType=0";
+      logWarning(seissol::MPI::mpi.rank())
+          << "SlipRateOutputType=1 is incompatible with imposed slip rates friction laws, "
+             "switching to SlipRateOutputType=0";
       drParameters->slipRateOutputType = 0;
     }
     drParameters->backgroundType = getWithDefault(yamlDrParams, "backgroundtype", 0);

--- a/src/DynamicRupture/Parameters.h
+++ b/src/DynamicRupture/Parameters.h
@@ -6,6 +6,7 @@
 #include "DynamicRupture/Typedefs.hpp"
 #include "Initializer/InputAux.hpp"
 #include "Kernels/precision.hpp"
+#include "Parallel/MPI.h"
 #include "Typedefs.hpp"
 
 #include <Eigen/Dense>

--- a/src/DynamicRupture/Parameters.h
+++ b/src/DynamicRupture/Parameters.h
@@ -61,6 +61,13 @@ inline std::unique_ptr<DRParameters> readParametersFromYaml(std::shared_ptr<YAML
     drParameters->slipRateOutputType = getWithDefault(yamlDrParams, "sliprateoutputtype", 1);
     drParameters->frictionLawType =
         static_cast<FrictionLawType>(getWithDefault(yamlDrParams, "fl", 0));
+    if (((drParameters->frictionLawType == FrictionLawType::ImposedSlipRatesYoffe) or
+         (drParameters->frictionLawType == FrictionLawType::ImposedSlipRatesGaussian)) and
+        (drParameters->slipRateOutputType == 1)) {
+      logWarning() << "SlipRateOutputType=1 is incompatible with imposed slip rates friction laws, "
+                      "switching to SlipRateOutputType=0";
+      drParameters->slipRateOutputType = 0;
+    }
     drParameters->backgroundType = getWithDefault(yamlDrParams, "backgroundtype", 0);
     drParameters->isThermalPressureOn = getWithDefault(yamlDrParams, "thermalpress", false);
     drParameters->t0 = getWithDefault(yamlDrParams, "t_0", 0.0);


### PR DESCRIPTION
When using FrictionLawType::ImposedSlipRatesYoffe or FrictionLawType::ImposedSlipRatesGaussian, strength is set to 0 (https://github.com/SeisSol/SeisSol/blob/master/src/DynamicRupture/Output/ImposedSlipRates.hpp#L9), and therefore computed updated Tractions (https://github.com/SeisSol/SeisSol/blob/master/src/DynamicRupture/Output/ReceiverBasedOutput.cpp#L308, before they are reset, https://github.com/SeisSol/SeisSol/blob/master/src/DynamicRupture/Output/ImposedSlipRates.hpp#L17) and associated derived SR (https://github.com/SeisSol/SeisSol/blob/master/src/DynamicRupture/Output/ReceiverBasedOutput.cpp#L327) are wrong when calculated with SlipRateOutputType=1.
On the other hand, the SR value calculated from the velocities on both sides of the faults are correct.