### PR TITLE
Fix typo in documentation

### DIFF
--- a/Documentation/fault-output.rst
+++ b/Documentation/fault-output.rst
@@ -106,9 +106,9 @@ The output is generated every printtimeinterval (local) time step. Using
 this output with local time-stepping may result in differently sampled
 receiver files.
 
-.. _ioutputmask-1:
+.. _outputmask-1:
 
-iOutputMask
+OutputMask
 ~~~~~~~~~~~
 
 same as for ParaView output.

--- a/Documentation/parameters.par
+++ b/Documentation/parameters.par
@@ -52,7 +52,7 @@ SlipRateOutputType=0        ! 0: (smoother) slip rate output evaluated from the 
 &Elementwise
 printIntervalCriterion = 2       ! 1=iteration, 2=time
 printtimeinterval_sec = 0.2      ! Time interval at which output will be written
-OutputMask = 1 1 1 1 1 1 1 1 1 1 1   ! turn on and off fault outputs
+OutputMask = 1 1 1 1 1 1 1 1 1 1 1 1  ! turn on and off fault outputs
 refinement_strategy = 2
 refinement = 1
 /
@@ -60,7 +60,7 @@ refinement = 1
 ! parameterize ascii fault file outputs
 &Pickpoint
 printtimeinterval = 1       ! Index of printed info at timesteps
-OutputMask = 1 1 1 0        ! turn on and off fault outputs
+OutputMask = 1 1 1 1 1 1 1 1 1 1 1 1  ! turn on and off fault outputs
 nOutpoints = 28
 PPFileName = 'tpv33_faultreceivers.dat'
 /


### PR DESCRIPTION
fix typo in fault-output.rst

fix mistake in parameters.par example