### PR TITLE
Synchronize LTSTree after Setup of the Initial Conditions

### DIFF
--- a/.ci/format.sh
+++ b/.ci/format.sh
@@ -28,6 +28,7 @@ format() {
         src/Initializer/preProcessorMacros.hpp
         src/Initializer/time_stepping/GlobalTimestep.hpp
         src/Initializer/time_stepping/GlobalTimestep.cpp
+        src/Initializer/tree/LTSSync.hpp
         src/Kernels/common.hpp
         src/Monitoring/instrumentation.hpp
         src/Geometry/MeshReader.h

--- a/src/Initializer/InitProcedure/InitModel.cpp
+++ b/src/Initializer/InitProcedure/InitModel.cpp
@@ -9,6 +9,7 @@
 #include "Physics/Attenuation.hpp"
 #include "Equations/datastructures.hpp"
 #include "Initializer/tree/Lut.hpp"
+#include "Initializer/tree/LTSSync.hpp"
 #include "Initializer/typedefs.hpp"
 
 #include "SeisSol.h"
@@ -24,66 +25,6 @@ using namespace seissol::initializer;
 
 using Material_t = seissol::model::Material_t;
 using Plasticity = seissol::model::Plasticity;
-
-/*
-Assigns the given value to the target object, initializing the memory in the process.
-
-NOTE: std::copy (or the likes) do not work here, since they do not initialize the _vptr for virtual
-function calls (rather, they leave it undefined), since they do merely assign `value` to `target`.
-*/
-
-template <typename T>
-static void initAssign(T& target, const T& value) {
-  if constexpr (std::is_trivially_copyable_v<T>) {
-    // if the object is trivially copyable, we may just memcpy it (it's safe to do that in this
-    // case).
-    std::memcpy(&target, &value, sizeof(T));
-  } else {
-    // otherwise, call the class/struct initializer.
-    // problem: we may have an array here... So we unwrap it.
-    if constexpr (std::is_array_v<T>) {
-      // unwrap array, dimension by dimension...
-      // example: T[N][M] yields SubT=T[M]
-      using SubT = std::remove_extent_t<T>;
-      auto subExtent = std::extent_v<T>;
-
-      // for now, init element-wise... (TODO(David): we could look for something faster here, in
-      // case it should ever matter)
-      for (size_t i = 0; i < subExtent; ++i) {
-        initAssign<SubT>(target[i], value[i]);
-      }
-    } else {
-      // now call new here.
-      new (&target) T(value);
-    }
-  }
-  // (these two methods cannot be combined, unless we have some way for C-style arrays, i.e. S[N]
-  // for <typename S, size_t N>, to use a copy constructor as well)
-}
-
-template <typename T>
-static void synchronize(const seissol::initializers::Variable<T>& handle) {
-  auto& memoryManager = seissol::SeisSol::main.getMemoryManager();
-  const auto& meshToLts = memoryManager.getLtsLut()->getMeshToLtsLut(handle.mask);
-  unsigned* duplicatedMeshIds = memoryManager.getLtsLut()->getDuplicatedMeshIds(handle.mask);
-  const unsigned numberOfDuplicatedMeshIds =
-      memoryManager.getLtsLut()->getNumberOfDuplicatedMeshIds(handle.mask);
-  T* var = memoryManager.getLtsTree()->var(handle);
-#ifdef _OPENMP
-#pragma omp parallel for schedule(static)
-#endif
-  for (unsigned dupMeshId = 0; dupMeshId < numberOfDuplicatedMeshIds; ++dupMeshId) {
-    const unsigned meshId = duplicatedMeshIds[dupMeshId];
-    const T* ref = &var[meshToLts[0][meshId]];
-    for (unsigned dup = 1; dup < seissol::initializers::Lut::MaxDuplicates &&
-                           meshToLts[dup][meshId] != std::numeric_limits<unsigned>::max();
-         ++dup) {
-
-      // copy data on a byte-wise level (we need to initialize memory here as well)
-      initAssign(var[meshToLts[dup][meshId]], *ref);
-    }
-  }
-}
 
 template <typename T>
 static std::vector<T> queryDB(seissol::initializers::QueryGenerator* queryGen,

--- a/src/Initializer/InitProcedure/InitModel.cpp
+++ b/src/Initializer/InitProcedure/InitModel.cpp
@@ -190,12 +190,6 @@ void initializeCellMaterial() {
     }
     ltsToMesh += it->getNumberOfCells();
   }
-
-  // synchronize data
-  synchronize(memoryManager.getLts()->material);
-  if (seissolParams.model.plasticity) {
-    synchronize(memoryManager.getLts()->plasticity);
-  }
 }
 
 struct LtsInfo {
@@ -248,12 +242,6 @@ static void initializeCellMatrices(LtsInfo& ltsInfo) {
 
   memoryManager.recordExecutionPaths(seissolParams.model.plasticity);
 #endif
-
-  // synchronize data
-  synchronize(memoryManager.getLts()->dofs);
-  if (kernels::size<tensor::Qane>() > 0) {
-    synchronize(memoryManager.getLts()->dofsAne);
-  }
 }
 
 static void initializeClusteredLts(LtsInfo& ltsInfo) {

--- a/src/Initializer/InitialFieldProjection.cpp
+++ b/src/Initializer/InitialFieldProjection.cpp
@@ -40,6 +40,8 @@
 
 #include "InitialFieldProjection.h"
 
+#include "Initializer/tree/LTSSync.hpp"
+
 #include <Numerical_aux/Quadrature.h>
 #include <Numerical_aux/BasisFunction.h>
 #include <Numerical_aux/Transformation.h>
@@ -120,4 +122,9 @@ void seissol::initializers::projectInitialField(std::vector<std::unique_ptr<phys
 #ifdef _OPENMP
   }
 #endif
+
+  seissol::initializer::synchronize(lts.dofs);
+  if (kernels::size<tensor::Qane>() > 0) {
+    seissol::initializer::synchronize(lts.dofsAne);
+  }
 }

--- a/src/Initializer/InitialFieldProjection.cpp
+++ b/src/Initializer/InitialFieldProjection.cpp
@@ -123,8 +123,8 @@ void seissol::initializers::projectInitialField(std::vector<std::unique_ptr<phys
   }
 #endif
 
-  seissol::initializer::synchronize(lts.dofs);
+  seissol::initializer::synchronizeLTSTreeDuplicates(lts.dofs);
   if (kernels::size<tensor::Qane>() > 0) {
-    seissol::initializer::synchronize(lts.dofsAne);
+    seissol::initializer::synchronizeLTSTreeDuplicates(lts.dofsAne);
   }
 }

--- a/src/Initializer/tree/LTSSync.hpp
+++ b/src/Initializer/tree/LTSSync.hpp
@@ -1,0 +1,77 @@
+#ifndef INITIALIZER_TREE_LTSSYNC
+#define INITIALIZER_TREE_LTSSYNC
+
+#include <cstddef>
+#include <cstring>
+#include <type_traits>
+
+#include "SeisSol.h"
+#include "Initializer/MemoryManager.h"
+#include "LTSTree.hpp"
+#include "Lut.hpp"
+
+namespace seissol::initializer {
+
+/*
+Assigns the given value to the target object, initializing the memory in the process.
+
+NOTE: std::copy (or the likes) do not work here, since they do not initialize the _vptr for virtual
+function calls (rather, they leave it undefined), since they do merely assign `value` to `target`.
+*/
+
+template <typename T>
+static void initAssign(T& target, const T& value) {
+  if constexpr (std::is_trivially_copyable_v<T>) {
+    // if the object is trivially copyable, we may just memcpy it (it's safe to do that in this
+    // case).
+    std::memcpy(&target, &value, sizeof(T));
+  } else {
+    // otherwise, call the class/struct initializer.
+    // problem: we may have an array here... So we unwrap it.
+    if constexpr (std::is_array_v<T>) {
+      // unwrap array, dimension by dimension...
+      // example: T[N][M] yields SubT=T[M]
+      using SubT = std::remove_extent_t<T>;
+      auto subExtent = std::extent_v<T>;
+
+      // for now, init element-wise... (TODO(David): we could look for something faster here, in
+      // case it should ever matter)
+      for (size_t i = 0; i < subExtent; ++i) {
+        initAssign<SubT>(target[i], value[i]);
+      }
+    } else {
+      // now call new here.
+      new (&target) T(value);
+    }
+  }
+  // (these two methods cannot be combined, unless we have some way for C-style arrays, i.e. S[N]
+  // for <typename S, size_t N>, to use a copy constructor as well)
+}
+
+template <typename T>
+static void synchronize(const seissol::initializers::Variable<T>& handle) {
+  auto& memoryManager = seissol::SeisSol::main.getMemoryManager();
+  const auto& meshToLts = memoryManager.getLtsLut()->getMeshToLtsLut(handle.mask);
+  unsigned* duplicatedMeshIds = memoryManager.getLtsLut()->getDuplicatedMeshIds(handle.mask);
+  const unsigned numberOfDuplicatedMeshIds =
+      memoryManager.getLtsLut()->getNumberOfDuplicatedMeshIds(handle.mask);
+  T* var = memoryManager.getLtsTree()->var(handle);
+#ifdef _OPENMP
+#pragma omp parallel for schedule(static)
+#endif
+  for (unsigned dupMeshId = 0; dupMeshId < numberOfDuplicatedMeshIds; ++dupMeshId) {
+    const unsigned meshId = duplicatedMeshIds[dupMeshId];
+    const T* ref = &var[meshToLts[0][meshId]];
+    for (unsigned dup = 1; dup < seissol::initializers::Lut::MaxDuplicates &&
+                           meshToLts[dup][meshId] != std::numeric_limits<unsigned>::max();
+         ++dup) {
+
+      // copy data on a byte-wise level (we need to initialize memory here as well)
+      initAssign(var[meshToLts[dup][meshId]], *ref);
+    }
+  }
+}
+
+} // namespace seissol::initializer
+
+#endif


### PR DESCRIPTION
Fixes another bug caused by the initialization re-ordering by #829: the initial conditions were behaving a bit off. To be exact, duplicates in the LTS tree were not initialized for initial conditions, since an Lut lookup was used for that (and to my knowledge, it's the last place where that was the case). Now, we just synchronize the LTSTree after initializing the data. (if someone wants to, we could transform it into a loop over the LTSTree eventually)