### PR TITLE
Improve ASAGI cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -287,7 +287,7 @@ if (ASAGI)
   # todo warn if netcdf is off
   pkg_check_modules(ASAGI REQUIRED IMPORTED_TARGET asagi) # asagi_nompi?
   target_compile_definitions(SeisSol-common-properties INTERFACE USE_ASAGI)
-  target_link_libraries(SeisSol-common-properties INTERFACE ${ASAGI_STATIC_LDFLAGS})
+  target_link_libraries(SeisSol-common-properties INTERFACE ${ASAGI_LDFLAGS})
   target_include_directories(SeisSol-common-properties INTERFACE ${ASAGI_INCLUDE_DIRS})
   target_compile_options(SeisSol-common-properties INTERFACE ${ASAGI_CFLAGS} ${ASAGI_CFLAGS_OTHER})
 endif()


### PR DESCRIPTION
When I was building SeisSol with ASAGI, I got the following errors:
```
[100%] Linking CXX executable SeisSol_Release_dhsw_4_viscoelastic2
ld: cannot find -lpnetcdf
ld: cannot find -lhdf5_hl
ld: cannot find -lhdf5
```
This PR fixes that, as it doesn't require the static ldflags. We properly link the required hdf5/netcdf libraries elswhwere in SeisSol.