### PR TITLE
Adapted the device::UsmAllocator

### DIFF
--- a/src/Kernels/PointSourceClusterOnDevice.h
+++ b/src/Kernels/PointSourceClusterOnDevice.h
@@ -5,7 +5,6 @@
 #define KERNELS_POINTSOURCECLUSTERONDEVICE_H_
 
 #include "PointSourceCluster.h"
-
 #include <SourceTerm/typedefs.hpp>
 
 namespace seissol::kernels {

--- a/src/SeisSol.cpp
+++ b/src/SeisSol.cpp
@@ -189,7 +189,7 @@ void seissol::SeisSol::finalize()
 
 	const int rank = MPI::mpi.rank();
 
-	m_timeManager.freeCommunicationManager();
+	m_timeManager.freeDynamicResources();
 
 #ifdef ACL_DEVICE
 	device::DeviceInstance &device = device::DeviceInstance::getInstance();

--- a/src/Solver/time_stepping/TimeCluster.h
+++ b/src/Solver/time_stepping/TimeCluster.h
@@ -411,6 +411,7 @@ public:
    * @param sourceCluster Contains point sources for cluster
    */
   void setPointSources(std::unique_ptr<kernels::PointSourceCluster> sourceCluster);
+  void freePointSources() { m_sourceCluster.reset(nullptr); }
 
   void setReceiverCluster( kernels::ReceiverCluster* receiverCluster) {
     m_receiverCluster = receiverCluster;

--- a/src/Solver/time_stepping/TimeManager.cpp
+++ b/src/Solver/time_stepping/TimeManager.cpp
@@ -378,7 +378,10 @@ void seissol::time_stepping::TimeManager::setTv(double tv) {
   }
 }
 
-void seissol::time_stepping::TimeManager::freeCommunicationManager() {
+void seissol::time_stepping::TimeManager::freeDynamicResources() {
+  for (auto& cluster : clusters) {
+    cluster->freePointSources();
+  }
   communicationManager.reset(nullptr);
 }
 

--- a/src/Solver/time_stepping/TimeManager.h
+++ b/src/Solver/time_stepping/TimeManager.h
@@ -185,7 +185,7 @@ class seissol::time_stepping::TimeManager {
 
     void printComputationTime(const std::string& outputPrefix, bool isLoopStatisticsNetcdfOutputOn);
 
-    void freeCommunicationManager();
+    void freeDynamicResources();
 };
 
 #endif

--- a/src/SourceTerm/Manager.cpp
+++ b/src/SourceTerm/Manager.cpp
@@ -91,6 +91,7 @@
 #ifdef ACL_DEVICE
 #include <Kernels/PointSourceClusterOnDevice.h>
 #include <Parallel/AcceleratorDevice.h>
+#include "Device/UsmAllocator.h"
 #endif
 
 /**
@@ -269,8 +270,8 @@ void seissol::sourceterm::Manager::loadSources(SourceType sourceType,
                                                seissol::initializers::Lut* ltsLut,
                                                time_stepping::TimeManager& timeManager) {
 #ifdef ACL_DEVICE
-  auto queue = seissol::AcceleratorDevice::getInstance().getSyclDefaultQueue();
-  auto alloc = AllocatorT(std::move(queue));
+  auto& instance = device::DeviceInstance::getInstance();
+  auto alloc = device::UsmAllocator<real>(instance);
 #else
   auto alloc = AllocatorT();
 #endif

--- a/src/SourceTerm/PointSource.h
+++ b/src/SourceTerm/PointSource.h
@@ -2,24 +2,26 @@
  * @file
  * This file is part of SeisSol.
  *
- * @author Carsten Uphoff (c.uphoff AT tum.de, http://www5.in.tum.de/wiki/index.php/Carsten_Uphoff,_M.Sc.)
- * @author Sebastian Wolf (wolf.sebastian AT tum.de, https://www5.in.tum.de/wiki/index.php/Sebastian_Wolf,_M.Sc.)
+ * @author Carsten Uphoff (c.uphoff AT tum.de,
+ *http://www5.in.tum.de/wiki/index.php/Carsten_Uphoff,_M.Sc.)
+ * @author Sebastian Wolf (wolf.sebastian AT tum.de,
+ *https://www5.in.tum.de/wiki/index.php/Sebastian_Wolf,_M.Sc.)
  *
  * @section LICENSE
  * Copyright (c) 2015 - 2020, SeisSol Group
  * Copyright (c) 2023, Intel corporation
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
- * 
+ *
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- * 
+ *
  * 3. Neither the name of the copyright holder nor the names of its
  *    contributors may be used to endorse or promote products derived from this
  *    software without specific prior written permission.
@@ -45,44 +47,35 @@
 
 #include <Initializer/typedefs.hpp>
 #include "SourceTerm/typedefs.hpp"
-
 #include <array>
 
-#ifdef ACL_DEVICE
-#include <sycl/sycl.hpp>
-#endif
-
-namespace seissol {
-  namespace sourceterm {
-    /** The local moment tensor shall be transformed into the global coordinate system.
-     * 
-     * The second order tensor (matrix) can be understood as a transform
-     * on a vector, e.g. p_L = T_L * q_L. (Let L = Local moment tensor, M = Moment tensor.)
-     * We are looking for the transformed tensor p_M = T_M * q_M, i.e.
-     * the local moment tensor rotated by strike, dip, and rake.
-     * Assume x_L = R * x_M, where R is an orthogonal matrix. Then
-     * p_M = R^T * p_L = R^T * T_L * R * q_M and hence
-     *   T_M = R^T * T_L * R.
-     * Thus, the rotation matrix R is the transformation from the global (x,y,z)
-     * coordinate system to local (fault plane) coordinate system and is obtained
-     * by the successive rotations  strike (s) -> dip (d) -> rake (l).
-     * 
-     *                   |  cos l  sin l    | | 1               |  |  cos s -sin s    |
-     * R_l * R_d * R_s = | -sin l  cos l    | |    cos d -sin d |  |  sin s  cos s    |
-     *                   |                1 | |    sin d  cos d |  |                1 |
-     *
-     **/    
-    void transformMomentTensor(real const i_localMomentTensor[3][3],
-                               real const i_localSolidVelocityComponent[3],
-                               real i_localPressureComponent,
-                               real const i_localFluidVelocityComponent[3],
-                               real strike,
-                               real dip,
-                               real rake,
-                               AlignedArray<real, PointSources::TensorSize>& o_forceComponents);
-
-
-  }
-}
+namespace seissol::sourceterm {
+/** The local moment tensor shall be transformed into the global coordinate system.
+ *
+ * The second order tensor (matrix) can be understood as a transform
+ * on a vector, e.g. p_L = T_L * q_L. (Let L = Local moment tensor, M = Moment tensor.)
+ * We are looking for the transformed tensor p_M = T_M * q_M, i.e.
+ * the local moment tensor rotated by strike, dip, and rake.
+ * Assume x_L = R * x_M, where R is an orthogonal matrix. Then
+ * p_M = R^T * p_L = R^T * T_L * R * q_M and hence
+ *   T_M = R^T * T_L * R.
+ * Thus, the rotation matrix R is the transformation from the global (x,y,z)
+ * coordinate system to local (fault plane) coordinate system and is obtained
+ * by the successive rotations  strike (s) -> dip (d) -> rake (l).
+ *
+ *                   |  cos l  sin l    | | 1               |  |  cos s -sin s    |
+ * R_l * R_d * R_s = | -sin l  cos l    | |    cos d -sin d |  |  sin s  cos s    |
+ *                   |                1 | |    sin d  cos d |  |                1 |
+ *
+ **/
+void transformMomentTensor(real const i_localMomentTensor[3][3],
+                           real const i_localSolidVelocityComponent[3],
+                           real i_localPressureComponent,
+                           real const i_localFluidVelocityComponent[3],
+                           real strike,
+                           real dip,
+                           real rake,
+                           AlignedArray<real, PointSources::TensorSize>& o_forceComponents);
+} // namespace seissol::sourceterm
 
 #endif

--- a/src/SourceTerm/typedefs.hpp
+++ b/src/SourceTerm/typedefs.hpp
@@ -52,13 +52,13 @@
 #include <cstdint>
 
 #ifdef ACL_DEVICE
-#include <sycl/sycl.hpp>
+#include "Device/UsmAllocator.h"
 #endif
 
 namespace seissol {
   namespace sourceterm {
 #ifdef ACL_DEVICE
-    using AllocatorT = sycl::usm_allocator<real, sycl::usm::alloc::shared>;
+    using AllocatorT = device::UsmAllocator<real>;
 #else
     using AllocatorT = std::allocator<real>;
 #endif


### PR DESCRIPTION
Hi Carsten (@uphoffc), Here are my changes which I would like to push to your branch `carsten/point-source-gpu`

- OpenSYCL doesn't work with `queue.parallel_for`. I switched the implementation to `submit`
- applied `clang-format` to `src/SourceTerm/PointSource.h`. Probably I need to do the same for `PointSource.cpp` and add them to the watchlist in the CI pipeline.

Issues:
- @uphoffc, I am not sure that the numerics is correct. I will do some tests. Have you tested it?
-  The destructor of `PointSourceClusterOnDevice` needs to before exiting `main` function. Probably `PointSourceClusterOnDevice` belongs to `TimeCluster` which belongs to `TimeManager` which belongs to `SeisSol` which is a static object. If it is not done then the following problem occurs

```
Thu Jun 08 17:25:45, Info:  Time wave field writer backend: 0.344369 (min: 0.344369, max: 0.344369)
Thu Jun 08 17:25:45, Info:  Time wave field writer frontend: 0.582039 (min: 0.582039, max: 0.582039)
Thu Jun 08 17:25:45, Info:  SeisSol done. Goodbye. 
[hpcsccs14:1763134] *** Process received signal ***
[hpcsccs14:1763134] Signal: Segmentation fault (11)
[hpcsccs14:1763134] Signal code: Invalid permissions (2)
[hpcsccs14:1763134] Failing at address: 0x559940e3bb20
[hpcsccs14:1763134] [ 0] /lib/x86_64-linux-gnu/libpthread.so.0(+0x153c0)[0x147a21ad63c0]
[hpcsccs14:1763134] [ 1] [0x559940e3bb20]
[hpcsccs14:1763134] *** End of error message ***
Segmentation fault (core dumped)
```

Please, have a look at `https://github.com/SeisSol/Device/pull/27` 