### PR TITLE
Fix namespace

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -48,7 +48,7 @@
 int main(int argc, char* argv[]) {
 #ifdef ACL_DEVICE
 #ifdef USE_MPI
-  MPI::mpi.bindAcceleratorDevice();
+  seissol::MPI::mpi.bindAcceleratorDevice();
 #endif // USE_MPI
   device::DeviceInstance& device = device::DeviceInstance::getInstance();
   device.api->initialize();


### PR DESCRIPTION
The line below fails to compile if the MPI implementation defines the namespace MPI. This PR fixes compilation by making the reference to the seissol namespace explicit.