### PR TITLE
Make the Output/FaultOutput Flag Work

### DIFF
--- a/src/Initializer/InitProcedure/InitIO.cpp
+++ b/src/Initializer/InitProcedure/InitIO.cpp
@@ -157,7 +157,9 @@ static void enableCheckpointing() {
 }
 
 static void initFaultOutputManager() {
-  seissol::SeisSol::main.getMemoryManager().initFaultOutputManager();
+  const auto& seissolParams = seissol::SeisSol::main.getSeisSolParameters();
+  seissol::SeisSol::main.getMemoryManager().initFaultOutputManager(
+      seissolParams.output.faultOutput);
 
   auto* faultOutputManager = seissol::SeisSol::main.getMemoryManager().getFaultOutputManager();
   seissol::SeisSol::main.timeManager().setFaultOutputManager(faultOutputManager);

--- a/src/Initializer/MemoryManager.cpp
+++ b/src/Initializer/MemoryManager.cpp
@@ -841,9 +841,9 @@ void seissol::initializers::MemoryManager::initializeFrictionLaw() {
   m_faultOutputManager = std::move(product.output);
 }
 
-void seissol::initializers::MemoryManager::initFaultOutputManager() {
+void seissol::initializers::MemoryManager::initFaultOutputManager(bool enable) {
   // TODO: switch m_dynRup to shared or weak pointer
-  if (m_dynRupParameters->isDynamicRuptureEnabled) {
+  if (m_dynRupParameters->isDynamicRuptureEnabled && enable) {
     m_faultOutputManager->setInputParam(*m_inputParams, seissol::SeisSol::main.meshReader());
     m_faultOutputManager->setLtsData(&m_ltsTree,
                                      &m_lts,

--- a/src/Initializer/MemoryManager.h
+++ b/src/Initializer/MemoryManager.h
@@ -404,7 +404,7 @@ class seissol::initializers::MemoryManager {
 #endif
 
   void initializeFrictionLaw();
-  void initFaultOutputManager();
+  void initFaultOutputManager(bool enable);
   void initFrictionData();
 };
 

--- a/src/tests/Solver/time_stepping/AbstractTimeCluster.t.h
+++ b/src/tests/Solver/time_stepping/AbstractTimeCluster.t.h
@@ -48,7 +48,6 @@ TEST_CASE("GTS Timesteping works") {
   const double dt = 1.0;
   const auto numberOfIterations = 10;
   const double endTime = dt * numberOfIterations;
-  const double tolerance = 1e-15;
   auto cluster1 = MockTimeCluster(dt, 1);
   auto cluster2 = MockTimeCluster(dt, 1);
   auto clusters = std::vector<MockTimeCluster*>{
@@ -115,7 +114,6 @@ TEST_CASE("LTS Timesteping works") {
   const double dt = 1.0;
   const auto numberOfIterations = 2;
   const double endTime = dt * numberOfIterations;
-  const double tolerance = 1e-15;
   auto cluster1 = MockTimeCluster(dt, 1);
   auto cluster2 = MockTimeCluster(2*dt, 2);
   auto clusters = std::vector<MockTimeCluster*>{


### PR DESCRIPTION
The output section by now had a `faultoutput` field which did not do anything so far.

Now it enables/disables the fault outputs, as if a dynamic rupture didn't exist. However: we'll have a duplicate with `outputpointtype` in the dynamic rupture part as well (i.e. if we say `outputpointtype = 0`, we also disable DR output).

So instead, we could also just remove the `faultoutput` flag.