### PR TITLE
Remove superfluous include

### DIFF
--- a/src/Solver/time_stepping/MiniSeisSol.cpp
+++ b/src/Solver/time_stepping/MiniSeisSol.cpp
@@ -48,7 +48,6 @@
 
 #ifdef ACL_DEVICE
 #include <Initializer/BatchRecorders/Recorders.h>
-#include <Parallel/AcceleratorDevice.h>
 #include "device.h"
 #endif
 


### PR DESCRIPTION
Lets some builds fail—hence we remove it.

Ported from #1003 .