### PR TITLE
Optionally Serialize Device Initialization

### DIFF
--- a/src/Initializer/MemoryManager.cpp
+++ b/src/Initializer/MemoryManager.cpp
@@ -100,6 +100,7 @@ void seissol::initializers::MemoryManager::initialize()
       serialize = strcmp(value, "1") == 0;
     }
     if (serialize) {
+      logInfo(MPI::mpi.rank()) << "Serializing device global data initialization.";
       MPI::mpi.serializeOperation([&]() {
         GlobalDataInitializerOnDevice::init(m_globalDataOnDevice, m_memoryAllocator, memory::DeviceGlobalMemory);
       }, MPI::mpi.sharedMemComm());


### PR DESCRIPTION
This PR serializes Device initialization on a node. (the patch was originally by Ravil, I merely made the serialization operation a bit more general and placed it into `Parallel/MPI.h`)

Needed for some AMD GPU drivers.