### PR TITLE
Allow retry for GPU build

### DIFF
--- a/gitlab-gpu-pipeline.yml
+++ b/gitlab-gpu-pipeline.yml
@@ -135,6 +135,7 @@ gpu_convergence_test:
     artifacts:
         paths:
             - build_*
+    retry: 2
 
 
 gpu_run_tpv:
@@ -171,6 +172,7 @@ gpu_run_tpv:
     artifacts:
         paths:
             - output-*
+    retry: 2
 
 
 check_faultoutput:

--- a/gitlab-gpu-pipeline.yml
+++ b/gitlab-gpu-pipeline.yml
@@ -98,6 +98,7 @@ gpu_build:
     artifacts:
         paths:
             - build_*
+    retry: 2
 
 
 gpu_convergence_test:


### PR DESCRIPTION
The GPU pipeline fails quite often due to these errors, e.g. https://gitlab.lrz.de/ci_seissol/SeisSol/-/jobs/6640476
![image](https://github.com/SeisSol/SeisSol/assets/24592027/62edffbe-b098-4072-a1c5-d5af854357d7)
This PR makes the pipeline more robust, as it allow retries. Maybe 3 tries would be even better.
