### PR TITLE
Set device context for the communication thread

### DIFF
--- a/src/Initializer/InputParameters.cpp
+++ b/src/Initializer/InputParameters.cpp
@@ -290,12 +290,12 @@ static void readOutput(ParameterReader& baseReader, SeisSolParameters& seissolPa
       [](bool& enabled, double interval, const std::string& valName, const std::string& intName) {
         if (enabled && interval <= 0) {
           auto intPhrase = valName + " = 0";
-          logInfo() << "In your parameter file, you have specified a non-positive interval for"
-                    << intName
-                    << ". This mechanism is deprecated and may be removed in a future version of "
-                       "SeisSol. Consider disabling the whole module by setting"
-                    << valName << "to 0 instead by adding" << intPhrase
-                    << "to the \"output\" section of your parameter file instead.";
+          logInfo(seissol::MPI::mpi.rank())
+              << "In your parameter file, you have specified a non-positive interval for" << intName
+              << ". This mechanism is deprecated and may be removed in a future version of "
+                 "SeisSol. Consider disabling the whole module by setting"
+              << valName << "to 0 instead by adding" << intPhrase
+              << "to the \"output\" section of your parameter file instead.";
 
           // still, replicate the old behavior.
           enabled = false;
@@ -379,10 +379,11 @@ static void readOutput(ParameterReader& baseReader, SeisSolParameters& seissolPa
 
   if (seissolParams.output.waveFieldParameters.enabled &&
       seissolParams.output.format == OutputFormat::None) {
-    logInfo() << "Disabling the wavefield output by setting \"outputformat = 10\" is deprecated "
-                 "and may be removed in a future version of SeisSol. Consider using the parameter "
-                 "\"wavefieldoutput\" instead. To disable wavefield output, add \"wavefieldoutput "
-                 "= 0\" to the \"output\" section of your parameters file.";
+    logInfo(seissol::MPI::mpi.rank())
+        << "Disabling the wavefield output by setting \"outputformat = 10\" is deprecated "
+           "and may be removed in a future version of SeisSol. Consider using the parameter "
+           "\"wavefieldoutput\" instead. To disable wavefield output, add \"wavefieldoutput "
+           "= 0\" to the \"output\" section of your parameters file.";
 
     seissolParams.output.waveFieldParameters.enabled = false;
   }

--- a/src/Parallel/AcceleratorDevice.cpp
+++ b/src/Parallel/AcceleratorDevice.cpp
@@ -41,15 +41,6 @@ void AcceleratorDevice::bindSyclDevice(int deviceId) {
 
 void AcceleratorDevice::bindNativeDevice(int deviceId) {
   device::DeviceInstance& device = device::DeviceInstance::getInstance();
-
-#ifdef _OPENMP
-#pragma omp parallel
-  {
-#pragma omp critical
-    { device.api->setDevice(deviceId); }
-  }
-#else
   device.api->setDevice(deviceId);
-#endif
 }
 } // namespace seissol

--- a/src/SeisSol.cpp
+++ b/src/SeisSol.cpp
@@ -67,6 +67,10 @@
 #endif
 
 bool seissol::SeisSol::init(int argc, char* argv[]) {
+#if defined(ACL_DEVICE) && defined(USE_MPI)
+  MPI::mpi.bindAcceleratorDevice();
+#endif
+
 #ifdef USE_ASAGI
   // Construct an instance of AsagiModule, to initialize it.
   // It needs to be done here, as it registers PRE_MPI hooks
@@ -74,10 +78,6 @@ bool seissol::SeisSol::init(int argc, char* argv[]) {
 #endif
   // Call pre MPI hooks
   seissol::Modules::callHook<seissol::PRE_MPI>();
-
-#if defined(ACL_DEVICE) && defined(USE_MPI)
-  MPI::mpi.bindAcceleratorDevice();
-#endif
 
   MPI::mpi.init(argc, argv);
   const int rank = MPI::mpi.rank();

--- a/src/Solver/time_stepping/CommunicationManager.cpp
+++ b/src/Solver/time_stepping/CommunicationManager.cpp
@@ -1,6 +1,9 @@
 #include "CommunicationManager.h"
-
 #include "Parallel/Pin.h"
+
+#ifdef ACL_DEVICE
+#include "device.h"
+#endif // ACL_DEVICE
 
 seissol::time_stepping::AbstractCommunicationManager::AbstractCommunicationManager(
     seissol::time_stepping::AbstractCommunicationManager::ghostClusters_t ghostClusters) : ghostClusters(std::move(ghostClusters)) {
@@ -72,6 +75,10 @@ void seissol::time_stepping::ThreadedCommunicationManager::reset(double newSyncT
   // Start a new communication thread.
   // Note: Easier than keeping one alive, and not that expensive.
   thread = std::thread([this](){
+#ifdef ACL_DEVICE
+    device::DeviceInstance& device = device::DeviceInstance::getInstance();
+    device.api->setDevice(0);
+#endif // ACL_DEVICE
     // Pin this thread to the last core
     // We compute the mask outside the thread because otherwise
     // it confuses profilers and debuggers!


### PR DESCRIPTION
* set the device at the very top of seissol (before any possible MPI_Init)
* adds GPU binding to the comm thread (important for UCX)
* fixed printing of info data to the console

Note: this PR comes together with https://github.com/SeisSol/Device/pull/25