### PR TITLE
fail if dynamic rupture parameters not find

### DIFF
--- a/gitlab-cpu-pipeline.yml
+++ b/gitlab-cpu-pipeline.yml
@@ -129,7 +129,7 @@ run_tpv:
         - git clone https://github.com/SeisSol/precomputed-seissol.git
         - ls
         - cd precomputed-seissol
-        - git checkout 8b1201c
+        - git checkout 2ae63167d0c5e35cb01c56198dba94a2b7a224d9
         - cd ..
         - export equations=elastic
         - if [ "$tpv" = ahsp ]; then equations=anisotropic; fi;

--- a/gitlab-gpu-pipeline.yml
+++ b/gitlab-gpu-pipeline.yml
@@ -159,7 +159,7 @@ gpu_run_tpv:
         - git clone https://github.com/SeisSol/precomputed-seissol.git
         - ls
         - cd precomputed-seissol
-        - git checkout b60e02c
+        - git checkout f7bb557b8cdffe92dc630170f2e48471b18a618d
         - cd ..
         - cd ./build_${backend}_${precision} ;
         - cp -r ../precomputed-seissol/tpv${tpv}/* .

--- a/gitlab-gpu-pipeline.yml
+++ b/gitlab-gpu-pipeline.yml
@@ -159,7 +159,7 @@ gpu_run_tpv:
         - git clone https://github.com/SeisSol/precomputed-seissol.git
         - ls
         - cd precomputed-seissol
-        - git checkout f7bb557b8cdffe92dc630170f2e48471b18a618d
+        - git checkout 2ae63167d0c5e35cb01c56198dba94a2b7a224d9
         - cd ..
         - cd ./build_${backend}_${precision} ;
         - cp -r ../precomputed-seissol/tpv${tpv}/* .

--- a/src/DynamicRupture/Parameters.h
+++ b/src/DynamicRupture/Parameters.h
@@ -74,25 +74,33 @@ inline std::unique_ptr<DRParameters> readParametersFromYaml(std::shared_ptr<YAML
     drParameters->backgroundType = getWithDefault(yamlDrParams, "backgroundtype", 0);
     drParameters->isThermalPressureOn = getWithDefault(yamlDrParams, "thermalpress", false);
     drParameters->t0 = getWithDefault(yamlDrParams, "t_0", 0.0);
-    drParameters->rsF0 = getWithDefault(yamlDrParams, "rs_f0", 0.0);
-    drParameters->rsA = getWithDefault(yamlDrParams, "rs_a", 0.0);
-    drParameters->rsB = getWithDefault(yamlDrParams, "rs_b", 0.0);
-    drParameters->rsSr0 = getWithDefault(yamlDrParams, "rs_sr0", 0.0);
-    drParameters->rsInitialSlipRate1 = getWithDefault(yamlDrParams, "rs_inisliprate1", 0.0);
-    drParameters->rsInitialSlipRate2 = getWithDefault(yamlDrParams, "rs_inisliprate2", 0.0);
-    drParameters->muW = getWithDefault(yamlDrParams, "rs_muw", 0.0);
 
-    // Thermal Pressurization parameters
-    drParameters->thermalDiffusivity = getWithDefault(yamlDrParams, "tp_thermaldiffusivity", 0.0);
-    drParameters->heatCapacity = getWithDefault(yamlDrParams, "tp_heatcapacity", 0.0);
-    drParameters->undrainedTPResponse = getWithDefault(yamlDrParams, "tp_undrainedtpresponse", 0.0);
-    drParameters->initialTemperature = getWithDefault(yamlDrParams, "tp_initemp", 0.0);
-    drParameters->initialPressure = getWithDefault(yamlDrParams, "tp_inipressure", 0.0);
-
+    if ((drParameters->frictionLawType == FrictionLawType::RateAndStateAgingLaw) or
+        (drParameters->frictionLawType == FrictionLawType::RateAndStateSlipLaw) or
+        (drParameters->frictionLawType == FrictionLawType::RateAndStateVelocityWeakening) or
+        (drParameters->frictionLawType == FrictionLawType::RateAndStateFastVelocityWeakening)) {
+      drParameters->rsF0 = getOrFail<double>(yamlDrParams, "rs_f0");
+      drParameters->rsB = getOrFail<double>(yamlDrParams, "rs_b");
+      drParameters->rsSr0 = getOrFail<double>(yamlDrParams, "rs_sr0");
+      drParameters->rsInitialSlipRate1 = getOrFail<double>(yamlDrParams, "rs_inisliprate1");
+      drParameters->rsInitialSlipRate2 = getOrFail<double>(yamlDrParams, "rs_inisliprate2");
+    }
+    if (drParameters->frictionLawType == FrictionLawType::RateAndStateFastVelocityWeakening) {
+      drParameters->muW = getOrFail<double>(yamlDrParams, "rs_muw");
+    }
+    if (drParameters->isThermalPressureOn) {
+      // Thermal Pressurization parameters
+      drParameters->thermalDiffusivity = getOrFail<double>(yamlDrParams, "tp_thermaldiffusivity");
+      drParameters->heatCapacity = getOrFail<double>(yamlDrParams, "tp_heatcapacity");
+      drParameters->undrainedTPResponse = getOrFail<double>(yamlDrParams, "tp_undrainedtpresponse");
+      drParameters->initialTemperature = getOrFail<double>(yamlDrParams, "tp_initemp");
+      drParameters->initialPressure = getOrFail<double>(yamlDrParams, "tp_inipressure");
+    }
     // Prakash-Clifton regularization parameters
-    drParameters->vStar = getWithDefault(yamlDrParams, "pc_vstar", 0.0);
-    drParameters->prakashLength = getWithDefault(yamlDrParams, "pc_prakashlength", 0.0);
-
+    if (drParameters->frictionLawType == FrictionLawType::LinearSlipWeakeningBimaterial) {
+      drParameters->vStar = getOrFail<double>(yamlDrParams, "pc_vstar");
+      drParameters->prakashLength = getOrFail<double>(yamlDrParams, "pc_prakashlength");
+    }
     // filename of the yaml file describing the fault parameters
     drParameters->faultFileName = getWithDefault(yamlDrParams, "modelfilename", std::string(""));
   }

--- a/src/DynamicRupture/Parameters.h
+++ b/src/DynamicRupture/Parameters.h
@@ -29,7 +29,6 @@ struct DRParameters {
   bool isThermalPressureOn{false};
   real t0{0.0};
   real rsF0{0.0};
-  real rsA{0.0};
   real rsB{0.0};
   real rsSr0{0.0};
   real rsInitialSlipRate1{0.0};

--- a/src/Initializer/InputAux.hpp
+++ b/src/Initializer/InputAux.hpp
@@ -62,6 +62,20 @@ T getWithDefault(const YAML::Node& param, const std::string& field, T defaultVal
   }
   return value;
 }
+/*
+ * returns field value if field found in YAML node else fail
+ * @param param: YAML Node, which we want to read from.
+ * @param field: Name of the field, we would like to read
+ */
+template <typename T>
+T getOrFail(const YAML::Node& param, const std::string& field) {
+  if (param[field]) {
+    return getUnsafe<T>(param, field);
+  } else {
+    logError() << "The field" << field << "was not found, but it is required.";
+    return T(); // unreachable. TODO(David): use compiler hint instead
+  }
+}
 
 /**
  * \brief Returns true if number elements in the input string (separated by the white space)


### PR DESCRIPTION
Require that the friction law parameters are specified in the parameter file, and do not use default values if not found.