### PR TITLE
Point source GPU

### DIFF
--- a/src/Initializer/InitProcedure/InitSideConditions.cpp
+++ b/src/Initializer/InitProcedure/InitSideConditions.cpp
@@ -8,8 +8,6 @@
 
 #include "Parallel/MPI.h"
 
-#include <utility>
-
 static TravellingWaveParameters getTravellingWaveInformation() {
   const auto& initConditionParams = seissol::SeisSol::main.getSeisSolParameters().initialization;
 

--- a/src/Initializer/InitProcedure/InitSideConditions.cpp
+++ b/src/Initializer/InitProcedure/InitSideConditions.cpp
@@ -8,6 +8,8 @@
 
 #include "Parallel/MPI.h"
 
+#include <utility>
+
 static TravellingWaveParameters getTravellingWaveInformation() {
   const auto& initConditionParams = seissol::SeisSol::main.getSeisSolParameters().initialization;
 

--- a/src/Initializer/typedefs.hpp
+++ b/src/Initializer/typedefs.hpp
@@ -391,27 +391,6 @@ struct CellMaterialData {
 #endif
 };
 
-/** A piecewise linear function.
- * 
- *  Say t \in I_j, then
- *    f(t) = m_j * t + n_j,
- *  where I_j is the half-open interval [t_o + j*dt, t_o + (j+1)*dt).
- *  j runs through 0,...,n-1.
- **/
-struct PiecewiseLinearFunction1D {
-  /** slopes[i] = m_i */
-  std::vector<real> slopes;
-
-  /** intercepts[i] = n_i */
-  std::vector<real> intercepts;
-  
-  /** onsetTime = t_o */
-  real onsetTime;
-  
-  /** samplingInterval = dt */
-  real samplingInterval;
-};
-
 struct DRFaceInformation {
   unsigned meshFace;
   unsigned plusSide;

--- a/src/Initializer/typedefs.hpp
+++ b/src/Initializer/typedefs.hpp
@@ -56,6 +56,7 @@
 #include <DynamicRupture/Misc.h>
 
 #include <cstddef>
+#include <vector>
 
 // cross-cluster time stepping information
 struct TimeStepping {
@@ -398,23 +399,17 @@ struct CellMaterialData {
  *  j runs through 0,...,n-1.
  **/
 struct PiecewiseLinearFunction1D {
-   /** slopes[i] = m_i */
-  real* slopes;
+  /** slopes[i] = m_i */
+  std::vector<real> slopes;
 
   /** intercepts[i] = n_i */
-  real* intercepts;
-  
-  /** numberOfPieces = n */
-  unsigned numberOfPieces;
+  std::vector<real> intercepts;
   
   /** onsetTime = t_o */
   real onsetTime;
   
   /** samplingInterval = dt */
   real samplingInterval;
-  
-  PiecewiseLinearFunction1D() : slopes(NULL), intercepts(NULL), numberOfPieces(0) {}
-  ~PiecewiseLinearFunction1D() { delete[] slopes; delete[] intercepts; numberOfPieces = 0; }
 };
 
 struct DRFaceInformation {

--- a/src/Kernels/PointSourceCluster.h
+++ b/src/Kernels/PointSourceCluster.h
@@ -1,0 +1,17 @@
+// Copyright (C) 2023 Intel Corporation
+// SPDX-License-Identifier: BSD-3-Clause
+
+#ifndef KERNELS_POINTSOURCECLUSTER_H_
+#define KERNELS_POINTSOURCECLUSTER_H_
+
+#include "SourceTerm/typedefs.hpp"
+
+namespace seissol::kernels {
+class PointSourceCluster {
+  public:
+  virtual ~PointSourceCluster() = default;
+  virtual void addTimeIntegratedPointSources(double from, double to) = 0;
+};
+} // namespace seissol::kernels
+
+#endif // KERNELS_POINTSOURCECLUSTER_H_

--- a/src/Kernels/PointSourceClusterOnDevice.cpp
+++ b/src/Kernels/PointSourceClusterOnDevice.cpp
@@ -1,0 +1,130 @@
+// Copyright (C) 2023 Intel Corporation
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include "PointSourceClusterOnDevice.h"
+
+#include <generated_code/tensor.h>
+#include <generated_code/init.h>
+#include <Parallel/AcceleratorDevice.h>
+#include <SourceTerm/PointSource.h>
+
+#include <utility>
+#include <sycl/sycl.hpp>
+
+namespace seissol::kernels {
+
+PointSourceClusterOnDevice::PointSourceClusterOnDevice(sourceterm::ClusterMapping mapping,
+                                                       sourceterm::PointSources sources)
+    : clusterMapping_(std::move(mapping)), sources_(std::move(sources)) {}
+
+void PointSourceClusterOnDevice::addTimeIntegratedPointSources(double from, double to) {
+  auto& queue = seissol::AcceleratorDevice::getInstance().getSyclDefaultQueue();
+  auto& mapping = clusterMapping_.cellToSources;
+  if (mapping.size() > 0) {
+    auto* mapping_ptr = mapping.data();
+    auto* slipRates0 = sources_.slipRates[0].data();
+    auto* slipRates1 = sources_.slipRates[1].data();
+    auto* slipRates2 = sources_.slipRates[2].data();
+    auto* mInvJInvPhisAtSources = sources_.mInvJInvPhisAtSources.data();
+    auto* tensor = sources_.tensor.data();
+    auto* A = sources_.A.data();
+    auto* stiffnessTensor = sources_.stiffnessTensor.data();
+    if (sources_.mode == sourceterm::PointSources::NRF) {
+      queue
+          .parallel_for({mapping.size()},
+                        [=](sycl::item<1> id) {
+                          unsigned startSource = mapping_ptr[id[0]].pointSourcesOffset;
+                          unsigned endSource = mapping_ptr[id[0]].pointSourcesOffset +
+                                               mapping_ptr[id[0]].numberOfPointSources;
+                          for (unsigned source = startSource; source < endSource; ++source) {
+                            addTimeIntegratedPointSourceNRF(
+                                {&slipRates0[source], &slipRates1[source], &slipRates2[source]},
+                                mInvJInvPhisAtSources[source].data(),
+                                tensor[source].data(),
+                                A[source],
+                                stiffnessTensor[source].data(),
+                                from,
+                                to,
+                                *mapping_ptr[id[0]].dofs);
+                          }
+                        })
+          .wait();
+    } else {
+      queue
+          .parallel_for({mapping.size()},
+                        [=](sycl::item<1> id) {
+                          unsigned startSource = mapping_ptr[id[0]].pointSourcesOffset;
+                          unsigned endSource = mapping_ptr[id[0]].pointSourcesOffset +
+                                               mapping_ptr[id[0]].numberOfPointSources;
+                          for (unsigned source = startSource; source < endSource; ++source) {
+                            addTimeIntegratedPointSourceFSRM(&slipRates0[source],
+                                                             mInvJInvPhisAtSources[source].data(),
+                                                             tensor[source].data(),
+                                                             from,
+                                                             to,
+                                                             *mapping_ptr[id[0]].dofs);
+                          }
+                        })
+          .wait();
+    }
+  }
+}
+
+void PointSourceClusterOnDevice::addTimeIntegratedPointSourceNRF(
+    std::array<sourceterm::PiecewiseLinearFunction1D const*, 3> slipRates,
+    real* mInvJInvPhisAtSources,
+    real* tensor,
+    real A,
+    real* stiffnessTensor,
+    double from,
+    double to,
+    real dofs[tensor::Q::size()]) {
+  real slip[3] = {real(0.0)};
+  for (unsigned i = 0; i < 3; ++i) {
+    if (slipRates[i]->slopes.size() > 0) {
+      slip[i] = sourceterm::computePwLFTimeIntegral(*slipRates[i], from, to);
+    }
+  }
+
+  real rotatedSlip[3] = {real(0.0)};
+  for (unsigned i = 0; i < 3; ++i) {
+    for (unsigned j = 0; j < 3; ++j) {
+      rotatedSlip[j] += tensor[j + i * 3] * slip[i];
+    }
+  }
+
+  auto mom = [&](unsigned p, unsigned q) {
+    real m = 0.0;
+    for (unsigned i = 0; i < 3; ++i) {
+      for (unsigned j = 0; j < 3; ++j) {
+        m += -A * stiffnessTensor[p + 3 * q + 9 * i + 27 * j] * rotatedSlip[i] * tensor[6 + j];
+      }
+    }
+    return m;
+  };
+
+  real moment[6] = {mom(0, 0), mom(1, 1), mom(2, 2), mom(0, 1), mom(1, 2), mom(0, 2)};
+  for (unsigned t = 0; t < 6; ++t) {
+    for (unsigned k = 0; k < tensor::mInvJInvPhisAtSources::Shape[0]; ++k) {
+      dofs[k + t * (init::Q::Stop[0] - init::Q::Start[0])] += mInvJInvPhisAtSources[k] * moment[t];
+    }
+  }
+}
+
+void PointSourceClusterOnDevice::addTimeIntegratedPointSourceFSRM(
+    sourceterm::PiecewiseLinearFunction1D const* slipRate0,
+    real* mInvJInvPhisAtSources,
+    real* tensor,
+    double from,
+    double to,
+    real* dofs) {
+  auto stfIntegral = sourceterm::computePwLFTimeIntegral(*slipRate0, from, to);
+  for (unsigned p = 0; p < tensor::momentFSRM::Shape[0]; ++p) {
+    for (unsigned k = 0; k < tensor::mInvJInvPhisAtSources::Shape[0]; ++k) {
+      dofs[k + p * (init::Q::Stop[0] - init::Q::Start[0])] +=
+          stfIntegral * mInvJInvPhisAtSources[k] * tensor[p];
+    }
+  }
+}
+
+} // namespace seissol::kernels

--- a/src/Kernels/PointSourceClusterOnDevice.h
+++ b/src/Kernels/PointSourceClusterOnDevice.h
@@ -1,0 +1,40 @@
+// Copyright (C) 2023 Intel Corporation
+// SPDX-License-Identifier: BSD-3-Clause
+
+#ifndef KERNELS_POINTSOURCECLUSTERONDEVICE_H_
+#define KERNELS_POINTSOURCECLUSTERONDEVICE_H_
+
+#include "PointSourceCluster.h"
+
+#include <SourceTerm/typedefs.hpp>
+
+namespace seissol::kernels {
+class PointSourceClusterOnDevice : public PointSourceCluster {
+  public:
+  PointSourceClusterOnDevice(sourceterm::ClusterMapping mapping, sourceterm::PointSources sources);
+  void addTimeIntegratedPointSources(double from, double to) override;
+
+  private:
+  static void addTimeIntegratedPointSourceNRF(
+      std::array<sourceterm::PiecewiseLinearFunction1D const*, 3> slipRates,
+      real* mInvJInvPhisAtSources,
+      real* tensor,
+      real A,
+      real* stiffnessTensor,
+      double from,
+      double to,
+      real* dofs);
+  static void
+      addTimeIntegratedPointSourceFSRM(sourceterm::PiecewiseLinearFunction1D const* slipRate0,
+                                       real* mInvJInvPhisAtSources,
+                                       real* tensor,
+                                       double from,
+                                       double to,
+                                       real* dofs);
+
+  sourceterm::ClusterMapping clusterMapping_;
+  sourceterm::PointSources sources_;
+};
+} // namespace seissol::kernels
+
+#endif // KERNELS_POINTSOURCECLUSTERONDEVICE_H_

--- a/src/Kernels/PointSourceClusterOnHost.cpp
+++ b/src/Kernels/PointSourceClusterOnHost.cpp
@@ -1,0 +1,88 @@
+// Copyright (c) 2015-2020 SeisSol Group
+// Copyright (C) 2023 Intel Corporation
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include "PointSourceClusterOnHost.h"
+
+#include <generated_code/kernel.h>
+#include <generated_code/init.h>
+#include <SourceTerm/PointSource.h>
+
+#include <utility>
+
+namespace seissol::kernels {
+
+PointSourceClusterOnHost::PointSourceClusterOnHost(sourceterm::ClusterMapping mapping,
+                                                   sourceterm::PointSources sources)
+    : clusterMapping_(std::move(mapping)), sources_(std::move(sources)) {}
+
+void PointSourceClusterOnHost::addTimeIntegratedPointSources(double from, double to) {
+  auto& mapping = clusterMapping_.cellToSources;
+  if (mapping.size() > 0) {
+#ifdef _OPENMP
+#pragma omp parallel for schedule(static)
+#endif
+    for (unsigned m = 0; m < mapping.size(); ++m) {
+      unsigned startSource = mapping[m].pointSourcesOffset;
+      unsigned endSource = mapping[m].pointSourcesOffset + mapping[m].numberOfPointSources;
+      if (sources_.mode == sourceterm::PointSources::NRF) {
+        for (unsigned source = startSource; source < endSource; ++source) {
+          addTimeIntegratedPointSourceNRF(source, from, to, *mapping[m].dofs);
+        }
+      } else {
+        for (unsigned source = startSource; source < endSource; ++source) {
+          addTimeIntegratedPointSourceFSRM(source, from, to, *mapping[m].dofs);
+        }
+      }
+    }
+  }
+}
+
+void PointSourceClusterOnHost::addTimeIntegratedPointSourceNRF(unsigned source,
+                                                               double from,
+                                                               double to,
+                                                               real dofs[tensor::Q::size()]) {
+  real slip[] = {0.0, 0.0, 0.0};
+  for (unsigned i = 0; i < 3; ++i) {
+    if (sources_.slipRates[source][i].slopes.size() > 0) {
+      slip[i] = sourceterm::computePwLFTimeIntegral(sources_.slipRates[source][i], from, to);
+    }
+  }
+
+  real rotatedSlip[] = {0.0, 0.0, 0.0};
+  for (unsigned i = 0; i < 3; ++i) {
+    for (unsigned j = 0; j < 3; ++j) {
+      rotatedSlip[j] += sources_.tensor[source][j + i * 3] * slip[i];
+    }
+  }
+
+  kernel::sourceNRF krnl;
+  krnl.Q = dofs;
+  krnl.mInvJInvPhisAtSources = sources_.mInvJInvPhisAtSources[source].data();
+  krnl.stiffnessTensor = sources_.stiffnessTensor[source].data();
+  krnl.mSlip = rotatedSlip;
+  krnl.mNormal = sources_.tensor[source].data() + 6;
+  krnl.mArea = -sources_.A[source];
+  krnl.momentToNRF = init::momentToNRF::Values;
+#ifdef MULTIPLE_SIMULATIONS
+  krnl.oneSimToMultSim = init::oneSimToMultSim::Values;
+#endif
+  krnl.execute();
+}
+
+void PointSourceClusterOnHost::addTimeIntegratedPointSourceFSRM(unsigned source,
+                                                                double from,
+                                                                double to,
+                                                                real dofs[tensor::Q::size()]) {
+  kernel::sourceFSRM krnl;
+  krnl.Q = dofs;
+  krnl.mInvJInvPhisAtSources = sources_.mInvJInvPhisAtSources[source].data();
+  krnl.momentFSRM = sources_.tensor[source].data();
+  krnl.stfIntegral = sourceterm::computePwLFTimeIntegral(sources_.slipRates[source][0], from, to);
+#ifdef MULTIPLE_SIMULATIONS
+  krnl.oneSimToMultSim = init::oneSimToMultSim::Values;
+#endif
+  krnl.execute();
+}
+
+} // namespace seissol::kernels

--- a/src/Kernels/PointSourceClusterOnHost.cpp
+++ b/src/Kernels/PointSourceClusterOnHost.cpp
@@ -44,8 +44,8 @@ void PointSourceClusterOnHost::addTimeIntegratedPointSourceNRF(unsigned source,
                                                                real dofs[tensor::Q::size()]) {
   real slip[] = {0.0, 0.0, 0.0};
   for (unsigned i = 0; i < 3; ++i) {
-    if (sources_.slipRates[source][i].slopes.size() > 0) {
-      slip[i] = sourceterm::computePwLFTimeIntegral(sources_.slipRates[source][i], from, to);
+    if (sources_.slipRates[i][source].slopes.size() > 0) {
+      slip[i] = sourceterm::computePwLFTimeIntegral(sources_.slipRates[i][source], from, to);
     }
   }
 
@@ -78,7 +78,7 @@ void PointSourceClusterOnHost::addTimeIntegratedPointSourceFSRM(unsigned source,
   krnl.Q = dofs;
   krnl.mInvJInvPhisAtSources = sources_.mInvJInvPhisAtSources[source].data();
   krnl.momentFSRM = sources_.tensor[source].data();
-  krnl.stfIntegral = sourceterm::computePwLFTimeIntegral(sources_.slipRates[source][0], from, to);
+  krnl.stfIntegral = sourceterm::computePwLFTimeIntegral(sources_.slipRates[0][source], from, to);
 #ifdef MULTIPLE_SIMULATIONS
   krnl.oneSimToMultSim = init::oneSimToMultSim::Values;
 #endif

--- a/src/Kernels/PointSourceClusterOnHost.h
+++ b/src/Kernels/PointSourceClusterOnHost.h
@@ -1,0 +1,32 @@
+// Copyright (C) 2023 Intel Corporation
+// SPDX-License-Identifier: BSD-3-Clause
+
+#ifndef KERNELS_POINTSOURCECLUSTERONHOST_H_
+#define KERNELS_POINTSOURCECLUSTERONHOST_H_
+
+#include "PointSourceCluster.h"
+
+#include <SourceTerm/typedefs.hpp>
+
+namespace seissol::kernels {
+class PointSourceClusterOnHost : public PointSourceCluster {
+  public:
+  PointSourceClusterOnHost(sourceterm::ClusterMapping mapping, sourceterm::PointSources sources);
+  void addTimeIntegratedPointSources(double from, double to) override;
+
+  private:
+  void addTimeIntegratedPointSourceNRF(unsigned source,
+                                       double from,
+                                       double to,
+                                       real dofs[tensor::Q::size()]);
+  void addTimeIntegratedPointSourceFSRM(unsigned source,
+                                        double from,
+                                        double to,
+                                        real dofs[tensor::Q::size()]);
+
+  sourceterm::ClusterMapping clusterMapping_;
+  sourceterm::PointSources sources_;
+};
+} // namespace seissol::kernels
+
+#endif // KERNELS_POINTSOURCECLUSTERONHOST_H_

--- a/src/Solver/time_stepping/TimeCluster.cpp
+++ b/src/Solver/time_stepping/TimeCluster.cpp
@@ -118,9 +118,7 @@ seissol::time_stepping::TimeCluster::TimeCluster(unsigned int i_clusterId, unsig
     m_dynRup(i_dynRup),
     frictionSolver(i_FrictionSolver),
     faultOutputManager(i_faultOutputManager),
-    m_cellToPointSources(nullptr),
-    m_numberOfCellToPointSourcesMappings(0),
-    m_pointSources(nullptr),
+    m_sourceCluster{nullptr},
     // cells
     m_loopStatistics(i_loopStatistics),
     actorStateStatistics(actorStateStatistics),
@@ -161,13 +159,9 @@ seissol::time_stepping::TimeCluster::~TimeCluster() {
 #endif
 }
 
-void seissol::time_stepping::TimeCluster::setPointSources( sourceterm::CellToPointSourcesMapping const* i_cellToPointSources,
-                                                           unsigned i_numberOfCellToPointSourcesMappings,
-                                                           sourceterm::PointSources const* i_pointSources )
-{
-  m_cellToPointSources = i_cellToPointSources;
-  m_numberOfCellToPointSourcesMappings = i_numberOfCellToPointSourcesMappings;
-  m_pointSources = i_pointSources;
+void seissol::time_stepping::TimeCluster::setPointSources(
+    std::unique_ptr<kernels::PointSourceCluster> sourceCluster) {
+  m_sourceCluster = std::move(sourceCluster);
 }
 
 void seissol::time_stepping::TimeCluster::writeReceivers() {
@@ -187,36 +181,8 @@ void seissol::time_stepping::TimeCluster::computeSources() {
 
   // Return when point sources not initialised. This might happen if there
   // are no point sources on this rank.
-  if (m_numberOfCellToPointSourcesMappings != 0) {
-#ifdef _OPENMP
-  #pragma omp parallel for schedule(static)
-#endif
-    for (unsigned mapping = 0; mapping < m_numberOfCellToPointSourcesMappings; ++mapping) {
-      unsigned startSource = m_cellToPointSources[mapping].pointSourcesOffset;
-      unsigned endSource =
-          m_cellToPointSources[mapping].pointSourcesOffset + m_cellToPointSources[mapping].numberOfPointSources;
-      if (m_pointSources->mode == sourceterm::PointSources::NRF) {
-        for (unsigned source = startSource; source < endSource; ++source) {
-          sourceterm::addTimeIntegratedPointSourceNRF(m_pointSources->mInvJInvPhisAtSources[source],
-                                                      m_pointSources->tensor[source],
-                                                      m_pointSources->A[source],
-                                                      m_pointSources->stiffnessTensor[source],
-                                                      m_pointSources->slipRates[source],
-                                                      ct.correctionTime,
-                                                      ct.correctionTime + timeStepSize(),
-                                                      *m_cellToPointSources[mapping].dofs);
-        }
-      } else {
-        for (unsigned source = startSource; source < endSource; ++source) {
-          sourceterm::addTimeIntegratedPointSourceFSRM(m_pointSources->mInvJInvPhisAtSources[source],
-                                                       m_pointSources->tensor[source],
-                                                       m_pointSources->slipRates[source][0],
-                                                       ct.correctionTime,
-                                                       ct.correctionTime + timeStepSize(),
-                                                       *m_cellToPointSources[mapping].dofs);
-        }
-      }
-    }
+  if (m_sourceCluster) {
+    m_sourceCluster->addTimeIntegratedPointSources(ct.correctionTime, ct.correctionTime + timeStepSize());
   }
 #ifdef ACL_DEVICE
   device.api->popLastProfilingMark();

--- a/src/Solver/time_stepping/TimeCluster.h
+++ b/src/Solver/time_stepping/TimeCluster.h
@@ -87,6 +87,7 @@
 #include <Kernels/Neighbor.h>
 #include <Kernels/DynamicRupture.h>
 #include <Kernels/Plasticity.h>
+#include <Kernels/PointSourceCluster.h>
 #include <Kernels/TimeCommon.h>
 #include <Solver/FreeSurfaceIntegrator.h>
 #include <Monitoring/LoopStatistics.h>
@@ -164,14 +165,7 @@ private:
     dr::friction_law::FrictionSolver* frictionSolver;
     dr::output::OutputManager* faultOutputManager;
 
-    //! Mapping of cells to point sources
-    sourceterm::CellToPointSourcesMapping const* m_cellToPointSources;
-
-    //! Number of mapping of cells to point sources
-    unsigned m_numberOfCellToPointSourcesMappings;
-
-    //! Point sources
-    sourceterm::PointSources const* m_pointSources;
+    std::unique_ptr<kernels::PointSourceCluster> m_sourceCluster;
 
     enum class ComputePart {
       Local = 0,
@@ -412,15 +406,11 @@ public:
   ~TimeCluster() override;
 
   /**
-   * Sets the pointer to the cluster's point sources
+   * Sets the the cluster's point sources
    *
-   * @param i_cellToPointSources Contains mappings of 1 cell offset to m point sources
-   * @param i_numberOfCellToPointSourcesMappings Size of i_cellToPointSources
-   * @param i_pointSources pointer to all point sources used on this cluster
+   * @param sourceCluster Contains point sources for cluster
    */
-  void setPointSources( sourceterm::CellToPointSourcesMapping const* i_cellToPointSources,
-                        unsigned i_numberOfCellToPointSourcesMappings,
-                        sourceterm::PointSources const* i_pointSources );
+  void setPointSources(std::unique_ptr<kernels::PointSourceCluster> sourceCluster);
 
   void setReceiverCluster( kernels::ReceiverCluster* receiverCluster) {
     m_receiverCluster = receiverCluster;

--- a/src/Solver/time_stepping/TimeManager.cpp
+++ b/src/Solver/time_stepping/TimeManager.cpp
@@ -345,14 +345,12 @@ double seissol::time_stepping::TimeManager::getTimeTolerance() {
 }
 
 void seissol::time_stepping::TimeManager::setPointSourcesForClusters(
-    std::unordered_map<LayerType, std::vector<sourceterm::ClusterMapping>>& clusterMappings,
-    std::unordered_map<LayerType, std::vector<sourceterm::PointSources>>& pointSources) {
+    std::unordered_map<LayerType, std::vector<std::unique_ptr<kernels::PointSourceCluster>>> sourceClusters) {
   for (auto& cluster : clusters) {
-    cluster->setPointSources(
-        clusterMappings[cluster->getLayerType()][cluster->getClusterId()].cellToSources,
-        clusterMappings[cluster->getLayerType()][cluster->getClusterId()].numberOfMappings,
-        &(pointSources[cluster->getLayerType()][cluster->getClusterId()])
-        );
+    auto layerClusters = sourceClusters.find(cluster->getLayerType());
+    if (layerClusters != sourceClusters.end() && cluster->getClusterId() < layerClusters->second.size()) {
+      cluster->setPointSources(std::move(layerClusters->second[cluster->getClusterId()]));
+    }
   }
 }
 

--- a/src/Solver/time_stepping/TimeManager.h
+++ b/src/Solver/time_stepping/TimeManager.h
@@ -52,6 +52,7 @@
 #include <utils/logger.h>
 #include <Initializer/MemoryManager.h>
 #include <Initializer/time_stepping/LtsLayout.h>
+#include <Kernels/PointSourceCluster.h>
 #include <Solver/FreeSurfaceIntegrator.h>
 #include <ResultWriter/ReceiverWriter.h>
 #include "TimeCluster.h"
@@ -159,12 +160,10 @@ class seissol::time_stepping::TimeManager {
     /**
      * Distributes point sources pointers to clusters
      * 
-     * @param clusterMappings Maps layers+clusters to point sources
-     * @param pointSources Map from layer to list of point sources
+     * @param sourceClusters Collection of point sources for clusters
      */
     void setPointSourcesForClusters(
-        std::unordered_map<LayerType, std::vector<sourceterm::ClusterMapping>>& clusterMappings,
-        std::unordered_map<LayerType, std::vector<sourceterm::PointSources>>& pointSources);
+        std::unordered_map<LayerType, std::vector<std::unique_ptr<kernels::PointSourceCluster>>> sourceClusters);
 
   /**
    * Returns the writer for the receivers

--- a/src/SourceTerm/Manager.cpp
+++ b/src/SourceTerm/Manager.cpp
@@ -83,6 +83,7 @@
 #include "Parallel/MPI.h"
 
 #include <Initializer/PointMapper.h>
+#include <Kernels/PointSourceClusterOnHost.h>
 #include <utils/logger.h>
 #include <string>
 #include <cstring>
@@ -91,10 +92,11 @@
  * Computes mInvJInvPhisAtSources[i] = |J|^-1 * M_ii^-1 * phi_i(xi, eta, zeta),
  * where xi, eta, zeta is the point in the reference tetrahedron corresponding to x, y, z.
  */
-void seissol::sourceterm::computeMInvJInvPhisAtSources(Eigen::Vector3d const& centre,
-                                                       real* mInvJInvPhisAtSources,
-                                                       unsigned meshId,
-                                                       seissol::geometry::MeshReader const& mesh) {
+void seissol::sourceterm::computeMInvJInvPhisAtSources(
+    Eigen::Vector3d const& centre,
+    AlignedArray<real, tensor::mInvJInvPhisAtSources::size()>& mInvJInvPhisAtSources,
+    unsigned meshId,
+    seissol::geometry::MeshReader const& mesh) {
   auto const& elements = mesh.getElements();
   auto const& vertices = mesh.getVertices();
 
@@ -113,7 +115,7 @@ void seissol::sourceterm::computeMInvJInvPhisAtSources(Eigen::Vector3d const& ce
   kernel::computeMInvJInvPhisAtSources krnl;
   krnl.basisFunctionsAtPoint = basisFunctionsAtPoint.m_data.data();
   krnl.M3inv = init::M3inv::Values;
-  krnl.mInvJInvPhisAtSources = mInvJInvPhisAtSources;
+  krnl.mInvJInvPhisAtSources = mInvJInvPhisAtSources.data();
   krnl.JInv = JInv;
   krnl.execute();
 }
@@ -131,7 +133,7 @@ void seissol::sourceterm::transformNRFSourceToInternalSource(
     unsigned index) {
   computeMInvJInvPhisAtSources(centre, pointSources.mInvJInvPhisAtSources[index], meshId, mesh);
 
-  real* faultBasis = pointSources.tensor[index];
+  auto& faultBasis = pointSources.tensor[index];
   faultBasis[0] = subfault.tan1(0);
   faultBasis[1] = subfault.tan1(1);
   faultBasis[2] = subfault.tan1(2);
@@ -163,17 +165,18 @@ void seissol::sourceterm::transformNRFSourceToInternalSource(
   for (unsigned sr = 0; sr < 3; ++sr) {
     unsigned numSamples = nextOffsets[sr] - offsets[sr];
     double const* samples = (numSamples > 0) ? &sliprates[sr][offsets[sr]] : NULL;
-    samplesToPiecewiseLinearFunction1D(
-        samples, numSamples, subfault.tinit, subfault.timestep, &pointSources.slipRates[index][sr]);
+    pointSources.slipRates[index][sr] =
+        samplesToPiecewiseLinearFunction1D(samples, numSamples, subfault.tinit, subfault.timestep);
   }
 }
 
-void seissol::sourceterm::Manager::mapPointSourcesToClusters(
+auto seissol::sourceterm::Manager::mapPointSourcesToClusters(
     const unsigned* meshIds,
     unsigned numberOfSources,
     seissol::initializers::LTSTree* ltsTree,
     seissol::initializers::LTS* lts,
-    seissol::initializers::Lut* ltsLut) {
+    seissol::initializers::Lut* ltsLut)
+    -> std::unordered_map<LayerType, std::vector<ClusterMapping>> {
   auto layerClusterToPointSources =
       std::unordered_map<LayerType, std::vector<std::vector<unsigned>>>{};
   layerClusterToPointSources[Copy].resize(ltsTree->numChildren());
@@ -191,6 +194,7 @@ void seissol::sourceterm::Manager::mapPointSourcesToClusters(
     layerClusterToMeshIds[layer][cluster].push_back(meshId);
   }
 
+  std::unordered_map<LayerType, std::vector<ClusterMapping>> layeredClusterMapping;
   for (auto layer : {Copy, Interior}) {
     layeredClusterMapping[layer].resize(ltsTree->numChildren());
     auto& clusterToMeshIds = layerClusterToMeshIds[layer];
@@ -211,24 +215,22 @@ void seissol::sourceterm::Manager::mapPointSourcesToClusters(
         }
       }
 
-      clusterMappings[cluster].sources = new unsigned[clusterToPointSources[cluster].size()];
-      clusterMappings[cluster].numberOfSources = clusterToPointSources[cluster].size();
-      clusterMappings[cluster].cellToSources = new CellToPointSourcesMapping[numberOfMappings];
-      clusterMappings[cluster].numberOfMappings = numberOfMappings;
+      clusterMappings[cluster].sources.resize(clusterToPointSources[cluster].size());
+      clusterMappings[cluster].cellToSources.resize(numberOfMappings);
 
       for (unsigned source = 0; source < clusterToPointSources[cluster].size(); ++source) {
         clusterMappings[cluster].sources[source] = clusterToPointSources[cluster][source];
       }
-      std::sort(clusterMappings[cluster].sources,
-                clusterMappings[cluster].sources + clusterMappings[cluster].numberOfSources,
+      std::sort(clusterMappings[cluster].sources.begin(),
+                clusterMappings[cluster].sources.end(),
                 [&](unsigned i, unsigned j) { return meshIds[i] < meshIds[j]; });
 
       unsigned clusterSource = 0;
       unsigned mapping = 0;
-      while (clusterSource < clusterMappings[cluster].numberOfSources) {
+      while (clusterSource < clusterMappings[cluster].sources.size()) {
         unsigned meshId = meshIds[clusterMappings[cluster].sources[clusterSource]];
         unsigned next = clusterSource + 1;
-        while (next < clusterMappings[cluster].numberOfSources &&
+        while (next < clusterMappings[cluster].sources.size() &&
                meshIds[clusterMappings[cluster].sources[next]] == meshId) {
           ++next;
         }
@@ -246,9 +248,11 @@ void seissol::sourceterm::Manager::mapPointSourcesToClusters(
 
         clusterSource = next;
       }
-      assert(mapping == clusterMappings[cluster].numberOfMappings);
+      assert(mapping == clusterMappings[cluster].cellToSources.size());
     }
   }
+
+  return layeredClusterMapping;
 }
 
 void seissol::sourceterm::Manager::loadSources(SourceType sourceType,
@@ -258,17 +262,19 @@ void seissol::sourceterm::Manager::loadSources(SourceType sourceType,
                                                seissol::initializers::LTS* lts,
                                                seissol::initializers::Lut* ltsLut,
                                                time_stepping::TimeManager& timeManager) {
+  auto sourceClusters =
+      std::unordered_map<LayerType, std::vector<std::unique_ptr<kernels::PointSourceCluster>>>{};
   if (sourceType == SourceType::NrfSource) {
     logInfo(seissol::MPI::mpi.rank()) << "Reading an NRF source (type 42).";
 #if defined(USE_NETCDF) && !defined(NETCDF_PASSIVE)
-    loadSourcesFromNRF(fileName, mesh, ltsTree, lts, ltsLut, timeManager);
+    loadSourcesFromNRF(fileName, mesh, ltsTree, lts, ltsLut);
 #else
     logError() << "NRF sources (type 42) need SeisSol to be linked with an (active) Netcdf "
                   "library. However, this is not the case for this build.";
 #endif
   } else if (sourceType == SourceType::FsrmSource) {
     logInfo(seissol::MPI::mpi.rank()) << "Reading an FSRM source (type 50).";
-    loadSourcesFromFSRM(fileName, mesh, ltsTree, lts, ltsLut, timeManager);
+    loadSourcesFromFSRM(fileName, mesh, ltsTree, lts, ltsLut);
   } else if (sourceType == SourceType::None) {
     logInfo(seissol::MPI::mpi.rank()) << "No source term specified.";
   } else {
@@ -276,14 +282,23 @@ void seissol::sourceterm::Manager::loadSources(SourceType sourceType,
                << "has been defined, but not yet been implemented in SeisSol.";
   }
   // otherwise, we do not have any source term.
+
+  timeManager.setPointSourcesForClusters(std::move(sourceClusters));
 }
 
-void seissol::sourceterm::Manager::loadSourcesFromFSRM(char const* fileName,
+auto seissol::sourceterm::Manager::makePointSourceCluster(ClusterMapping mapping,
+                                                          PointSources sources)
+    -> std::unique_ptr<kernels::PointSourceCluster> {
+  return std::make_unique<kernels::PointSourceClusterOnHost>(std::move(mapping),
+                                                             std::move(sources));
+}
+
+auto seissol::sourceterm::Manager::loadSourcesFromFSRM(char const* fileName,
                                                        seissol::geometry::MeshReader const& mesh,
                                                        seissol::initializers::LTSTree* ltsTree,
                                                        seissol::initializers::LTS* lts,
-                                                       seissol::initializers::Lut* ltsLut,
-                                                       time_stepping::TimeManager& timeManager) {
+                                                       seissol::initializers::Lut* ltsLut)
+    -> std::unordered_map<LayerType, std::vector<std::unique_ptr<kernels::PointSourceCluster>>> {
   // until further rewrite, we'll leave most of the raw pointers/arrays in here.
 
   int rank = seissol::MPI::mpi.rank();
@@ -305,7 +320,7 @@ void seissol::sourceterm::Manager::loadSourcesFromFSRM(char const* fileName,
 
   unsigned* originalIndex = new unsigned[fsrm.numberOfSources];
   unsigned numSources = 0;
-  for (int source = 0; source < fsrm.numberOfSources; ++source) {
+  for (unsigned source = 0; source < fsrm.numberOfSources; ++source) {
     originalIndex[numSources] = source;
     meshIds[numSources] = meshIds[source];
     numSources += contained[source];
@@ -313,38 +328,29 @@ void seissol::sourceterm::Manager::loadSourcesFromFSRM(char const* fileName,
   delete[] contained;
 
   logInfo(rank) << "Mapping point sources to LTS cells...";
-  mapPointSourcesToClusters(meshIds, numSources, ltsTree, lts, ltsLut);
+  auto layeredClusterMapping = mapPointSourcesToClusters(meshIds, numSources, ltsTree, lts, ltsLut);
+  std::unordered_map<LayerType, std::vector<std::unique_ptr<kernels::PointSourceCluster>>>
+      layeredSourceClusters;
 
   for (auto layer : {Interior, Copy}) {
-    auto& sources = layeredSources[layer];
-    sources.resize(ltsTree->numChildren());
+    auto& sourceCluster = layeredSourceClusters[layer];
+    sourceCluster.resize(ltsTree->numChildren());
     auto& clusterMappings = layeredClusterMapping[layer];
     for (unsigned cluster = 0; cluster < ltsTree->numChildren(); ++cluster) {
-      sources[cluster].mode = PointSources::FSRM;
-      sources[cluster].numberOfSources = clusterMappings[cluster].numberOfSources;
-      int error = posix_memalign(reinterpret_cast<void**>(&sources[cluster].mInvJInvPhisAtSources),
-                                 ALIGNMENT,
-                                 clusterMappings[cluster].numberOfSources *
-                                     tensor::mInvJInvPhisAtSources::size() * sizeof(real));
-      if (error) {
-        logError() << "posix_memalign failed in source term manager.";
-      }
-      error = posix_memalign(reinterpret_cast<void**>(&sources[cluster].tensor),
-                             ALIGNMENT,
-                             clusterMappings[cluster].numberOfSources * PointSources::TensorSize *
-                                 sizeof(real));
-      if (error) {
-        logError() << "posix_memalign failed in source term manager.";
-      }
-      sources[cluster].slipRates.resize(clusterMappings[cluster].numberOfSources);
+      auto numberOfSources = clusterMappings[cluster].sources.size();
+      auto sources = PointSources{};
+      sources.mode = PointSources::FSRM;
+      sources.numberOfSources = numberOfSources;
+      sources.mInvJInvPhisAtSources.resize(numberOfSources);
+      sources.tensor.resize(numberOfSources);
+      sources.slipRates.resize(numberOfSources);
 
-      for (unsigned clusterSource = 0; clusterSource < clusterMappings[cluster].numberOfSources;
-           ++clusterSource) {
+      for (unsigned clusterSource = 0; clusterSource < numberOfSources; ++clusterSource) {
         unsigned sourceIndex = clusterMappings[cluster].sources[clusterSource];
         unsigned fsrmIndex = originalIndex[sourceIndex];
 
         computeMInvJInvPhisAtSources(fsrm.centers[fsrmIndex],
-                                     sources[cluster].mInvJInvPhisAtSources[clusterSource],
+                                     sources.mInvJInvPhisAtSources[clusterSource],
                                      meshIds[sourceIndex],
                                      mesh);
         transformMomentTensor(fsrm.momentTensor,
@@ -354,16 +360,16 @@ void seissol::sourceterm::Manager::loadSourcesFromFSRM(char const* fileName,
                               fsrm.strikes[fsrmIndex],
                               fsrm.dips[fsrmIndex],
                               fsrm.rakes[fsrmIndex],
-                              sources[cluster].tensor[clusterSource]);
+                              sources.tensor[clusterSource]);
 
         for (unsigned i = 0; i < NUMBER_OF_QUANTITIES; ++i) {
-          sources[cluster].tensor[clusterSource][i] *= fsrm.areas[fsrmIndex];
+          sources.tensor[clusterSource][i] *= fsrm.areas[fsrmIndex];
         }
 #ifndef USE_POROELASTIC
         seissol::model::Material& material =
             ltsLut->lookup(lts->material, meshIds[sourceIndex] - 1).local;
         for (unsigned i = 0; i < 3; ++i) {
-          sources[cluster].tensor[clusterSource][6 + i] /= material.rho;
+          sources.tensor[clusterSource][6 + i] /= material.rho;
         }
 #else
         logWarning() << "The poroelastic equation does not scale the force components with the "
@@ -371,30 +377,33 @@ void seissol::sourceterm::Manager::loadSourcesFromFSRM(char const* fileName,
                         "to the documentation of SeisSol.";
 #endif
 
-        samplesToPiecewiseLinearFunction1D(fsrm.timeHistories[fsrmIndex].data(),
-                                           fsrm.numberOfSamples,
-                                           fsrm.onsets[fsrmIndex],
-                                           fsrm.timestep,
-                                           &sources[cluster].slipRates[clusterSource][0]);
+        sources.slipRates[clusterSource][0] =
+            samplesToPiecewiseLinearFunction1D(fsrm.timeHistories[fsrmIndex].data(),
+                                               fsrm.numberOfSamples,
+                                               fsrm.onsets[fsrmIndex],
+                                               fsrm.timestep);
       }
+
+      sourceCluster[cluster] =
+          makePointSourceCluster(std::move(clusterMappings[cluster]), std::move(sources));
     }
   }
   delete[] originalIndex;
   delete[] meshIds;
 
-  timeManager.setPointSourcesForClusters(layeredClusterMapping, layeredSources);
-
   logInfo(rank) << ".. finished point source initialization.";
+
+  return layeredSourceClusters;
 }
 
 // TODO Add support for passive netCDF
 #if defined(USE_NETCDF) && !defined(NETCDF_PASSIVE)
-void seissol::sourceterm::Manager::loadSourcesFromNRF(char const* fileName,
+auto seissol::sourceterm::Manager::loadSourcesFromNRF(char const* fileName,
                                                       seissol::geometry::MeshReader const& mesh,
                                                       seissol::initializers::LTSTree* ltsTree,
                                                       seissol::initializers::LTS* lts,
-                                                      seissol::initializers::Lut* ltsLut,
-                                                      time_stepping::TimeManager& timeManager) {
+                                                      seissol::initializers::Lut* ltsLut)
+    -> std::unordered_map<LayerType, std::vector<std::unique_ptr<kernels::PointSourceCluster>>> {
   int rank = seissol::MPI::mpi.rank();
 
   logInfo(rank) << "<--------------------------------------------------------->";
@@ -439,36 +448,27 @@ void seissol::sourceterm::Manager::loadSourcesFromNRF(char const* fileName,
   }
 
   logInfo(rank) << "Mapping point sources to LTS cells...";
-  mapPointSourcesToClusters(meshIds, numSources, ltsTree, lts, ltsLut);
+
+  auto layeredClusterMapping = mapPointSourcesToClusters(meshIds, numSources, ltsTree, lts, ltsLut);
+  std::unordered_map<LayerType, std::vector<std::unique_ptr<kernels::PointSourceCluster>>>
+      layeredSourceClusters;
 
   for (auto layer : {Interior, Copy}) {
-    auto& sources = layeredSources[layer];
-    sources.resize(ltsTree->numChildren());
+    auto& sourceCluster = layeredSourceClusters[layer];
+    sourceCluster.resize(ltsTree->numChildren());
     auto& clusterMappings = layeredClusterMapping[layer];
     for (unsigned cluster = 0; cluster < ltsTree->numChildren(); ++cluster) {
-      sources[cluster].mode = PointSources::NRF;
-      sources[cluster].numberOfSources = clusterMappings[cluster].numberOfSources;
-      int error = posix_memalign(reinterpret_cast<void**>(&sources[cluster].mInvJInvPhisAtSources),
-                                 ALIGNMENT,
-                                 clusterMappings[cluster].numberOfSources *
-                                     tensor::mInvJInvPhisAtSources::size() * sizeof(real));
-      if (error) {
-        logError() << "posix_memalign failed in source term manager.";
-      }
-      error = posix_memalign(reinterpret_cast<void**>(&sources[cluster].tensor),
-                             ALIGNMENT,
-                             clusterMappings[cluster].numberOfSources * PointSources::TensorSize *
-                                 sizeof(real));
-      if (error) {
-        logError() << "posix_memalign failed in source term manager.";
-      }
+      auto numberOfSources = clusterMappings[cluster].sources.size();
+      auto sources = PointSources{};
+      sources.mode = PointSources::NRF;
+      sources.numberOfSources = numberOfSources;
+      sources.mInvJInvPhisAtSources.resize(numberOfSources);
+      sources.tensor.resize(numberOfSources);
+      sources.A.resize(numberOfSources);
+      sources.stiffnessTensor.resize(numberOfSources);
+      sources.slipRates.resize(numberOfSources);
 
-      sources[cluster].A.resize(clusterMappings[cluster].numberOfSources);
-      sources[cluster].stiffnessTensor.resize(clusterMappings[cluster].numberOfSources);
-      sources[cluster].slipRates.resize(clusterMappings[cluster].numberOfSources);
-
-      for (unsigned clusterSource = 0; clusterSource < clusterMappings[cluster].numberOfSources;
-           ++clusterSource) {
+      for (unsigned clusterSource = 0; clusterSource < numberOfSources; ++clusterSource) {
         unsigned sourceIndex = clusterMappings[cluster].sources[clusterSource];
         unsigned nrfIndex = originalIndex[sourceIndex];
         transformNRFSourceToInternalSource(
@@ -480,16 +480,18 @@ void seissol::sourceterm::Manager::loadSourcesFromNRF(char const* fileName,
             nrf.sroffsets[nrfIndex + 1],
             nrf.sliprates,
             &ltsLut->lookup(lts->material, meshIds[sourceIndex]).local,
-            sources[cluster],
+            sources,
             clusterSource);
       }
+      sourceCluster[cluster] =
+          makePointSourceCluster(std::move(clusterMappings[cluster]), std::move(sources));
     }
   }
   delete[] originalIndex;
   delete[] meshIds;
 
-  timeManager.setPointSourcesForClusters(layeredClusterMapping, layeredSources);
-
   logInfo(rank) << ".. finished point source initialization.";
+
+  return layeredSourceClusters;
 }
 #endif // defined(USE_NETCDF) && !defined(NETCDF_PASSIVE)

--- a/src/SourceTerm/Manager.cpp
+++ b/src/SourceTerm/Manager.cpp
@@ -267,14 +267,14 @@ void seissol::sourceterm::Manager::loadSources(SourceType sourceType,
   if (sourceType == SourceType::NrfSource) {
     logInfo(seissol::MPI::mpi.rank()) << "Reading an NRF source (type 42).";
 #if defined(USE_NETCDF) && !defined(NETCDF_PASSIVE)
-    loadSourcesFromNRF(fileName, mesh, ltsTree, lts, ltsLut);
+    sourceClusters = loadSourcesFromNRF(fileName, mesh, ltsTree, lts, ltsLut);
 #else
     logError() << "NRF sources (type 42) need SeisSol to be linked with an (active) Netcdf "
                   "library. However, this is not the case for this build.";
 #endif
   } else if (sourceType == SourceType::FsrmSource) {
     logInfo(seissol::MPI::mpi.rank()) << "Reading an FSRM source (type 50).";
-    loadSourcesFromFSRM(fileName, mesh, ltsTree, lts, ltsLut);
+    sourceClusters = loadSourcesFromFSRM(fileName, mesh, ltsTree, lts, ltsLut);
   } else if (sourceType == SourceType::None) {
     logInfo(seissol::MPI::mpi.rank()) << "No source term specified.";
   } else {

--- a/src/SourceTerm/Manager.h
+++ b/src/SourceTerm/Manager.h
@@ -46,18 +46,21 @@
 #include <cstdarg>
 
 #include <Initializer/tree/Lut.hpp>
+#include <Kernels/PointSourceCluster.h>
 #include <Solver/time_stepping/TimeManager.h>
 #include <Geometry/MeshReader.h>
 #include <inttypes.h>
+#include <memory>
 
 namespace seissol {
 namespace sourceterm {
 enum class SourceType : int { None = 0, NrfSource = 42, FsrmSource = 50 };
 
-void computeMInvJInvPhisAtSources(Eigen::Vector3d const& centre,
-                                  real* mInvJInvPhisAtSources,
-                                  unsigned meshId,
-                                  seissol::geometry::MeshReader const& mesh);
+void computeMInvJInvPhisAtSources(
+    Eigen::Vector3d const& centre,
+    AlignedArray<real, tensor::mInvJInvPhisAtSources::size()>& mInvJInvPhisAtSources,
+    unsigned meshId,
+    seissol::geometry::MeshReader const& mesh);
 void transformNRFSourceToInternalSource(Eigen::Vector3d const& centre,
                                         unsigned meshId,
                                         seissol::geometry::MeshReader const& mesh,
@@ -73,10 +76,6 @@ class Manager;
 } // namespace seissol
 
 class seissol::sourceterm::Manager {
-  private:
-  std::unordered_map<LayerType, std::vector<ClusterMapping>> layeredClusterMapping;
-  std::unordered_map<LayerType, std::vector<PointSources>> layeredSources;
-
   public:
   Manager() = default;
   ~Manager() = default;
@@ -89,26 +88,31 @@ class seissol::sourceterm::Manager {
                    seissol::initializers::Lut* ltsLut,
                    time_stepping::TimeManager& timeManager);
 
-  void mapPointSourcesToClusters(unsigned const* meshIds,
+  private:
+  auto mapPointSourcesToClusters(const unsigned* meshIds,
                                  unsigned numberOfSources,
                                  seissol::initializers::LTSTree* ltsTree,
                                  seissol::initializers::LTS* lts,
-                                 seissol::initializers::Lut* ltsLut);
+                                 seissol::initializers::Lut* ltsLut)
+      -> std::unordered_map<LayerType, std::vector<ClusterMapping>>;
 
-  void loadSourcesFromFSRM(char const* fileName,
+  auto makePointSourceCluster(ClusterMapping mapping, PointSources sources)
+      -> std::unique_ptr<kernels::PointSourceCluster>;
+
+  auto loadSourcesFromFSRM(char const* fileName,
                            seissol::geometry::MeshReader const& mesh,
                            seissol::initializers::LTSTree* ltsTree,
                            seissol::initializers::LTS* lts,
-                           seissol::initializers::Lut* ltsLut,
-                           time_stepping::TimeManager& timeManager);
+                           seissol::initializers::Lut* ltsLut)
+      -> std::unordered_map<LayerType, std::vector<std::unique_ptr<kernels::PointSourceCluster>>>;
 
 #if defined(USE_NETCDF) && !defined(NETCDF_PASSIVE)
-  void loadSourcesFromNRF(char const* fileName,
+  auto loadSourcesFromNRF(char const* fileName,
                           seissol::geometry::MeshReader const& mesh,
                           seissol::initializers::LTSTree* ltsTree,
                           seissol::initializers::LTS* lts,
-                          seissol::initializers::Lut* ltsLut,
-                          time_stepping::TimeManager& timeManager);
+                          seissol::initializers::Lut* ltsLut)
+      -> std::unordered_map<LayerType, std::vector<std::unique_ptr<kernels::PointSourceCluster>>>;
 #endif
 };
 

--- a/src/SourceTerm/Manager.h
+++ b/src/SourceTerm/Manager.h
@@ -70,7 +70,8 @@ void transformNRFSourceToInternalSource(Eigen::Vector3d const& centre,
                                         double* const sliprates[3],
                                         seissol::model::Material* material,
                                         PointSources& pointSources,
-                                        unsigned index);
+                                        unsigned index,
+                                        AllocatorFactory const& alloc);
 class Manager;
 } // namespace sourceterm
 } // namespace seissol
@@ -93,7 +94,8 @@ class seissol::sourceterm::Manager {
                                  unsigned numberOfSources,
                                  seissol::initializers::LTSTree* ltsTree,
                                  seissol::initializers::LTS* lts,
-                                 seissol::initializers::Lut* ltsLut)
+                                 seissol::initializers::Lut* ltsLut,
+                                 AllocatorFactory const& alloc)
       -> std::unordered_map<LayerType, std::vector<ClusterMapping>>;
 
   auto makePointSourceCluster(ClusterMapping mapping, PointSources sources)
@@ -103,7 +105,8 @@ class seissol::sourceterm::Manager {
                            seissol::geometry::MeshReader const& mesh,
                            seissol::initializers::LTSTree* ltsTree,
                            seissol::initializers::LTS* lts,
-                           seissol::initializers::Lut* ltsLut)
+                           seissol::initializers::Lut* ltsLut,
+                           AllocatorFactory const& alloc)
       -> std::unordered_map<LayerType, std::vector<std::unique_ptr<kernels::PointSourceCluster>>>;
 
 #if defined(USE_NETCDF) && !defined(NETCDF_PASSIVE)
@@ -111,7 +114,8 @@ class seissol::sourceterm::Manager {
                           seissol::geometry::MeshReader const& mesh,
                           seissol::initializers::LTSTree* ltsTree,
                           seissol::initializers::LTS* lts,
-                          seissol::initializers::Lut* ltsLut)
+                          seissol::initializers::Lut* ltsLut,
+                          AllocatorFactory const& alloc)
       -> std::unordered_map<LayerType, std::vector<std::unique_ptr<kernels::PointSourceCluster>>>;
 #endif
 };

--- a/src/SourceTerm/PointSource.h
+++ b/src/SourceTerm/PointSource.h
@@ -48,6 +48,10 @@
 
 #include <array>
 
+#ifdef ACL_DEVICE
+#include <sycl/sycl.hpp>
+#endif
+
 namespace seissol {
   namespace sourceterm {
     /** The local moment tensor shall be transformed into the global coordinate system.
@@ -84,8 +88,9 @@ namespace seissol {
     PiecewiseLinearFunction1D samplesToPiecewiseLinearFunction1D(real_from const* i_samples,
                                             unsigned i_numberOfSamples,
                                             real i_onsetTime,
-                                            real i_samplingInterval) {
-      auto pwLF = PiecewiseLinearFunction1D{};
+                                            real i_samplingInterval,
+                                            AllocatorFactory const& alloc) {
+      auto pwLF = PiecewiseLinearFunction1D{alloc};
       if (i_numberOfSamples == 0) {
         return pwLF;
       }
@@ -123,6 +128,9 @@ namespace seissol {
     }
 
     /** Returns integral_fromTime^toTime i_pwLF dt. */
+#ifdef ACL_DEVICE
+    SYCL_EXTERNAL
+#endif
     real computePwLFTimeIntegral(PiecewiseLinearFunction1D const& i_pwLF,
                                  double i_fromTime,
                                  double i_toTime);

--- a/src/sources.cmake
+++ b/src/sources.cmake
@@ -53,6 +53,7 @@ src/Solver/time_stepping/TimeManager.cpp
 src/Solver/Pipeline/DrTuner.cpp
 src/Kernels/DynamicRupture.cpp
 src/Kernels/Plasticity.cpp
+src/Kernels/PointSourceClusterOnHost.cpp
 src/Kernels/TimeCommon.cpp
 src/Kernels/Receiver.cpp
 src/SeisSol.cpp

--- a/src/sources.cmake
+++ b/src/sources.cmake
@@ -53,13 +53,9 @@ src/Solver/time_stepping/TimeManager.cpp
 src/Solver/Pipeline/DrTuner.cpp
 src/Kernels/DynamicRupture.cpp
 src/Kernels/Plasticity.cpp
-src/Kernels/PointSourceClusterOnHost.cpp
 src/Kernels/TimeCommon.cpp
 src/Kernels/Receiver.cpp
 src/SeisSol.cpp
-src/SourceTerm/Manager.cpp
-src/SourceTerm/FSRMReader.cpp
-src/SourceTerm/PointSource.cpp
 src/Parallel/Pin.cpp
 src/Parallel/mpiC.cpp
 src/Parallel/FaultMPI.cpp
@@ -118,11 +114,16 @@ set(SYCL_DEPENDENT_SRC_FILES
   ${CMAKE_CURRENT_SOURCE_DIR}/src/DynamicRupture/Output/ReceiverBasedOutput.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/src/DynamicRupture/Output/FaultRefiner/FaultRefiners.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/src/DynamicRupture/Output/OutputAux.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/src/DynamicRupture/Output/Builders/ReceiverBasedOutputBuilder.cpp)
+  ${CMAKE_CURRENT_SOURCE_DIR}/src/DynamicRupture/Output/Builders/ReceiverBasedOutputBuilder.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/src/Kernels/PointSourceClusterOnHost.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/src/SourceTerm/FSRMReader.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/src/SourceTerm/Manager.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/src/SourceTerm/PointSource.cpp)
 
 set(SYCL_ONLY_SRC_FILES
   ${CMAKE_CURRENT_SOURCE_DIR}/src/Parallel/AcceleratorDevice.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/src/DynamicRupture/FrictionLaws/GpuImpl/FrictionSolverDetails.cpp)
+  ${CMAKE_CURRENT_SOURCE_DIR}/src/DynamicRupture/FrictionLaws/GpuImpl/FrictionSolverDetails.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/src/Kernels/PointSourceClusterOnDevice.cpp)
 
 target_compile_options(SeisSol-common-properties INTERFACE ${EXTRA_CXX_FLAGS})
 target_include_directories(SeisSol-common-properties INTERFACE ${CMAKE_CURRENT_BINARY_DIR}/src/generated_code)
@@ -154,8 +155,8 @@ endif()
 
 
 if (NETCDF)
+  list(APPEND SYCL_DEPENDENT_SRC_FILES ${CMAKE_CURRENT_SOURCE_DIR}/src/SourceTerm/NRFReader.cpp)
   target_sources(SeisSol-lib PRIVATE
-    ${CMAKE_CURRENT_SOURCE_DIR}/src/SourceTerm/NRFReader.cpp # if netCDF
     ${CMAKE_CURRENT_SOURCE_DIR}/src/Geometry/NetcdfReader.cpp
     )
 endif()


### PR DESCRIPTION
This PR makes the following contributions:

* Refactor PointSources struct to work with std::vector only instead of raw pointers (relying on C++17 for correct memory alignment)
* If ACL_DEVICE is defined, PiecewiseLinearFunction1D and PointSources use sycl::usm_allocator instead of std::allocator for allocating shared memory.
* Point source data now belongs to TimeCluster instead to sourceterm::Manager
* Introduce PointSourceCluster class that takes care of point source calculation (moved out of TimeCluster)
* Introduce SYCL implementation for computing point sources on the device (class PointSourceClusterOnDevice). Major benefit is that h2d and d2h transfers become unnecessary.