### PR TITLE
change time step selection of extractDataFromUnstructuredOutput.py

### DIFF
--- a/postprocessing/visualization/tools/extractDataFromUnstructuredOutput.py
+++ b/postprocessing/visualization/tools/extractDataFromUnstructuredOutput.py
@@ -9,12 +9,21 @@ import argparse
 parser = argparse.ArgumentParser(description="resample output file and write as binary files")
 parser.add_argument("xdmfFilename", help="xdmf output file")
 parser.add_argument("--add2prefix", help="string to append to prefix for new file", type=str, default="_resampled")
-parser.add_argument("--Data", nargs="+", metavar=("variable"), help="Data to resample (example SRs, or all)", required=True)
-parser.add_argument("--downsample", help="write one out of n output", type=int)
+parser.add_argument("--Data", nargs="+", metavar=("variable"), help="Data to resample (example SRs, or all)", default=["all"])
 parser.add_argument("--precision", type=str, choices=["float", "double"], default="float", help="precision of output file")
 parser.add_argument("--backend", type=str, choices=["hdf5", "raw"], default="hdf5", help="backend used: raw (.bin file), hdf5 (.h5)")
-parser.add_argument("--last", dest="last", default=False, action="store_true", help="output last time step")
-parser.add_argument("--idt", nargs="+", help="list of time step to write (ex $(seq 7 3 28))", type=int)
+parser.add_argument(
+    "--time",
+    nargs=1,
+    default=["i:"],
+    help=(
+        "simulation time or steps to extract, separated by ','. prepend a i for a step,"
+        " or a python slice notation. E.g. 45.0,i2,i4:10:2,i-1 will extract a snapshot"
+        " at simulation time 45.0, the 2nd time step, and time steps 4,6, 8 and the"
+        " last time step"
+    ),
+)
+
 parser.add_argument(
     "--xfilter",
     nargs=2,
@@ -37,19 +46,48 @@ parser.add_argument(
     type=float,
 )
 args = parser.parse_args()
+class SeissolxdmfExtended(seissolxdmf.seissolxdmf):
+    def OutputTimes(self):
+        """returns the list of output times written in the file"""
+        root = self.tree.getroot()
+        outputTimes = []
+        for Property in root.findall("Domain/Grid/Grid/Time"):
+            outputTimes.append(float(Property.get("Value")))
+        return outputTimes
 
+    def ComputeTimeIndices(self, at_time):
+        """retrive list of time index in file"""
+        outputTimes = np.array(sx.OutputTimes())
+        idsOutputTimes = list(range(0, len(outputTimes)))
+        lidt = []
+        for oTime in at_time:
+            if not oTime.startswith("i"):
+                idsClose = np.where(np.isclose(outputTimes, float(oTime), atol=0.0001))
+                if not len(idsClose[0]):
+                    print(f"t={oTime} not found in {sx.xdmfFilename}")
+                else:
+                    lidt.append(idsClose[0][0])
+            else:
+                sslice = oTime[1:]
+                if ":" in sslice or sslice=='-1':
+                    parts = sslice.split(":")
+                    startstopstep = [None for i in range(3)]
+                    for i, part in enumerate(parts):
+                        startstopstep[i] = int(part) if part else None
+                    lidt.extend(idsOutputTimes[startstopstep[0] : startstopstep[1] : startstopstep[2]])
+                else:
+                    lidt.append(int(sslice))
+        return sorted(list(set(lidt)))
 
-class seissolxdmfExtended(seissolxdmf.seissolxdmf):
     def ReadData(self, dataName, idt=-1):
-        if dataName == "SR":
+        if dataName == "SR" and "SR" not in sx.ReadAvailableDataFields():
             SRs = super().ReadData("SRs", idt)
             SRd = super().ReadData("SRd", idt)
-            return np.sqrt(SRs ** 2 + SRd ** 2)
+            return np.sqrt(SRs**2 + SRd**2)
         else:
             return super().ReadData(dataName, idt)
 
-
-sx = seissolxdmfExtended(args.xdmfFilename)
+sx = SeissolxdmfExtended(args.xdmfFilename)
 xyz = sx.ReadGeometry()
 connect = sx.ReadConnect()
 
@@ -85,21 +123,9 @@ if spatial_filtering:
             spatial_filtering = False
     else:
         raise ValueError("all elements are outside filter range")
-ndt = sx.ndt
 
-if args.last:
-    indices = [ndt - 1]
-    if args.idt or args.downsample:
-        print("last option cannot be used together with idt and downsample options")
-        exit()
-else:
-    if args.idt and args.downsample:
-        print("idt and downsample options cannot be used together")
-        exit()
-    elif not args.downsample:
-        indices = args.idt
-    else:
-        indices = range(0, ndt, args.downsample)
+ndt = sx.ndt
+indices = sx.ComputeTimeIndices(args.time[0].split(','))
 
 # Check if input is in hdf5 format or not
 first_data_field = list(sx.ReadAvailableDataFields())[0]

--- a/postprocessing/visualization/tools/extractDataFromUnstructuredOutput.py
+++ b/postprocessing/visualization/tools/extractDataFromUnstructuredOutput.py
@@ -221,6 +221,9 @@ for ida, sdata in enumerate(args.Data):
             myData = sx.ReadData(args.Data[ida], idt=i)[ids]
         else:
             myData = sx.ReadData(args.Data[ida], idt=i)
+        if kk == len(indices)-1 and myData.shape[0]==0:
+           print("last time step is corrupted, replacing with 0s")
+           myData = np.zeros((nElements))
         if write2Binary:
             myData.astype(myDtype).tofile(output_file)
         else:


### PR DESCRIPTION
important change is the following:
```
parser.add_argument(
    "--time",
    nargs=1,
    default=["i:"],
    help=(
        "simulation time or steps to extract, separated by ','. prepend a i for a step,"
        " or a python slice notation. E.g. 45.0,i2,i4:10:2,i-1 will extract a snapshot"
        " at simulation time 45.0, the 2nd time step, and time steps 4,6, 8 and the"
        " last time step"
    ),
)
```
Example:
```
(base) ulrich@ulrich-ThinkPad-T490s:~/trash$ python ~/SeisSol/SeisSol/postprocessing/visualization/tools/extractDataFromUnstructuredOutput.py ./Tohoku_thrust_2d_plast_all_mu_dep_resampled-fault.xdmf --Data "ASl" --time "2.0,i13,i-1,i20,i20:40"
done writing Tohoku_thrust_2d_plast_all_mu_dep_resampled_resampled-fault_vertex.h5
ASl 0 1 2 3 4 5 6 7 8 9 10
11 12 13 14 15 16 17 18 19 20
21 22 done writing Tohoku_thrust_2d_plast_all_mu_dep_resampled_resampled-fault_cell.h5
done writing Tohoku_thrust_2d_plast_all_mu_dep_resampled_resampled-fault.xdmf
````
Note that now, running extractDataFromUnstructuredOutput.py  witout arguments extract all fields and timesteps (#782):
```
(base) ulrich@ulrich-ThinkPad-T490s:~/trash$ python ~/SeisSol/SeisSol/postprocessing/visualization/tools/extractDataFromUnstructuredOutput.py ./Tohoku_thrust_2d_plast_all_mu_dep_resampled-fault.xdmf 
done writing Tohoku_thrust_2d_plast_all_mu_dep_resampled_resampled-fault_vertex.h5
args.Data was set to all and now contains ['ASl', 'SR']
ASl 0 1 2 3 4 5 6 7 8 9 10
11 12 13 14 15 16 17 18 19 20
21 22 23 24 25 26 27 28 29 30
31 32 33 34 35 36 37 38 39 40
41 42 43 44 45 46 47 48 49 50
51 52 53 54 55 56 57 58 59 60
SR 0 1 2 3 4 5 6 7 8 9 10
11 12 13 14 15 16 17 18 19 20
21 22 23 24 25 26 27 28 29 30
31 32 33 34 35 36 37 38 39 40
41 42 43 44 45 46 47 48 49 50
51 52 53 54 55 56 57 58 59 60
done writing Tohoku_thrust_2d_plast_all_mu_dep_resampled_resampled-fault_cell.h5
done writing Tohoku_thrust_2d_plast_all_mu_dep_resampled_resampled-fault.xdmf
```


Also I added a fix for cases where seissol crashed when writting output.
In this case, all variables may not be written, and the extractor will fail writing the missing data:
```
7361 7362 7363 7364 7365 7366 7367 7368 7369 7370
7371 Traceback (most recent call last):
  File "/scratch1/09160/ulrich/SeisSol/postprocessing/visualization/tools/extractDataFromUnstructuredOutput.py", line 201, in <module>
    dset[kk, :] = myData[:]
  File "h5py/_objects.pyx", line 54, in h5py._objects.with_phil.wrapper
  File "h5py/_objects.pyx", line 55, in h5py._objects.with_phil.wrapper
  File "/opt/apps/intel19/impi19_0/python3/3.7.0/lib/python3.7/site-packages/h5py/_hl/dataset.py", line 707, in __setitem__
    for fspace in selection.broadcast(mshape):
  File "/opt/apps/intel19/impi19_0/python3/3.7.0/lib/python3.7/site-packages/h5py/_hl/selections.py", line 299, in broadcast
    raise TypeError("Can't broadcast %s -> %s" % (target_shape, self.mshape))
TypeError: Can't broadcast (0,) -> (4378850,)
done writing Turkey_Mrf3_o6v_ev1_rough_067_R0tuned_u1u2u3-surface_vertex.h5
```
This fixes the problem.