### PR TITLE
Update Gitlab pipelines

### DIFF
--- a/gitlab-cpu-pipeline.yml
+++ b/gitlab-cpu-pipeline.yml
@@ -1,6 +1,7 @@
 default:
     tags:
-        - lrzcc-k8s-4cores-10gb 
+        - sccs
+        - helper
     image:
         name: $CI_REGISTRY_USER/$cpu_image_name:$cpu_image_version
         entrypoint: [""]
@@ -33,6 +34,9 @@ fetch_submodules:
         
 build_seissol:
     stage: build
+    tags:
+        - sccs
+        - build
     needs:
         - job: fetch_submodules
     parallel:
@@ -79,6 +83,9 @@ build_seissol:
 run_unit_tests:
     stage: test
     allow_failure: true
+    tags:
+        - sccs
+        - cpu-hsw
     needs:
         - job: build_seissol
     parallel:
@@ -99,6 +106,9 @@ run_unit_tests:
 run_tpv:
     stage: test
     allow_failure: false
+    tags:
+        - sccs
+        - cpu-hsw
     needs:
         - job: build_seissol
     parallel:

--- a/gitlab-gpu-pipeline.yml
+++ b/gitlab-gpu-pipeline.yml
@@ -1,12 +1,13 @@
 default:
     tags:
-        - tum05-k8s-4cores-16gb
+        - sccs
+        - helper
     image:
         name: $CI_REGISTRY_USER/$gpu_image_name:$gpu_image_version
         entrypoint: [""]
 
 variables:
-    HOST: "snb"
+    HOST: "wsm"
     GPU_VENDOR: "nvidia"
     GPU_MODEL: "sm_60"
 
@@ -22,7 +23,9 @@ gpu_pre_build:
     allow_failure: false
     variables:
         GIT_STRATEGY: clone
-
+    tags:
+        - sccs
+        - build
     before_script:
         - git branch -vva
         - echo $commit_author_name
@@ -62,6 +65,9 @@ gpu_pre_build:
 gpu_build:
     stage: build
     allow_failure: false
+    tags:
+        - sccs
+        - gpubuild
     needs:
         - job: gpu_pre_build
     parallel:
@@ -100,7 +106,8 @@ gpu_convergence_test:
     needs:
         - job: gpu_build
     tags:
-        - tum05-k8s-1core-8gb-gpu
+        - sccs
+        - gpu-nvidia-sm_60
     parallel:
         matrix:
         - BACKEND: [cuda, hipsycl, hip]
@@ -135,7 +142,8 @@ gpu_run_tpv:
     needs:
         - job: gpu_build
     tags:
-        - tum05-k8s-1core-8gb-gpu
+        - sccs
+        - gpu-nvidia-sm_60
     parallel:
         matrix:
             - precision: [single]
@@ -241,7 +249,8 @@ gpu_performance_test:
         - job: gpu_run_tpv
           artifacts: false
     tags:
-        - tum05-k8s-1core-8gb-gpu
+        - sccs
+        - gpu-nvidia-sm_60
     parallel:
         matrix:
         - BACKEND: [cuda, hipsycl, hip]


### PR DESCRIPTION
Makes the Gitlab pipelines work.

Internally, we moved the CPU pipeline to the SCCS CI node now.

Also, the single stages are now using different node configurations.

But still, right now there are dependencies of the CPU version to be build with the respective CPU features (due to the doctest CMake script requiring them—I might file an issue for that; and the GPU version needs a CUDA runtime available which may become dificult, for now)