### PR TITLE
Bump cpu image version

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,7 +5,7 @@ stages:
 
 variables:
   cpu_image_name: "cpu-ci-image"
-  cpu_image_version: "v0.0.5"
+  cpu_image_version: "v0.0.6"
   gpu_image_name: "gpu-ci-image"
   gpu_image_version: "v0.0.4"
 


### PR DESCRIPTION
Recent changes (#1017) required an update of the version number.