### PR TITLE
Disable Some OpenMP Clauses for NVHPC

### DIFF
--- a/src/DynamicRupture/Output/ReceiverBasedOutput.cpp
+++ b/src/DynamicRupture/Output/ReceiverBasedOutput.cpp
@@ -1,11 +1,9 @@
-#include "DynamicRupture/Output/OutputAux.hpp"
 #include "Initializer/tree/Layer.hpp"
+#include "Initializer/preProcessorMacros.hpp"
 #include "Numerical_aux/BasisFunction.h"
 #include "ReceiverBasedOutput.hpp"
 #include "generated_code/kernel.h"
 #include "generated_code/tensor.h"
-#include <unordered_map>
-#include "Initializer/preProcessorMacros.hpp"
 
 using namespace seissol::dr::misc::quantity_indices;
 

--- a/src/DynamicRupture/Output/ReceiverBasedOutput.cpp
+++ b/src/DynamicRupture/Output/ReceiverBasedOutput.cpp
@@ -5,6 +5,7 @@
 #include "generated_code/kernel.h"
 #include "generated_code/tensor.h"
 #include <unordered_map>
+#include "Initializer/preProcessorMacros.hpp"
 
 using namespace seissol::dr::misc::quantity_indices;
 
@@ -44,7 +45,9 @@ void ReceiverOutput::calcFaultOutput(const OutputType type,
   const size_t level = (type == OutputType::AtPickpoint) ? outputData->currentCacheLevel : 0;
   const auto faultInfos = meshReader->getFault();
 
+#if defined(_OPENMP) && !NVHPC_AVOID_OMP
 #pragma omp parallel for
+#endif
   for (size_t i = 0; i < outputData->receiverPoints.size(); ++i) {
 
     assert(outputData->receiverPoints[i].isInside == true &&

--- a/src/Initializer/InitialFieldProjection.cpp
+++ b/src/Initializer/InitialFieldProjection.cpp
@@ -48,6 +48,8 @@
 #include <generated_code/kernel.h>
 #include <generated_code/tensor.h>
 
+#include "Initializer/preProcessorMacros.hpp"
+
 GENERATE_HAS_MEMBER(selectAneFull)
 GENERATE_HAS_MEMBER(selectElaFull)
 GENERATE_HAS_MEMBER(Values)
@@ -75,7 +77,7 @@ void seissol::initializers::projectInitialField(std::vector<std::unique_ptr<phys
   double quadratureWeights[numQuadPoints];
   seissol::quadrature::TetrahedronQuadrature(quadraturePoints, quadratureWeights, quadPolyDegree);
 
-#ifdef _OPENMP
+#if defined(_OPENMP) && !NVHPC_AVOID_OMP
   #pragma omp parallel
   {
 #endif
@@ -91,7 +93,7 @@ void seissol::initializers::projectInitialField(std::vector<std::unique_ptr<phys
   kernels::set_selectAneFull(krnl, kernels::get_static_ptr_Values<init::selectAneFull>());
   kernels::set_selectElaFull(krnl, kernels::get_static_ptr_Values<init::selectElaFull>());
 
-#ifdef _OPENMP
+#if defined(_OPENMP) && !NVHPC_AVOID_OMP
   #pragma omp for schedule(static)
 #endif
   for (unsigned int meshId = 0; meshId < elements.size(); ++meshId) {
@@ -119,7 +121,7 @@ void seissol::initializers::projectInitialField(std::vector<std::unique_ptr<phys
     }
     krnl.execute();
   }
-#ifdef _OPENMP
+#if defined(_OPENMP) && !NVHPC_AVOID_OMP
   }
 #endif
 

--- a/src/Initializer/preProcessorMacros.hpp
+++ b/src/Initializer/preProcessorMacros.hpp
@@ -15,4 +15,16 @@ constexpr std::size_t PAGESIZE_STACK = 4096;
 
 constexpr std::size_t ALLOW_POSSILBE_ZERO_LENGTH_ARRAY(std::size_t X) { return X == 0 ? 1 : X; }
 
+// workaround for old NVHPC versions (the output would cause errors there)
+#ifdef __NVCOMPILER
+// we'll leave the comment in the next line in for now, until a NVHPC version is fixed
+#if 0 // (__NVCOMPILER_MAJOR__ > 24) || (__NVCOMPILER_MAJOR__ == 24 && __NVCOMPILER_MINOR__ >= 3)
+#define NVHPC_AVOID_OMP 0
+#else
+#define NVHPC_AVOID_OMP 1
+#endif
+#else
+#define NVHPC_AVOID_OMP 0
+#endif
+
 #endif

--- a/src/ResultWriter/AnalysisWriter.cpp
+++ b/src/ResultWriter/AnalysisWriter.cpp
@@ -10,6 +10,7 @@
 #include "SeisSol.h"
 #include "Geometry/MeshReader.h"
 #include <Physics/InitialField.h>
+#include "Initializer/preProcessorMacros.hpp"
 
 namespace seissol::writer {
 
@@ -98,7 +99,7 @@ void AnalysisWriter::printAnalysis(double simulationTime) {
     auto analyticalL2Local = ErrorArray_t{0.0};
     auto analyticalLInfLocal = ErrorArray_t{-1.0};
 
-#ifdef _OPENMP
+#if defined(_OPENMP) && !NVHPC_AVOID_OMP
     const int numThreads = omp_get_max_threads();
 #else
     const int numThreads = 1;
@@ -119,12 +120,12 @@ void AnalysisWriter::printAnalysis(double simulationTime) {
 
     alignas(ALIGNMENT) real numericalSolutionData[tensor::dofsQP::size()];
     alignas(ALIGNMENT) real analyticalSolutionData[numQuadPoints*numberOfQuantities];
-#ifdef _OPENMP
+#if defined(_OPENMP) && !NVHPC_AVOID_OMP
     // Note: Adding default(none) leads error when using gcc-8
 #pragma omp parallel for shared(elements, vertices, iniFields, quadraturePoints, globalData, errsLInfLocal, simulationTime, ltsLut, lts, sim, quadratureWeights, elemsLInfLocal, errsL2Local, errsL1Local, analyticalsL1Local, analyticalsL2Local, analyticalsLInfLocal) firstprivate(quadraturePointsXyz) private(numericalSolutionData, analyticalSolutionData)
 #endif
     for (std::size_t meshId = 0; meshId < elements.size(); ++meshId) {
-#ifdef _OPENMP
+#if defined(_OPENMP) && !NVHPC_AVOID_OMP
       const int curThreadId = omp_get_thread_num();
 #else
       const int curThreadId = 0;

--- a/src/ResultWriter/EnergyOutput.cpp
+++ b/src/ResultWriter/EnergyOutput.cpp
@@ -5,6 +5,7 @@
 #include <Parallel/MPI.h>
 #include "SeisSol.h"
 #include "Initializer/InputParameters.hpp"
+#include "Initializer/preProcessorMacros.hpp"
 
 namespace seissol::writer {
 
@@ -152,7 +153,7 @@ void EnergyOutput::computeDynamicRuptureEnergies() {
     seissol::model::IsotropicWaveSpeeds* waveSpeedsPlus = it->var(dynRup->waveSpeedsPlus);
     seissol::model::IsotropicWaveSpeeds* waveSpeedsMinus = it->var(dynRup->waveSpeedsMinus);
 
-#if defined(_OPENMP) && !defined(__NVCOMPILER)
+#if defined(_OPENMP) && !NVHPC_AVOID_OMP
 #pragma omp parallel for reduction(                                                                \
         + : totalFrictionalWork, staticFrictionalWork, seismicMoment) default(none)                \
     shared(it,                                                                                     \
@@ -207,7 +208,7 @@ void EnergyOutput::computeVolumeEnergies() {
 
   // Note: Default(none) is not possible, clang requires data sharing attribute for g, gcc forbids
   // it
-#if defined(_OPENMP) && !defined(__NVCOMPILER)
+#if defined(_OPENMP) && !NVHPC_AVOID_OMP
 #pragma omp parallel for schedule(static) reduction(+ : totalGravitationalEnergyLocal,             \
                                                         totalAcousticEnergyLocal,                  \
                                                         totalAcousticKineticEnergyLocal,           \

--- a/src/Solver/FreeSurfaceIntegrator.cpp
+++ b/src/Solver/FreeSurfaceIntegrator.cpp
@@ -113,7 +113,7 @@ void seissol::solver::FreeSurfaceIntegrator::calculateOutput()
     real** displacementDofs = surfaceLayer->var(surfaceLts.displacementDofs);
     unsigned* side = surfaceLayer->var(surfaceLts.side);
 
-#ifdef _OPENMP
+#if defined(_OPENMP) && !NVHPC_AVOID_OMP
     #pragma omp parallel for schedule(static) default(none) shared(offset, surfaceLayer, dofs, displacementDofs, side)
 #endif // _OPENMP
     for (unsigned face = 0; face < surfaceLayer->getNumberOfCells(); ++face) {


### PR DESCRIPTION
NVHPC currently incorrectly implements some of the OpenMP clauses used in SeisSol—hence this PR to disable OpenMP at these places entirely. However, we introduce a flag in this PR that will probably enable the OpenMP clauses, once the bug has been fixed in NVHPC.

Supersedes #526 .