### PR TITLE
detail the dumping of dynamic libraries

### DIFF
--- a/Documentation/frontera.rst
+++ b/Documentation/frontera.rst
@@ -11,10 +11,9 @@ Add these lines to ``~/.bashrc``:
 
     module switch python3 python3/3.9.2
     module use /work2/09160/ulrich/frontera/spack/share/spack/modules/linux-centos7-cascadelake
-    module load seissol-env-develop-intel-19.1.1.217-x52n3zf
+    module load seissol-env
     export CC=mpiicc
     export CXX=mpiicpc
-    export FC=mpiifort
 
 This will load a preinstalled seissol-env module.
 
@@ -22,14 +21,13 @@ Alternatively (and for reference), to compile seissol-env on Frontera, follow th
 
 .. code-block:: bash
 
-    git clone --depth 1 --branch v0.18.1 https://github.com/spack/spack.git
+    git clone --depth 1 --branch v0.21.0 https://github.com/spack/spack.git
     cd spack
     echo "export SPACK_ROOT=$PWD" >> $HOME/.bashrc
     echo "export PATH=\$SPACK_ROOT/bin:\$PATH" >> $HOME/.bashrc
     # clone seissol-spack-aid and add the repository
-    git clone --branch supermuc_NG https://github.com/SeisSol/seissol-spack-aid.git
-    cd seissol-spack-aid
-    spack repo add ./spack
+    git clone https://github.com/SeisSol/seissol-spack-aid.git
+    spack repo add seissol-spack-aid/spack
     spack compiler find
 
 Following the workaround proposed in https://github.com/spack/spack/issues/10308, precise the module of the intel compilers in ``~/.spack/linux/compilers.yaml`` by changing ``modules: []`` to ``modules: ['intel/19.1.1']``.
@@ -39,10 +37,6 @@ Then, update ``~/.spack/packages.yaml`` as follow:
 .. code-block:: yaml
 
     packages:
-      autoconf:
-        externals:
-        - spec: autoconf@2.69
-          prefix: /opt/apps/autotools/1.2
       python:
         externals:
         - spec: python@3.9.2
@@ -60,19 +54,24 @@ Then, update ``~/.spack/packages.yaml`` as follow:
         providers:
           mpi: [intel-mpi]
 
-(note that the compilation was not successful with trying to add the cmake/3.24.2 module to packages.yaml).
+
+Additional already installed modules can be discovered and added with:
+
+.. code-block:: bash
+
+    spack external find
 
 Finally, install seissol-env with 
 
 .. code-block:: bash
 
-    spack install -j 16 seissol-env %intel@19.1.1.217 ^intel-mpi
+    spack install -j 16 seissol-env %intel ^intel-mpi
 
-and create a module with:
+We then create the required modules with:
 
 .. code-block:: bash
 
-    spack module tcl refresh seissol-env
+    spack module tcl refresh $(spack find -d --format "{name}{/hash:5}" seissol-env)
 
 To access the module at start up, add to your ``~/.bashrc``:
 
@@ -81,3 +80,74 @@ To access the module at start up, add to your ``~/.bashrc``:
     module use $SPACK_ROOT/share/spack/modules/linux-centos7-cascadelake/
 
 Finally, install SeisSol with cmake, as usual, with ``-DHOST_ARCH=skx``.
+
+For large runs, it is recommanded to have executable, dynamic libraries, setup and outputs on scratch.
+That is, $WORK is not built for large, intensive IOs, and loading the shared libraries from 8000+ nodes at once is quite intensive.
+This could potentially break the filesystem.
+The dynamic libraries can be copied to $SCRATCH with the following commands:
+
+.. code-block:: bash
+
+    # replace by the path to your seissol executable
+    mkdir -p $SCRATCH/libdump  && ldd SeisSol_Release_dskx_6_elastic | grep -E "/work|/scratch" | awk '{print $(NF-1)}' | xargs -I _ cp _ $SCRATCH/libdump
+
+Then you can unload the seissol-env module and add the required dynamic libraries, e.g. with:
+
+.. code-block:: bash
+
+    export LD_LIBRARY_PATH=$SCRATCH/lib_dump/:$LD_LIBRARY_PATH
+    module unload seissol-env
+
+Finally, we provide an example of launch script used for running a full-machine frontera run.
+In particular, note how timeout and retry count are increased.
+
+.. code-block:: bash
+
+    #!/bin/bash
+    #SBATCH --chdir=./
+    #SBATCH -o ./%j.out       # Name of stdout output file
+    #SBATCH -e ./%j.out       # Name of stderr error file
+    #SBATCH -p debug         # Queue (partition) name
+    #SBATCH --nodes=8192
+    #SBATCH --ntasks-per-node=2
+    #SBATCH -t 24:00:00        # Run time (hh:mm:ss)
+    #SBATCH -A EAR22007       # Project/Allocation name (req'd if you have more than 1)
+
+    # Any other commands must follow all #SBATCH directives...
+    module list
+    pwd
+    date
+
+    #Prevents errors such as experience in Issue #691
+    export I_MPI_SHM_HEAP_VSIZE=32768
+
+    export OMP_NUM_THREADS=27
+    export OMP_PLACES="cores(27)"
+    export OMP_PROC_BIND="close"
+
+    export XDMFWRITER_ALIGNMENT=8388608
+    export XDMFWRITER_BLOCK_SIZE=8388608
+    export ASYNC_MODE=THREAD
+    export ASYNC_BUFFER_ALIGNMENT=8388608
+
+    echo 'num_nodes:' $SLURM_JOB_NUM_NODES 'ntasks:' $SLURM_NTASKS
+    ulimit -Ss 2097152
+
+    source ~cazes/texascale_settings.sh
+    export UCX_TLS=knem,dc
+    export UCX_DC_MLX5_TIMEOUT=35000000.00us
+    export UCX_DC_MLX5_RNR_TIMEOUT=35000000.00us
+    export UCX_DC_MLX5_RETRY_COUNT=180
+    export UCX_DC_MLX5_RNR_RETRY_COUNT=180
+    export UCX_RC_MLX5_TIMEOUT=35000000.00us
+    export UCX_RC_MLX5_RNR_TIMEOUT=35000000.00us
+    export UCX_RC_MLX5_RETRY_COUNT=180
+    export UCX_RC_MLX5_RNR_RETRY_COUNT=180
+    export UCX_UD_MLX5_TIMEOUT=35000000.00us
+    export UCX_UD_MLX5_RETRY_COUNT=180
+
+
+    # Launch MPI code... 
+    seissol_exe=SeisSol_Release_dskx_6_viscoelastic2
+    echo $seissol_exe
+    time -p ibrun $seissol_exe parameters.par

--- a/Documentation/supermuc.rst
+++ b/Documentation/supermuc.rst
@@ -173,7 +173,7 @@ to the amount of nodes you want to run on. A rule of thumb for optimal performan
   export OMP_NUM_THREADS=94
   export OMP_PLACES="cores(47)"
   #Prevents errors such as experience in Issue #691
-  export I_MPI_SHM_HEAP_VSIZE=8192
+  export I_MPI_SHM_HEAP_VSIZE=32768
 
   export XDMFWRITER_ALIGNMENT=8388608
   export XDMFWRITER_BLOCK_SIZE=8388608


### PR DESCRIPTION
On Frontera, we are ask to copy and load the dynamic libraries to scratch, rather than loading them from work (e.g. through spack or the module command). I dug info from slack, that I propose putting it here.

Note that there might be a problem on how impalajit is linked to seissol.  Therefore the manual add.
Here is an example of outcome of the ldd command.


```
ulrich@login4:/scratch1/09160/ulrich/Turkey-Syria-Earthquakes/SeisSolSetupHeterogeneities/event2$ ldd ../../../SeisSol/build/SeisSol_Release_dskx_6_viscoelastic2
        linux-vdso.so.1 =>  (0x00007ffcdd3e3000)
        /opt/apps/xalt/xalt/lib64/libxalt_init.so (0x00002b775dbe1000)
        libasagi.so.1 => /work2/09160/ulrich/frontera/spack/opt/spack/linux-centos7-cascadelake/intel-19.1.1.217/asagi-1.0.1-orizcqekhmhoqvcvyfxaciknepzznzze/lib/libasagi.so.1 (0x00002b775de24000)
        libimpalajit.so (0x00002b775d9e2000)
        liblua.so.5.3 => /work2/09160/ulrich/frontera/spack/opt/spack/linux-centos7-cascadelake/intel-19.1.1.217/lua-5.3.2-pm3jfytdvyp6rzajtfggwzd6mdikdcy7/lib/liblua.so.5.3 (0x00002b775da11000)
        libm.so.6 => /usr/lib64/libm.so.6 (0x00002b775e485000)
        libiomp5.so => /opt/intel/compilers_and_libraries_2020.1.217/linux/compiler/lib/intel64_lin/libiomp5.so (0x00002b775e787000)
        libnuma.so.1 => /usr/lib64/libnuma.so.1 (0x00002b775eb87000)
        libnetcdf.so.18 => /work2/09160/ulrich/frontera/spack/opt/spack/linux-centos7-cascadelake/intel-19.1.1.217/netcdf-c-4.7.4-g3gvnxkfx3nuaxaqufwxf57ptesxgtqv/lib/libnetcdf.so.18 (0x00002b775ed93000)
        libhdf5_hl.so.200 => /work2/09160/ulrich/frontera/spack/opt/spack/linux-centos7-cascadelake/intel-19.1.1.217/hdf5-1.12.2-fzowvyobpiowc3f3hsidtdj3mkxpkm6x/lib/libhdf5_hl.so.200 (0x00002b775dac4000)
        libhdf5.so.200 => /work2/09160/ulrich/frontera/spack/opt/spack/linux-centos7-cascadelake/intel-19.1.1.217/hdf5-1.12.2-fzowvyobpiowc3f3hsidtdj3mkxpkm6x/lib/libhdf5.so.200 (0x00002b775eed6000)
        libdl.so.2 => /usr/lib64/libdl.so.2 (0x00002b775f463000)
        libparmetis.so => /work2/09160/ulrich/frontera/spack/opt/spack/linux-centos7-cascadelake/intel-19.1.1.217/parmetis-4.0.3-uym4pr62ytixijmgnor4khqzkoitswhd/lib/libparmetis.so (0x00002b775daf1000)
        libmetis.so => /work2/09160/ulrich/frontera/spack/opt/spack/linux-centos7-cascadelake/intel-19.1.1.217/metis-5.1.0-fpsycvb3qzvisqxaq3v74mbgrhcwhid4/lib/libmetis.so (0x00002b775f667000)
        libyaml-cpp.so.0.6 => /work2/09160/ulrich/frontera/spack/opt/spack/linux-centos7-cascadelake/intel-19.1.1.217/yaml-cpp-0.6.2-qszzfashukprv326kpoe2ivdwrfq6a5f/lib/libyaml-cpp.so.0.6 (0x00002b775db47000)
        libmpicxx.so.12 => /opt/intel/compilers_and_libraries_2020.4.304/linux/mpi/intel64/lib/libmpicxx.so.12 (0x00002b775f719000)
        libmpifort.so.12 => /opt/intel/compilers_and_libraries_2020.4.304/linux/mpi/intel64/lib/libmpifort.so.12 (0x00002b775f939000)
        libmpi.so.12 => /opt/intel/compilers_and_libraries_2020.4.304/linux/mpi/intel64/lib/release/libmpi.so.12 (0x00002b775fcf7000)
        librt.so.1 => /usr/lib64/librt.so.1 (0x00002b7761057000)
        libpthread.so.0 => /usr/lib64/libpthread.so.0 (0x00002b776125f000)
        libstdc++.so.6 => /opt/apps/gcc/8.3.0/lib64/libstdc++.so.6 (0x00002b776147b000)
        libgcc_s.so.1 => /opt/apps/gcc/8.3.0/lib64/libgcc_s.so.1 (0x00002b7761607000)
        libc.so.6 => /usr/lib64/libc.so.6 (0x00002b7761621000)
        libimf.so => /opt/intel/compilers_and_libraries_2020.1.217/linux/compiler/lib/intel64_lin/libimf.so (0x00002b77619ef000)
        libsvml.so => /opt/intel/compilers_and_libraries_2020.1.217/linux/compiler/lib/intel64_lin/libsvml.so (0x00002b77620eb000)
        libirng.so => /opt/intel/compilers_and_libraries_2020.1.217/linux/compiler/lib/intel64_lin/libirng.so (0x00002b7763b9d000)
        libintlc.so.5 => /opt/intel/compilers_and_libraries_2020.1.217/linux/compiler/lib/intel64_lin/libintlc.so.5 (0x00002b7763f07000)
        /lib64/ld-linux-x86-64.so.2 (0x00002b775d9bd000)
        libz.so.1 => /work2/09160/ulrich/frontera/spack/opt/spack/linux-centos7-cascadelake/intel-19.1.1.217/zlib-1.2.12-xg5z54ec3z2k44hveyzeu6gfx3ilwqvz/lib/libz.so.1 (0x00002b776417f000)
        libsz.so.2 => /work2/09160/ulrich/frontera/spack/opt/spack/linux-centos7-cascadelake/intel-19.1.1.217/libaec-1.0.6-r4vukqls3ohz2fujtyfn6ibhynho7fy7/lib64/libsz.so.2 (0x00002b77641a1000)
        libfabric.so.1 => /opt/intel/compilers_and_libraries_2020.4.304/linux/mpi/intel64/libfabric/lib/libfabric.so.1 (0x00002b77641b3000)
```