### PR TITLE
Remove `FaultOutputFlag` and `BC_dr` Input Parameters

### DIFF
--- a/Documentation/parameters.par
+++ b/Documentation/parameters.par
@@ -29,10 +29,6 @@ kVec = 6.283 0 0             ! Gives direction of wave propagation, the waveleng
 ampField = 2 0 0 0 0 0 0 1 0 ! Amplification of the different wave modes
 /
 
-&Boundaries
-BC_dr = 1                               ! enable fault boundaries
-/
-
 &DynamicRupture
 FL = 16                      ! Friction law  
 !0: none, 16:LSW, 103: RS with strong velocity weakening

--- a/Documentation/parameters.par
+++ b/Documentation/parameters.par
@@ -105,7 +105,6 @@ LtsAutoMergeCostBaseline = 'bestWiggleFactor' ! Baseline used for auto merging c
 /
 
 &Output
-FaultOutputFlag = 1                  ! DR output (add this line only if DR is active)
 OutputFile = '../output_tpv33/tpv33'
 Format = 10                          ! Format (10= no output, 6=hdf5 output)
 WavefieldOutput = 1                  ! disable/enable wavefield output (right now, format=6 needs to be set as well)

--- a/src/Initializer/InitProcedure/Init.cpp
+++ b/src/Initializer/InitProcedure/Init.cpp
@@ -9,6 +9,8 @@
 #include <Numerical_aux/Statistics.h>
 #include <sstream>
 
+namespace {
+
 static void reportDeviceMemoryStatus() {
 #ifdef ACL_DEVICE
   device::DeviceInstance& device = device::DeviceInstance::getInstance();
@@ -68,6 +70,8 @@ static void closeSeisSol() {
   // deallocate memory manager
   seissol::SeisSol::main.deleteMemoryManager();
 }
+
+} // namespace
 
 void seissol::initializer::initprocedure::seissolMain() {
   initSeisSol();

--- a/src/Initializer/InitProcedure/InitIO.cpp
+++ b/src/Initializer/InitProcedure/InitIO.cpp
@@ -8,6 +8,8 @@
 
 #include "Parallel/MPI.h"
 
+namespace {
+
 static void setupCheckpointing() {
   const auto& seissolParams = seissol::SeisSol::main.getSeisSolParameters();
   auto& memoryManager = seissol::SeisSol::main.getMemoryManager();
@@ -195,6 +197,8 @@ static void setIntegralMask() {
   seissol::SeisSol::main.postProcessor().setIntegrationMask(
       seissolParams.output.waveFieldParameters.integrationMask);
 }
+
+} // namespace
 
 void seissol::initializer::initprocedure::initIO() {
   logInfo(seissol::MPI::mpi.rank()) << "Begin init output.";

--- a/src/Initializer/InitProcedure/InitModel.cpp
+++ b/src/Initializer/InitProcedure/InitModel.cpp
@@ -23,6 +23,8 @@
 
 using namespace seissol::initializer;
 
+namespace {
+
 using Material_t = seissol::model::Material_t;
 using Plasticity = seissol::model::Plasticity;
 
@@ -313,6 +315,8 @@ static void initializeMemoryLayout(LtsInfo& ltsInfo) {
 
   seissol::SeisSol::main.getMemoryManager().fixateBoundaryLtsTree();
 }
+
+} // namespace
 
 void seissol::initializer::initprocedure::initModel() {
   SCOREP_USER_REGION("init_model", SCOREP_USER_REGION_TYPE_FUNCTION);

--- a/src/Initializer/InitProcedure/InitSideConditions.cpp
+++ b/src/Initializer/InitProcedure/InitSideConditions.cpp
@@ -8,6 +8,8 @@
 
 #include "Parallel/MPI.h"
 
+namespace {
+
 static TravellingWaveParameters getTravellingWaveInformation() {
   const auto& initConditionParams = seissol::SeisSol::main.getSeisSolParameters().initialization;
 
@@ -140,6 +142,8 @@ static void initBoundary() {
         seissolParams.model.boundaryFileName.c_str());
   }
 }
+
+} // namespace
 
 void seissol::initializer::initprocedure::initSideConditions() {
   logInfo(seissol::MPI::mpi.rank()) << "Setting initial conditions.";

--- a/src/Initializer/InputParameters.cpp
+++ b/src/Initializer/InputParameters.cpp
@@ -18,6 +18,8 @@
 
 using namespace seissol::initializer::parameters;
 
+namespace {
+
 // converts a string to lower case, and trims it.
 static void sanitize(std::string& input) {
   utils::StringUtils::trim(input);
@@ -499,6 +501,8 @@ static void readSource(ParameterReader& baseReader, SeisSolParameters& seissolPa
   reader.warnDeprecated({"rtype", "ndirac", "npulsesource", "nricker"});
   reader.warnUnknown();
 }
+
+} // namespace
 
 void SeisSolParameters::readParameters(const YAML::Node& baseNode) {
   logInfo(seissol::MPI::mpi.rank()) << "Reading SeisSol parameter file...";

--- a/src/Initializer/InputParameters.cpp
+++ b/src/Initializer/InputParameters.cpp
@@ -467,9 +467,6 @@ static void readOutput(ParameterReader& baseReader, SeisSolParameters& seissolPa
                          "receiveroutput",
                          "receiveroutputinterval");
 
-  // output: fault
-  seissolParams.output.faultOutput = reader.readWithDefault("faultoutputflag", false);
-
   // output: loop statistics
   seissolParams.output.loopStatisticsNetcdfOutput =
       reader.readWithDefault("loopstatisticsnetcdfoutput", false);

--- a/src/Initializer/InputParameters.cpp
+++ b/src/Initializer/InputParameters.cpp
@@ -178,16 +178,6 @@ static void readModel(ParameterReader& baseReader, SeisSolParameters& seissolPar
   reader.warnUnknown();
 }
 
-static void readBoundaries(ParameterReader& baseReader, SeisSolParameters& seissolParams) {
-  auto reader = baseReader.readSubNode("boundaries");
-  seissolParams.dynamicRupture.hasFault = reader.readWithDefault("bc_dr", false);
-
-  // TODO(David): ? port DR reading here, maybe.
-
-  reader.warnDeprecated({"bc_fs", "bc_nc", "bc_if", "bc_of", "bc_pe"});
-  reader.warnUnknown();
-}
-
 static void readMesh(ParameterReader& baseReader, SeisSolParameters& seissolParams) {
   auto reader = baseReader.readSubNode("meshnml");
 
@@ -516,7 +506,6 @@ void SeisSolParameters::readParameters(const YAML::Node& baseNode) {
   ParameterReader baseReader(baseNode, false);
 
   readModel(baseReader, *this);
-  readBoundaries(baseReader, *this);
   readMesh(baseReader, *this);
   readTimeStepping(baseReader, *this);
   readInitialization(baseReader, *this);
@@ -529,7 +518,8 @@ void SeisSolParameters::readParameters(const YAML::Node& baseNode) {
   baseReader.markUnused("elementwise");
   baseReader.markUnused("pickpoint");
 
-  baseReader.warnDeprecated({"rffile",
+  baseReader.warnDeprecated({"boundaries",
+                             "rffile",
                              "inflowbound",
                              "inflowboundpwfile",
                              "inflowbounduin",

--- a/src/Initializer/InputParameters.cpp
+++ b/src/Initializer/InputParameters.cpp
@@ -468,7 +468,8 @@ static void readOutput(ParameterReader& baseReader, SeisSolParameters& seissolPa
                          "nrecordpoints",
                          "printintervalcriterion",
                          "pickdttype",
-                         "ioutputmaskmaterial"});
+                         "ioutputmaskmaterial",
+                         "faultoutputflag"});
   reader.warnUnknown();
 }
 

--- a/src/Initializer/InputParameters.hpp
+++ b/src/Initializer/InputParameters.hpp
@@ -85,11 +85,6 @@ struct InitializationParameters {
   double width;
 };
 
-struct DynamicRuptureParameters {
-  bool hasFault;
-  // TODO(David): port rest of the DR parameters here?
-};
-
 enum class OutputFormat : int { None = 10, Xdmf = 6 };
 
 enum class OutputRefinement : int { NoRefine = 0, Refine4 = 1, Refine8 = 2, Refine32 = 3 };
@@ -203,7 +198,6 @@ struct EndParameters {
 
 struct SeisSolParameters {
   ModelParameters model;
-  DynamicRuptureParameters dynamicRupture;
   MeshParameters mesh;
   InitializationParameters initialization;
   OutputParameters output;

--- a/src/Initializer/InputParameters.hpp
+++ b/src/Initializer/InputParameters.hpp
@@ -177,7 +177,6 @@ struct OutputParameters {
   ReceiverOutputParameters receiverParameters;
   FreeSurfaceOutputParameters freeSurfaceParameters;
   EnergyOutputParameters energyParameters;
-  bool faultOutput;
   bool loopStatisticsNetcdfOutput;
 };
 


### PR DESCRIPTION
The `FaultOutputFlag` had not effect anymore, so it could be safely removed.
Also, `BC_dr` did not work anymore, so it is now gone as well (we now always scan the mesh for any existing faults). With that, the `Boundaries` section has become obsolete.
Furthermore, some files get some anonymous namespaces around their static methods.