### PR TITLE
Add (shorter) CI expiration time span for artifacts

### DIFF
--- a/gitlab-cpu-pipeline.yml
+++ b/gitlab-cpu-pipeline.yml
@@ -30,6 +30,7 @@ fetch_submodules:
     artifacts:
         paths:
             - submodules
+        expire_in: 2 days
     retry: 2
         
 build_seissol:
@@ -79,6 +80,7 @@ build_seissol:
     artifacts:
         paths:
             - build_*
+        expire_in: 2 days
     retry: 2
             
 run_unit_tests:
@@ -147,6 +149,7 @@ run_tpv:
     artifacts:
         paths:
             - output-*
+        expire_in: 2 days
     retry: 2
 
 

--- a/gitlab-gpu-pipeline.yml
+++ b/gitlab-gpu-pipeline.yml
@@ -46,6 +46,7 @@ gpu_pre_build:
     artifacts:
         paths:
             - ./self_usr
+        expire_in: 2 days
 
 .common_gpu_test_script: &common_gpu_steps
     - export CTEST_OUTPUT_ON_FAILURE=1
@@ -98,6 +99,7 @@ gpu_build:
     artifacts:
         paths:
             - build_*
+        expire_in: 2 days
     retry: 2
 
 
@@ -135,6 +137,7 @@ gpu_convergence_test:
     artifacts:
         paths:
             - build_*
+        expire_in: 2 days
     retry: 2
 
 
@@ -172,6 +175,7 @@ gpu_run_tpv:
     artifacts:
         paths:
             - output-*
+        expire_in: 2 days
     retry: 2
 
 


### PR DESCRIPTION
Default time span is 30 days; seemingly accumulating too much memory in total.

Thus, we now set the duration of all artifacts to 2 days.
