### PR TITLE
Only create FLOP counter file for rank==0

### DIFF
--- a/src/Monitoring/FlopCounter.cpp
+++ b/src/Monitoring/FlopCounter.cpp
@@ -56,15 +56,18 @@ namespace seissol::monitoring {
 
 void FlopCounter::init(std::string outputFileNamePrefix) {
   const std::string outputFileName = outputFileNamePrefix + "-flops.csv";
+  const int rank = seissol::MPI::mpi.rank();
   const int worldSize = seissol::MPI::mpi.size();
-  out.open(outputFileName);
-  out << "time,";
-  for (size_t i = 0; i < worldSize - 1; ++i) {
-    out << "rank_" << i << "_accumulated,";
-    out << "rank_" << i << "_current,";
+  if (rank == 0) {
+    out.open(outputFileName);
+    out << "time,";
+    for (size_t i = 0; i < worldSize - 1; ++i) {
+      out << "rank_" << i << "_accumulated,";
+      out << "rank_" << i << "_current,";
+    }
+    out << "rank_" << worldSize - 1 << "_accumulated,";
+    out << "rank_" << worldSize - 1 << "_current" << std::endl;
   }
-  out << "rank_" << worldSize - 1 << "_accumulated,";
-  out << "rank_" << worldSize - 1 << "_current" << std::endl;
 }
 
 void FlopCounter::printPerformanceUpdate(double wallTime) {


### PR DESCRIPTION
Right now, each rank tried to create the FLOP counter file (all with the same file name) and write its header, while only rank 0 would fill it with data later on. This PR fixes that by creating the file only on rank 0.