### PR TITLE
Propagate Libxsmm and PSpaMM path from CMake to the generator scripts / Yateto

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,8 +126,8 @@ add_custom_command(
      "--PlasticityMethod" ${PLASTICITY_METHOD}
      "--gemm_tools" ${GEMM_TOOLS_LIST}
      "--drQuadRule" ${DR_QUAD_RULE}
-     "--executable_libxsmm" ${Libxsmm_executable_PROGRAM}
-     "--executable_pspamm" ${PSpaMM_PROGRAM}
+     "--executable_libxsmm=${Libxsmm_executable_PROGRAM}"
+     "--executable_pspamm=${PSpaMM_PROGRAM}"
      ${PREMULTIPLY_FLUX_VALUE} # boolean flag
      WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/generated_code
      DEPENDS

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,6 +126,8 @@ add_custom_command(
      "--PlasticityMethod" ${PLASTICITY_METHOD}
      "--gemm_tools" ${GEMM_TOOLS_LIST}
      "--drQuadRule" ${DR_QUAD_RULE}
+     "--executable_libxsmm" ${Libxsmm_executable_PROGRAM}
+     "--executable_pspamm" ${PSpaMM_PROGRAM}
      ${PREMULTIPLY_FLUX_VALUE} # boolean flag
      WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/generated_code
      DEPENDS

--- a/Documentation/installing-dependencies.rst
+++ b/Documentation/installing-dependencies.rst
@@ -148,20 +148,11 @@ Installing Libxsmm
 Installing PSpaMM
 ~~~~~~~~~~~~~~~~~
 
-
-
-.. code-block:: bash
-
-   git clone https://github.com/SeisSol/PSpaMM.git
-   # make sure $HOME/bin exists or create it with "mkdir ~/bin"
-   ln -s $(pwd)/PSpaMM/pspamm.py $HOME/bin/pspamm.py
-   
-Instead of linking, you could also add the following line to your .bashrc:
+You may install PSpaMM as a Python package.
 
 .. code-block:: bash
 
-   export PATH=<Your_Path_to_PSpaMM>:$PATH
-
+   pip3 install --user git+https://github.com/SeisSol/PSpaMM.git
 
 .. _installing_parmetis:
 

--- a/cmake/FindPSpaMM.cmake
+++ b/cmake/FindPSpaMM.cmake
@@ -16,7 +16,7 @@
 
 include(FindPackageHandleStandardArgs)
 
-find_program(PSpaMM_PROGRAM pspamm.py
+find_program(PSpaMM_PROGRAM pspamm-generator pspamm.py
   HINTS ENV PSpaMM_DIR
   DOC "Directory where the PSpaMM python script is located"
 )

--- a/generated_code/generate.py
+++ b/generated_code/generate.py
@@ -71,8 +71,8 @@ cmdLineParser.add_argument('--gemm_tools')
 cmdLineParser.add_argument('--drQuadRule')
 cmdLineParser.add_argument('--enable_premultiply_flux', action='store_true')
 cmdLineParser.add_argument('--disable_premultiply_flux', dest='enable_premultiply_flux', action='store_false')
-cmdLineParser.add_argument('--executable_libxsmm', default='libxsmm_gemm_generator')
-cmdLineParser.add_argument('--executable_pspamm', default='pspamm-generator')
+cmdLineParser.add_argument('--executable_libxsmm', default='')
+cmdLineParser.add_argument('--executable_pspamm', default='')
 cmdLineParser.set_defaults(enable_premultiply_flux=False)
 cmdLineArgs = cmdLineParser.parse_args()
 
@@ -154,9 +154,10 @@ gemm_generators = []
 for tool in gemm_tool_list:
   if hasattr(gemm_configuration, tool):
     specific_gemm_class = getattr(gemm_configuration, tool)
-    if specific_gemm_class is gemm_configuration.LIBXSMM:
+    # take executable arguments, but only if they are not empty
+    if specific_gemm_class is gemm_configuration.LIBXSMM and cmdLineArgs.executable_libxsmm != '':
       gemm_generators.append(specific_gemm_class(arch, cmdLineArgs.executable_libxsmm))
-    elif specific_gemm_class is gemm_configuration.PSpaMM:
+    elif specific_gemm_class is gemm_configuration.PSpaMM and cmdLineArgs.executable_pspamm != '':
       gemm_generators.append(specific_gemm_class(arch, cmdLineArgs.executable_pspamm))
     else:
       gemm_generators.append(specific_gemm_class(arch))

--- a/generated_code/generate.py
+++ b/generated_code/generate.py
@@ -71,6 +71,8 @@ cmdLineParser.add_argument('--gemm_tools')
 cmdLineParser.add_argument('--drQuadRule')
 cmdLineParser.add_argument('--enable_premultiply_flux', action='store_true')
 cmdLineParser.add_argument('--disable_premultiply_flux', dest='enable_premultiply_flux', action='store_false')
+cmdLineParser.add_argument('--executable_libxsmm', default='libxsmm_gemm_generator')
+cmdLineParser.add_argument('--executable_pspamm', default='pspamm-generator')
 cmdLineParser.set_defaults(enable_premultiply_flux=False)
 cmdLineArgs = cmdLineParser.parse_args()
 
@@ -152,7 +154,12 @@ gemm_generators = []
 for tool in gemm_tool_list:
   if hasattr(gemm_configuration, tool):
     specific_gemm_class = getattr(gemm_configuration, tool)
-    gemm_generators.append(specific_gemm_class(arch))
+    if specific_gemm_class is gemm_configuration.LIBXSMM:
+      gemm_generators.append(specific_gemm_class(arch, cmdLineArgs.executable_libxsmm))
+    elif specific_gemm_class is gemm_configuration.PSpaMM:
+      gemm_generators.append(specific_gemm_class(arch, cmdLineArgs.executable_pspamm))
+    else:
+      gemm_generators.append(specific_gemm_class(arch))
   else:
     print("YATETO::ERROR: unknown \"{}\" GEMM tool. "
           "Please, refer to the documentation".format(tool))


### PR DESCRIPTION
As the title says, if libxsmm or Pspamm are found by CMake, they may not be found by Yateto, because CMake may find them somewhere on the system; e.g. if the `CMAKE_PREFIX_PATH` contains a location which is not contained `PATH` variable.

Thus, this PR fixes that. Also, we prepare PSpaMM for https://github.com/SeisSol/PSpaMM/pull/8 (interestingly, that did not require any CI fixing, as it wasn't used there anywhere in any way).