### PR TITLE
port back healing into seissol (fix #842)

### DIFF
--- a/Documentation/dynamic-rupture.rst
+++ b/Documentation/dynamic-rupture.rst
@@ -161,7 +161,7 @@ where :math:`S(t) = \int_0^t |V(s)| ds` is the accumulated fault slip, and the o
 Friction parameters:
 
 +------------------+----------------------------------------+-------------------------------+
-| symbol           | quantity                               | seisSol name                  |
+| symbol           | quantity                               | SeisSol name                  |
 +==================+========================================+===============================+
 | :math:`\mu_s(x)` | static friction coefficient            | :code:`mu_s`                  |
 +------------------+----------------------------------------+-------------------------------+
@@ -173,13 +173,17 @@ Friction parameters:
 +------------------+----------------------------------------+-------------------------------+
 | :math:`T(x)`     | forced rupture time                    | :code:`forced_rupture_time`   |
 +------------------+----------------------------------------+-------------------------------+
+| :math:`v_0`      | threshold velocity                     | :code:`lsw_healingThreshold`  |
++------------------+----------------------------------------+-------------------------------+
 
 Friction law :code:`16` implements linear slip-weakening with a forced rupture time.
 If you are only interested in linear slip weakening friction without forced rupture time, do not supply the parameter `forced_rupture_time` in the fault `yaml` file.
 Friction law :code:`6` uses Prakash-Clifton regularization for bimaterial faults.
 For friction law :code:`16`, we resample the slip rate in every step to suppress spurious oscillations.
 In the case of Prakash-Clifton regularization, we do not resample the slip rate.
-
+If the slip rate :math:`V` drops below the threshold velocity :math:`v_0`, we reset the friction parameter :math:`\mu = \mu_s`.
+Also, we reset the state variable :math:`S = 0`.
+The threshold :math:`v_0` is set to :math:`-1.0` by default, such that healing is disabled.
 
 
 Examples of input files for the friction laws :code:`6` and :code:`16` are availbable in the :ref:`cookbook<cookbook overview>`.

--- a/src/DynamicRupture/FrictionLaws/LinearSlipWeakening.h
+++ b/src/DynamicRupture/FrictionLaws/LinearSlipWeakening.h
@@ -116,6 +116,12 @@ class LinearSlipWeakeningLaw : public BaseFrictionLaw<LinearSlipWeakeningLaw<Spe
       this->mu[ltsFace][pointIndex] =
           muS[ltsFace][pointIndex] -
           (muS[ltsFace][pointIndex] - muD[ltsFace][pointIndex]) * stateVariable[pointIndex];
+      // instantaneous healing
+      if ((this->peakSlipRate[ltsFace][pointIndex] > this->drParameters->healingThreshold) &&
+          (this->slipRateMagnitude[ltsFace][pointIndex] < this->drParameters->healingThreshold)) {
+        this->mu[ltsFace][pointIndex] = muS[ltsFace][pointIndex];
+        stateVariable[pointIndex] = 0.0;
+      }
     }
   }
 

--- a/src/DynamicRupture/Parameters.h
+++ b/src/DynamicRupture/Parameters.h
@@ -27,6 +27,7 @@ struct DRParameters {
   bool isRfOutputOn{false};
   bool isDsOutputOn{false};
   bool isThermalPressureOn{false};
+  real healingThreshold{-1.0};
   real t0{0.0};
   real rsF0{0.0};
   real rsA{0.0};
@@ -73,6 +74,7 @@ inline std::unique_ptr<DRParameters> readParametersFromYaml(std::shared_ptr<YAML
     }
     drParameters->backgroundType = getWithDefault(yamlDrParams, "backgroundtype", 0);
     drParameters->isThermalPressureOn = getWithDefault(yamlDrParams, "thermalpress", false);
+    drParameters->healingThreshold = getWithDefault(yamlDrParams, "lsw_healingthreshold", -1.0);
     drParameters->t0 = getWithDefault(yamlDrParams, "t_0", 0.0);
     drParameters->rsF0 = getWithDefault(yamlDrParams, "rs_f0", 0.0);
     drParameters->rsA = getWithDefault(yamlDrParams, "rs_a", 0.0);


### PR DESCRIPTION
this PR brings back healing into LSW.
it is based on Sebastian branch (sebastian/healing), which could not be automatically merged with master.

I just added the condition
(this->peakSlipRate[ltsFace][pointIndex] > this->drParameters->healingThreshold)
see
https://github.com/SeisSol/SeisSol/issues/842#issuecomment-1748222769

I've tested it on the Turkey "simple" setup.