### PR TITLE
Fix BoundingBox parameter parsing (and other arrays)

### DIFF
--- a/src/Initializer/InputParameters.cpp
+++ b/src/Initializer/InputParameters.cpp
@@ -215,9 +215,6 @@ static void readMesh(ParameterReader& baseReader, SeisSolParameters& seissolPara
   seissolParams.timeStepping.vertexWeight.weightFreeSurfaceWithGravity =
       reader.readWithDefault("vertexweightfreesurfacewithgravity", 100);
 
-  auto showEdgeCut = reader.readWithDefault("showedgecutstatistics", false);
-  seissolParams.mesh.showEdgeCutStatistics = showEdgeCut;
-
   reader.warnDeprecated({"periodic", "periodic_direction"});
   reader.warnUnknown();
 }
@@ -275,11 +272,18 @@ static void readInitialization(ParameterReader& baseReader, SeisSolParameters& s
           {"ocean_0", InitializationType::Ocean0},
           {"ocean_1", InitializationType::Ocean1},
           {"ocean_2", InitializationType::Ocean2},
+          {"pressureinjection", InitializationType::PressureInjection},
       });
-  seissolParams.initialization.origin = reader.readWithDefault("origin", std::array<double, 3>{0});
-  seissolParams.initialization.kVec = reader.readWithDefault("kvec", std::array<double, 3>{0});
+  const auto originString = reader.readWithDefault("origin", std::string("0.0 0.0 0.0"));
+  seissolParams.initialization.origin = initializers::convertStringToArray<double, 3>(originString);
+  const auto kVecString = reader.readWithDefault("kvec", std::string("0.0 0.0 0.0"));
+  seissolParams.initialization.kVec = initializers::convertStringToArray<double, 3>(kVecString);
+  const auto ampFieldString = reader.readWithDefault("ampfield", std::string(""));
   seissolParams.initialization.ampField =
-      reader.readWithDefault("ampfield", std::array<double, NUMBER_OF_QUANTITIES>{0});
+      initializers::convertStringToArray<double, NUMBER_OF_QUANTITIES>(ampFieldString);
+  seissolParams.initialization.magnitude = reader.readWithDefault("magnitude", 0.0);
+  seissolParams.initialization.width =
+      reader.readWithDefault("width", std::numeric_limits<double>::infinity());
 
   reader.warnUnknown();
 }

--- a/src/Initializer/InputParameters.cpp
+++ b/src/Initializer/InputParameters.cpp
@@ -201,11 +201,14 @@ static void readMesh(ParameterReader& baseReader, SeisSolParameters& seissolPara
       {{"netcdf", seissol::geometry::MeshFormat::Netcdf},
        {"puml", seissol::geometry::MeshFormat::PUML}});
 
-  seissolParams.mesh.displacement =
-      reader.readWithDefault("displacement", std::array<double, 3>{0, 0, 0});
-  auto scalingX = reader.readWithDefault("scalingmatrixx", std::array<double, 3>{1, 0, 0});
-  auto scalingY = reader.readWithDefault("scalingmatrixy", std::array<double, 3>{0, 1, 0});
-  auto scalingZ = reader.readWithDefault("scalingmatrixz", std::array<double, 3>{0, 0, 1});
+  seissolParams.mesh.displacement = seissol::initializers::convertStringToArray<double, 3>(
+      reader.readWithDefault("displacement", std::string("0.0 0.0 0.0")));
+  auto scalingX = seissol::initializers::convertStringToArray<double, 3>(
+      reader.readWithDefault("scalingmatrixx", std::string("1.0 0.0 0.0")));
+  auto scalingY = seissol::initializers::convertStringToArray<double, 3>(
+      reader.readWithDefault("scalingmatrixy", std::string("0.0 1.0 0.0")));
+  auto scalingZ = seissol::initializers::convertStringToArray<double, 3>(
+      reader.readWithDefault("scalingmatrixz", std::string("0.0 0.0 1.0")));
   seissolParams.mesh.scaling = {scalingX, scalingY, scalingZ};
 
   seissolParams.timeStepping.vertexWeight.weightElement =
@@ -214,6 +217,8 @@ static void readMesh(ParameterReader& baseReader, SeisSolParameters& seissolPara
       reader.readWithDefault("vertexweightdynamicrupture", 100);
   seissolParams.timeStepping.vertexWeight.weightFreeSurfaceWithGravity =
       reader.readWithDefault("vertexweightfreesurfacewithgravity", 100);
+
+  seissolParams.mesh.showEdgeCutStatistics = reader.readWithDefault("showedgecutstatistics", false);
 
   reader.warnDeprecated({"periodic", "periodic_direction"});
   reader.warnUnknown();
@@ -275,12 +280,14 @@ static void readInitialization(ParameterReader& baseReader, SeisSolParameters& s
           {"pressureinjection", InitializationType::PressureInjection},
       });
   const auto originString = reader.readWithDefault("origin", std::string("0.0 0.0 0.0"));
-  seissolParams.initialization.origin = initializers::convertStringToArray<double, 3>(originString);
+  seissolParams.initialization.origin =
+      seissol::initializers::convertStringToArray<double, 3>(originString);
   const auto kVecString = reader.readWithDefault("kvec", std::string("0.0 0.0 0.0"));
-  seissolParams.initialization.kVec = initializers::convertStringToArray<double, 3>(kVecString);
+  seissolParams.initialization.kVec =
+      seissol::initializers::convertStringToArray<double, 3>(kVecString);
   const auto ampFieldString = reader.readWithDefault("ampfield", std::string(""));
   seissolParams.initialization.ampField =
-      initializers::convertStringToArray<double, NUMBER_OF_QUANTITIES>(ampFieldString);
+      seissol::initializers::convertStringToArray<double, NUMBER_OF_QUANTITIES>(ampFieldString);
   seissolParams.initialization.magnitude = reader.readWithDefault("magnitude", 0.0);
   seissolParams.initialization.width =
       reader.readWithDefault("width", std::numeric_limits<double>::infinity());
@@ -356,7 +363,8 @@ static void readOutput(ParameterReader& baseReader, SeisSolParameters& seissolPa
   // (these variables are usually not prefixed with "wavefield" or the likes)
 
   // bounds
-  auto bounds = reader.readWithDefault("outputregionbounds", std::array<double, 6>{0});
+  auto bounds = seissol::initializers::convertStringToArray<double, 6>(
+      reader.readWithDefault("outputregionbounds", std::string("0.0 0.0 0.0 0.0 0.0 0.0")));
   seissolParams.output.waveFieldParameters.bounds.boundsX.lower = bounds[0];
   seissolParams.output.waveFieldParameters.bounds.boundsX.upper = bounds[1];
   seissolParams.output.waveFieldParameters.bounds.boundsY.lower = bounds[2];

--- a/src/Initializer/InputParameters.hpp
+++ b/src/Initializer/InputParameters.hpp
@@ -10,7 +10,7 @@
 #include <xdmfwriter/XdmfWriter.h>
 
 #include "Geometry/MeshReader.h"
-#include "SourceTerm/Manager.h"
+#include "SourceTerm/typedefs.hpp"
 #include "Checkpoint/Backend.h"
 #include "time_stepping/LtsWeights/WeightsFactory.h"
 
@@ -71,7 +71,8 @@ enum class InitializationType : int {
   Snell,
   Ocean0,
   Ocean1,
-  Ocean2
+  Ocean2,
+  PressureInjection
 };
 
 struct InitializationParameters {
@@ -79,6 +80,8 @@ struct InitializationParameters {
   std::array<double, 3> origin;
   std::array<double, 3> kVec;
   std::array<double, NUMBER_OF_QUANTITIES> ampField;
+  double magnitude;
+  double width;
 };
 
 struct DynamicRuptureParameters {
@@ -102,7 +105,6 @@ struct MeshParameters {
   seissol::geometry::MeshFormat meshFormat;
   std::array<double, 3> displacement;
   std::array<std::array<double, 3>, 3> scaling;
-  bool showEdgeCutStatistics;
 };
 
 struct OutputInterval {

--- a/src/Initializer/InputParameters.hpp
+++ b/src/Initializer/InputParameters.hpp
@@ -105,6 +105,7 @@ struct MeshParameters {
   seissol::geometry::MeshFormat meshFormat;
   std::array<double, 3> displacement;
   std::array<std::array<double, 3>, 3> scaling;
+  bool showEdgeCutStatistics;
 };
 
 struct OutputInterval {

--- a/src/SourceTerm/Manager.h
+++ b/src/SourceTerm/Manager.h
@@ -55,7 +55,6 @@
 #include <vector>
 
 namespace seissol::sourceterm {
-enum class SourceType : int { None = 0, NrfSource = 42, FsrmSource = 50 };
 
 void computeMInvJInvPhisAtSources(
     Eigen::Vector3d const& centre,

--- a/src/SourceTerm/typedefs.hpp
+++ b/src/SourceTerm/typedefs.hpp
@@ -57,6 +57,7 @@
 #endif
 
 namespace seissol::sourceterm {
+enum class SourceType : int { None = 0, NrfSource = 42, FsrmSource = 50 };
 #ifdef ACL_DEVICE
 using AllocatorT = device::UsmAllocator<real>;
 #else


### PR DESCRIPTION
Thanks to @sebwolf-de , there's now a method to parse strings to arrays.

I've extracted the respective changes from the dr/poro branch (cf. https://github.com/SeisSol/SeisSol/pull/895 ) and extended them to cover all array parameters.