### PR TITLE
Re-order tv init and time cluster creation

### DIFF
--- a/src/Initializer/InitProcedure/InitModel.cpp
+++ b/src/Initializer/InitProcedure/InitModel.cpp
@@ -250,11 +250,6 @@ void initializeCellMaterial() {
     ltsToMesh += it->getNumberOfCells();
   }
 
-  // set tv for all time clusters
-  if (seissolParams.model.plasticity) {
-    seissol::SeisSol::main.timeManager().setTv(seissolParams.model.tv);
-  }
-
   // synchronize data
   synchronize(memoryManager.getLts()->material);
   if (seissolParams.model.plasticity) {
@@ -381,6 +376,11 @@ static void initializeMemoryLayout(LtsInfo& ltsInfo) {
                                                    ltsInfo.meshStructure,
                                                    seissol::SeisSol::main.getMemoryManager(),
                                                    seissolParams.model.plasticity);
+
+  // set tv for all time clusters (this needs to be done, after the time clusters start existing)
+  if (seissolParams.model.plasticity) {
+    seissol::SeisSol::main.timeManager().setTv(seissolParams.model.tv);
+  }
 
   seissol::SeisSol::main.getMemoryManager().fixateBoundaryLtsTree();
 }


### PR DESCRIPTION
Fixes #890. I.e. make plasticity work again.

The reason was: the `tv` parameter needs to be set for all time clusters. In #829, `tv` was set before any time cluster was even created—and thus no time cluster got the `tv` value (instead, they got `tv=0`). Also, `tpv12_13` gives the expected plasticity value from before #829.