### PR TITLE
Remove Unnecessary Fault Output Allocations

### DIFF
--- a/gitlab-gpu-pipeline.yml
+++ b/gitlab-gpu-pipeline.yml
@@ -194,7 +194,7 @@ check_faultoutput:
               tpv: [5, 5-nuc, 6, 101, 101-slip, 104]
               backend: [cuda]
     before_script:
-        - pip3 install numpy>=1.12.0 lxml setuptools seissolxdmf pandas
+        - pip3 install numpy>=1.12.0 lxml==5.0.0 setuptools seissolxdmf pandas
     script: 
         - echo "check TPV{$tpv} with ${precision} precision and ${backend} backend"
         - ls

--- a/src/DynamicRupture/Output/OutputManager.cpp
+++ b/src/DynamicRupture/Output/OutputManager.cpp
@@ -234,6 +234,7 @@ void OutputManager::init() {
   if (ppOutputBuilder) {
     initPickpointOutput();
   }
+  impl->allocateMemory({ppOutputData, ewOutputData});
 }
 
 void OutputManager::initFaceToLtsMap() {

--- a/src/DynamicRupture/Output/ReceiverBasedOutput.cpp
+++ b/src/DynamicRupture/Output/ReceiverBasedOutput.cpp
@@ -62,12 +62,12 @@ void ReceiverOutput::allocateMemory(
 }
 
 ReceiverOutput::~ReceiverOutput() {
-#ifdef ACL_DEVICE
   if (deviceCopyMemory != nullptr) {
+#ifdef ACL_DEVICE
     device::DeviceInstance::getInstance().api->freePinnedMem(deviceCopyMemory);
+#endif
     deviceCopyMemory = nullptr;
   }
-#endif
 }
 
 void ReceiverOutput::calcFaultOutput(const OutputType type,

--- a/src/DynamicRupture/Output/ReceiverBasedOutput.cpp
+++ b/src/DynamicRupture/Output/ReceiverBasedOutput.cpp
@@ -79,14 +79,16 @@ void ReceiverOutput::calcFaultOutput(const OutputType type,
   const auto faultInfos = meshReader->getFault();
 
 #ifdef ACL_DEVICE
-  void* stream = device::DeviceInstance::getInstance().api->getDefaultStream();
-  device::DeviceInstance::getInstance().algorithms.copyScatterToUniform(outputData->deviceDataPtr,
-                                                                        deviceCopyMemory,
-                                                                        tensor::Q::size(),
-                                                                        tensor::Q::size(),
-                                                                        outputData->cellCount,
-                                                                        stream);
-  device::DeviceInstance::getInstance().api->syncDefaultStreamWithHost();
+  if (outputData->cellCount > 0) {
+    void* stream = device::DeviceInstance::getInstance().api->getDefaultStream();
+    device::DeviceInstance::getInstance().algorithms.copyScatterToUniform(outputData->deviceDataPtr,
+                                                                          deviceCopyMemory,
+                                                                          tensor::Q::size(),
+                                                                          tensor::Q::size(),
+                                                                          outputData->cellCount,
+                                                                          stream);
+    device::DeviceInstance::getInstance().api->syncDefaultStreamWithHost();
+  }
 #endif
 
 #if defined(_OPENMP) && !NVHPC_AVOID_OMP

--- a/src/DynamicRupture/Output/ReceiverBasedOutput.hpp
+++ b/src/DynamicRupture/Output/ReceiverBasedOutput.hpp
@@ -7,10 +7,13 @@
 #include "Initializer/LTS.h"
 #include "Initializer/tree/Lut.hpp"
 
+#include <memory>
+#include <vector>
+
 namespace seissol::dr::output {
 class ReceiverOutput {
   public:
-  virtual ~ReceiverOutput() = default;
+  virtual ~ReceiverOutput();
 
   void setLtsData(seissol::initializers::LTSTree* userWpTree,
                   seissol::initializers::LTS* userWpDescr,
@@ -18,6 +21,7 @@ class ReceiverOutput {
                   seissol::initializers::LTSTree* userDrTree,
                   seissol::initializers::DynamicRupture* userDrDescr);
 
+  void allocateMemory(const std::vector<std::shared_ptr<ReceiverOutputData>>& states);
   void setMeshReader(seissol::geometry::MeshReader* userMeshReader) { meshReader = userMeshReader; }
   void setFaceToLtsMap(FaceToLtsMapType* map) { faceToLtsMap = map; }
   void calcFaultOutput(OutputType type,
@@ -33,6 +37,7 @@ class ReceiverOutput {
   seissol::initializers::DynamicRupture* drDescr{nullptr};
   seissol::geometry::MeshReader* meshReader{nullptr};
   FaceToLtsMapType* faceToLtsMap{nullptr};
+  real* deviceCopyMemory{nullptr};
 
   struct LocalInfo {
     seissol::initializers::Layer* layer{};


### PR DESCRIPTION
Right now, the pickpoint fault output will allocate new memory far too often, as introduced by #1001 (thus slowing down the performance generally), thus the performance suffers.

This PR fixes that (in fact, if the fault output is enabled, we now get an even higher performance than with USM—as tested on HomeOne at least).

Also, we fix the GPU pipeline.
