### PR TITLE
Adjust tensor sizes to fix plasticity error

### DIFF
--- a/src/Initializer/BatchRecorders/PlasticityRecorder.cpp
+++ b/src/Initializer/BatchRecorders/PlasticityRecorder.cpp
@@ -11,8 +11,7 @@ void PlasticityRecorder::record(LTS& handler, Layer& layer) {
   loader.load(handler, layer);
   setUpContext(handler, layer, loader);
 
-  real(*pstrains)[7 * NUMBER_OF_ALIGNED_BASIS_FUNCTIONS] =
-      currentLayer->var(currentHandler->pstrain);
+  auto* pstrain = currentLayer->var(currentHandler->pstrain);
   size_t nodalStressTensorCounter = 0;
   real* scratchMem =
       static_cast<real*>(currentLayer->getScratchpadMemory(currentHandler->integratedDofsScratch));

--- a/src/Initializer/BatchRecorders/PlasticityRecorder.cpp
+++ b/src/Initializer/BatchRecorders/PlasticityRecorder.cpp
@@ -11,7 +11,7 @@ void PlasticityRecorder::record(LTS& handler, Layer& layer) {
   loader.load(handler, layer);
   setUpContext(handler, layer, loader);
 
-  auto* pstrain = currentLayer->var(currentHandler->pstrain);
+  auto* pstrains = currentLayer->var(currentHandler->pstrain);
   size_t nodalStressTensorCounter = 0;
   real* scratchMem =
       static_cast<real*>(currentLayer->getScratchpadMemory(currentHandler->integratedDofsScratch));

--- a/src/Initializer/LTS.h
+++ b/src/Initializer/LTS.h
@@ -98,7 +98,7 @@ struct seissol::initializers::LTS {
   Variable<PlasticityData>                plasticity;
   Variable<CellDRMapping[4]>              drMapping;
   Variable<CellBoundaryMapping[4]>        boundaryMapping;
-  Variable<real[7 * NUMBER_OF_ALIGNED_BASIS_FUNCTIONS]> pstrain;
+  Variable<real[tensor::QStress::size() + tensor::QEtaModal::size()]> pstrain;
   Variable<real*[4]>                      faceDisplacements;
   Bucket                                  buffersDerivatives;
   Bucket                                  faceDisplacementsBuffer;

--- a/src/Kernels/Plasticity.cpp
+++ b/src/Kernels/Plasticity.cpp
@@ -170,7 +170,7 @@ namespace seissol::kernels {
       adjKrnl.yieldFactor = yieldFactor;
       adjKrnl.execute();
 
-      // calculate plastic strain with first dof only (for now)
+      // calculate plastic strain
       for (unsigned q = 0; q < tensor::QStress::size(); ++q) {
         /**
          * Equation (10) from Wollherr et al.:

--- a/src/Kernels/Plasticity.cpp
+++ b/src/Kernels/Plasticity.cpp
@@ -83,10 +83,9 @@ namespace seissol::kernels {
 
     //copy dofs for later comparison, only first dof of stresses required
     // @todo multiple sims
-    // Number of basis functions * size of stress tensor
-    constexpr auto prev_degreesOfFreedomSize = tensor::Q::Shape[0] * 6;
-    real prev_degreesOfFreedom[prev_degreesOfFreedomSize];
-    for (unsigned q = 0; q < prev_degreesOfFreedomSize; ++q) {
+    
+    real prev_degreesOfFreedom[tensor::QStress::size()];
+    for (unsigned q = 0; q < tensor::QStress::size(); ++q) {
       prev_degreesOfFreedom[q] = degreesOfFreedom[q];
     }
 
@@ -172,7 +171,7 @@ namespace seissol::kernels {
       adjKrnl.execute();
 
       // calculate plastic strain with first dof only (for now)
-      for (unsigned q = 0; q < prev_degreesOfFreedomSize; ++q) {
+      for (unsigned q = 0; q < tensor::QStress::size(); ++q) {
         /**
          * Equation (10) from Wollherr et al.:
          *
@@ -210,7 +209,7 @@ namespace seissol::kernels {
 
       // Sizes:
       for (unsigned q = 0; q < tensor::QEtaModal::size(); ++q) {
-        QEtaModal[q] = pstrain[6 * tensor::QEtaModal::size() + q];
+        QEtaModal[q] = pstrain[tensor::QStress::size() + q];
       }
 
       /* Convert modal to nodal */
@@ -238,7 +237,7 @@ namespace seissol::kernels {
       n2m_eta_Krnl.QEtaModal = QEtaModal;
       n2m_eta_Krnl.execute();
       for (unsigned q = 0; q < tensor::QEtaModal::size(); ++q) {
-        pstrain[6 * tensor::QEtaModal::size() + q] = QEtaModal[q];
+        pstrain[tensor::QStress::size() + q] = QEtaModal[q];
       }
       return 1;
     }

--- a/src/ResultWriter/EnergyOutput.cpp
+++ b/src/ResultWriter/EnergyOutput.cpp
@@ -349,7 +349,7 @@ void EnergyOutput::computeVolumeEnergies() {
 #else
       real mu = material.local.mu;
 #endif
-      totalPlasticMoment += mu * volume * pstrainCell[6 * NUMBER_OF_ALIGNED_BASIS_FUNCTIONS];
+      totalPlasticMoment += mu * volume * pstrainCell[tensor::QStress::size()];
     }
   }
 }

--- a/src/Solver/time_stepping/TimeCluster.h
+++ b/src/Solver/time_stepping/TimeCluster.h
@@ -259,7 +259,7 @@ private:
       CellDRMapping (*drMapping)[4] = i_layerData.var(m_lts->drMapping);
       CellLocalInformation* cellInformation = i_layerData.var(m_lts->cellInformation);
       PlasticityData* plasticity = i_layerData.var(m_lts->plasticity);
-      real (*pstrain)[7 * NUMBER_OF_ALIGNED_BASIS_FUNCTIONS] = i_layerData.var(m_lts->pstrain);
+      auto* pstrain = i_layerData.var(m_lts->pstrain);
       unsigned numberOTetsWithPlasticYielding = 0;
 
       kernels::NeighborData::Loader loader;


### PR DESCRIPTION
Fixes #984 . Also, we remove references to `NUMBER_OF_ALIGNED_BASIS_FUNCTIONS` and replace them with the proper tensor sizes, to avoid potential future errors.