### PR TITLE
Add "Dynamic Rupture" to the Proxy

### DIFF
--- a/auto_tuning/proxy/src/proxy_bindings.cpp
+++ b/auto_tuning/proxy/src/proxy_bindings.cpp
@@ -13,7 +13,7 @@ PYBIND11_MODULE(seissol_proxy_bindings, module) {
       .value("localwoader", Kernel::localwoader)
       .value("neigh_dr", Kernel::neigh_dr)
       .value("godunov_dr", Kernel::godunov_dr)
-      .value("dr", Kernel::dr)
+      .value("dynrup", Kernel::dynrup)
       .export_values();
 
   py::class_<ProxyConfig>(module, "ProxyConfig")

--- a/auto_tuning/proxy/src/proxy_bindings.cpp
+++ b/auto_tuning/proxy/src/proxy_bindings.cpp
@@ -13,6 +13,7 @@ PYBIND11_MODULE(seissol_proxy_bindings, module) {
       .value("localwoader", Kernel::localwoader)
       .value("neigh_dr", Kernel::neigh_dr)
       .value("godunov_dr", Kernel::godunov_dr)
+      .value("dr", Kernel::dr)
       .export_values();
 
   py::class_<ProxyConfig>(module, "ProxyConfig")
@@ -20,6 +21,7 @@ PYBIND11_MODULE(seissol_proxy_bindings, module) {
       .def_readwrite("cells", &ProxyConfig::cells)
       .def_readwrite("timesteps", &ProxyConfig::timesteps)
       .def_readwrite("kernel", &ProxyConfig::kernel)
+      .def_readwrite("fault", &ProxyConfig::fault)
       .def_readwrite("verbose", &ProxyConfig::verbose);
 
   py::class_<ProxyOutput>(module, "ProxyOutput")

--- a/auto_tuning/proxy/src/proxy_common.hpp
+++ b/auto_tuning/proxy/src/proxy_common.hpp
@@ -13,12 +13,14 @@ enum Kernel {
   ader,
   localwoader,
   neigh_dr,
-  godunov_dr
+  godunov_dr,
+  dynrup
 };
 
 struct ProxyConfig {
   unsigned cells{static_cast<unsigned>(1e5)};
   unsigned timesteps{10};
+  unsigned fault{0};
   Kernel kernel{Kernel::all};
   bool verbose{true};
 };
@@ -99,7 +101,8 @@ protected:
       {Kernel::ader,        "ader"},
       {Kernel::localwoader, "localwoader"},
       {Kernel::neigh_dr,    "neigh_dr"},
-      {Kernel::godunov_dr,  "godunov_dr"}
+      {Kernel::godunov_dr,  "godunov_dr"},
+      {Kernel::dynrup,  "dynrup"},
   };
 
   inline static std::unordered_map<std::string, Kernel> invMap{
@@ -109,7 +112,8 @@ protected:
       {"ader", Kernel::ader},
       {"localwoader", Kernel::localwoader},
       {"neigh_dr", Kernel::neigh_dr},
-      {"godunov_dr", Kernel::godunov_dr}
+      {"godunov_dr", Kernel::godunov_dr},
+      {"dynrup", Kernel::dynrup},
   };
 };
 

--- a/auto_tuning/proxy/src/proxy_main.cpp
+++ b/auto_tuning/proxy/src/proxy_main.cpp
@@ -15,6 +15,7 @@ int main(int argc, char* argv[]) {
   args.addAdditionalOption("cells", "Number of cells");
   args.addAdditionalOption("timesteps", "Number of timesteps");
   args.addAdditionalOption("kernel", kernelHelp.str());
+  args.addAdditionalOption("fault", "Fault type (only used if kernel == \"dynrup\")", false);
 
   if (args.parse(argc, argv) != utils::Args::Success) {
     return -1;
@@ -23,6 +24,7 @@ int main(int argc, char* argv[]) {
   ProxyConfig config{};
   config.cells = args.getAdditionalArgument<unsigned>("cells");
   config.timesteps = args.getAdditionalArgument<unsigned>("timesteps");
+  config.fault = args.getAdditionalArgument<unsigned>("fault", 0);
   auto kernelStr = args.getAdditionalArgument<std::string>("kernel");
 
   try {

--- a/auto_tuning/proxy/src/proxy_seissol.cpp
+++ b/auto_tuning/proxy/src/proxy_seissol.cpp
@@ -155,11 +155,13 @@ ProxyOutput runProxy(ProxyConfig config) {
   }
 
 #ifdef ACL_DEVICE
-  deviceType &device = deviceType::getInstance();
-  device.api->setDevice(0);
+#ifdef USE_MPI
+  seissol::MPI::mpi.bindAcceleratorDevice();
+#endif // USE_MPI
+  device::DeviceInstance& device = device::DeviceInstance::getInstance();
   device.api->initialize();
   device.api->allocateStackMem();
-#endif
+#endif // ACL_DEVICE
 
   m_ltsTree = new seissol::initializers::LTSTree;
   m_dynRupTree = new seissol::initializers::LTSTree;

--- a/auto_tuning/proxy/src/proxy_seissol.cpp
+++ b/auto_tuning/proxy/src/proxy_seissol.cpp
@@ -273,6 +273,7 @@ ProxyOutput runProxy(ProxyConfig config) {
   output.hardwareGFlops = (static_cast<double>(actual_flops.d_hardwareFlops) * 1.e-9)/total;
   output.gibPerSecond = (bytes_estimate/(1024.0*1024.0*1024.0))/total;
 
+  m_frictionSolver.reset();
   delete m_ltsTree;
   delete m_dynRupTree;
   delete m_allocator;

--- a/auto_tuning/proxy/src/proxy_seissol_allocator.hpp
+++ b/auto_tuning/proxy/src/proxy_seissol_allocator.hpp
@@ -223,14 +223,14 @@ void initDataStructuresOnDevice(bool enableDynamicRupture) {
   recorder.addRecorder(new seissol::initializers::recording::PlasticityRecorder);
   recorder.record(m_lts, layer);
   if (enableDynamicRupture) {
-    seissol::initializers::MemoryManager::deriveRequiredScratchpadMemoryForDr(*m_dynRupTree, m_dynRup);
+    seissol::initializers::MemoryManager::deriveRequiredScratchpadMemoryForDr(*m_dynRupTree, *m_dynRup);
     m_dynRupTree->allocateScratchPads();
 
     CompositeRecorder <seissol::initializers::DynamicRupture> drRecorder;
     drRecorder.addRecorder(new DynamicRuptureRecorder);
 
     auto &drLayer = m_dynRupTree->child(0).child<Interior>();
-    drRecorder.record(m_dynRup, drLayer);
+    drRecorder.record(*m_dynRup, drLayer);
   }
 }
 #endif // ACL_DEVICE

--- a/auto_tuning/proxy/src/proxy_seissol_bytes.hpp
+++ b/auto_tuning/proxy/src/proxy_seissol_bytes.hpp
@@ -49,7 +49,7 @@ double bytes_all(unsigned int i_timesteps) {
   return bytes_local(i_timesteps) + bytes_neigh(i_timesteps);
 }
 
-double noestimate(unsigned) {
+double bytes_noestimate(unsigned) {
   return 0.0;
 }
 

--- a/auto_tuning/proxy/src/proxy_seissol_device_integrators.hpp
+++ b/auto_tuning/proxy/src/proxy_seissol_device_integrators.hpp
@@ -218,6 +218,15 @@ namespace proxy::device {
       device.api->syncGraph(computeGraphHandle);
     }
   }
+
+  void computeDynamicRupture() {
+    seissol::initializers::Layer& layerData = m_dynRupTree->child(0).child<Interior>();
+    m_frictionSolver->computeDeltaT(m_dynRupKernel.timePoints);
+    m_frictionSolver->evaluate(layerData,
+                           m_dynRup.get(),
+                           seissol::miniSeisSolTimeStep,
+                           m_dynRupKernel.timeWeights);
+  }
 } // namespace proxy::device
 
 

--- a/auto_tuning/proxy/src/proxy_seissol_flops.hpp
+++ b/auto_tuning/proxy/src/proxy_seissol_flops.hpp
@@ -104,7 +104,7 @@ seissol_flops flops_drgod_actual(unsigned int i_timesteps) {
   
   // iterate over cells
   seissol::initializers::Layer& interior = m_dynRupTree->child(0).child<Interior>();
-  DRFaceInformation* faceInformation = interior.var(m_dynRup.faceInformation);
+  DRFaceInformation* faceInformation = interior.var(m_dynRup->faceInformation);
   for (unsigned face = 0; face < interior.getNumberOfCells(); ++face) {
     long long l_drNonZeroFlops, l_drHardwareFlops;
     m_dynRupKernel.flopsGodunovState(faceInformation[face], l_drNonZeroFlops, l_drHardwareFlops);
@@ -148,4 +148,6 @@ seissol_flops flops_all_actual(unsigned int i_timesteps) {
   return ret;
 }
 
-
+seissol_flops flops_noestimate(unsigned) {
+  return seissol_flops{0LL, 0LL};
+}

--- a/auto_tuning/proxy/src/proxy_seissol_integrators.hpp
+++ b/auto_tuning/proxy/src/proxy_seissol_integrators.hpp
@@ -203,11 +203,11 @@ namespace proxy::cpu {
   void computeDynRupGodunovState()
   {
     seissol::initializers::Layer& layerData = m_dynRupTree->child(0).child<Interior>();
-    DRFaceInformation* faceInformation = layerData.var(m_dynRup.faceInformation);
-    DRGodunovData* godunovData = layerData.var(m_dynRup.godunovData);
-    DREnergyOutput* drEnergyOutput = layerData.var(m_dynRup.drEnergyOutput);
-    real** timeDerivativePlus = layerData.var(m_dynRup.timeDerivativePlus);
-    real** timeDerivativeMinus = layerData.var(m_dynRup.timeDerivativeMinus);
+    DRFaceInformation* faceInformation = layerData.var(m_dynRup->faceInformation);
+    DRGodunovData* godunovData = layerData.var(m_dynRup->godunovData);
+    DREnergyOutput* drEnergyOutput = layerData.var(m_dynRup->drEnergyOutput);
+    real** timeDerivativePlus = layerData.var(m_dynRup->timeDerivativePlus);
+    real** timeDerivativeMinus = layerData.var(m_dynRup->timeDerivativeMinus);
     alignas(ALIGNMENT) real QInterpolatedPlus[CONVERGENCE_ORDER][tensor::QInterpolated::size()];
     alignas(ALIGNMENT) real QInterpolatedMinus[CONVERGENCE_ORDER][tensor::QInterpolated::size()];
 
@@ -227,5 +227,14 @@ namespace proxy::cpu {
                                               timeDerivativePlus[prefetchFace],
                                               timeDerivativeMinus[prefetchFace] );
     }
+  }
+
+  void computeDynamicRupture() {
+    seissol::initializers::Layer& layerData = m_dynRupTree->child(0).child<Interior>();
+    m_frictionSolver->computeDeltaT(m_dynRupKernel.timePoints);
+    m_frictionSolver->evaluate(layerData,
+                           m_dynRup.get(),
+                           seissol::miniSeisSolTimeStep,
+                           m_dynRupKernel.timeWeights);
   }
 } // namespace proxy::cpu


### PR DESCRIPTION
As the title says, this PR adds the dynamic rupture computation to the proxy. For that, we also add a new parameter specifying the fault type. For now, no FLOP/s nor bytes numbers are reported, but merely the computational time.