### PR TITLE
Adjust fault face indexing to not iterate over an `std::map` for each lookup

### DIFF
--- a/src/DynamicRupture/Output/Builders/ReceiverBasedOutputBuilder.cpp
+++ b/src/DynamicRupture/Output/Builders/ReceiverBasedOutputBuilder.cpp
@@ -1,6 +1,5 @@
 #include "DynamicRupture/Output/Builders/ReceiverBasedOutputBuilder.hpp"
-#include <map>
-#include <set>
+#include <unordered_map>
 
 namespace seissol::dr::output {
 void ReceiverBasedOutputBuilder::setMeshReader(const seissol::geometry::MeshReader* reader) {
@@ -16,14 +15,35 @@ void ReceiverBasedOutputBuilder::setLtsData(seissol::initializers::LTSTree* user
   wpLut = userWpLut;
 }
 
+namespace {
+struct GhostElement {
+  std::pair<std::size_t, int> data;
+  std::size_t index;
+};
+
+template <typename T1, typename T2>
+struct HashPair {
+  std::size_t operator()(const std::pair<T1, T2>& data) const {
+    // Taken from: https://stackoverflow.com/questions/2590677/how-do-i-combine-hash-values-in-c0x
+    // (probably any other lcg-like hash function would work as well)
+    std::hash<T1> hasher1;
+    std::hash<T2> hasher2;
+    std::size_t seed = hasher1(data.first);
+    seed ^= hasher2(data.second) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
+    return seed;
+  }
+};
+} // namespace
+
 void ReceiverBasedOutputBuilder::initBasisFunctions() {
   const auto& faultInfo = meshReader->getFault();
   const auto& elementsInfo = meshReader->getElements();
   const auto& verticesInfo = meshReader->getVertices();
   const auto& mpiGhostMetadata = meshReader->getGhostlayerMetadata();
 
-  std::set<std::size_t> elementIndices;
-  std::map<std::pair<int, std::size_t>, std::pair<std::size_t, int>> elementIndicesGhost;
+  std::unordered_map<std::size_t, std::size_t> elementIndices;
+  std::unordered_map<std::pair<int, std::size_t>, GhostElement, HashPair<int, std::size_t>>
+      elementIndicesGhost;
   std::size_t foundPoints = 0;
 
   constexpr size_t numVertices{4};
@@ -33,7 +53,10 @@ void ReceiverBasedOutputBuilder::initBasisFunctions() {
       const auto elementIndex = faultInfo[point.faultFaceIndex].element;
       const auto& element = elementsInfo[elementIndex];
 
-      elementIndices.insert(elementIndex);
+      if (elementIndices.find(elementIndex) == elementIndices.end()) {
+        const auto index = elementIndices.size();
+        elementIndices[elementIndex] = index;
+      }
 
       const auto neighborElementIndex = faultInfo[point.faultFaceIndex].neighborElement;
 
@@ -45,7 +68,10 @@ void ReceiverBasedOutputBuilder::initBasisFunctions() {
 
       const VrtxCoords* neighborElemCoords[numVertices]{};
       if (neighborElementIndex >= 0) {
-        elementIndices.insert(neighborElementIndex);
+        if (elementIndices.find(neighborElementIndex) == elementIndices.end()) {
+          const auto index = elementIndices.size();
+          elementIndices[neighborElementIndex] = index;
+        }
         for (size_t vertexIdx = 0; vertexIdx < numVertices; ++vertexIdx) {
           const auto address = elementsInfo[neighborElementIndex].vertices[vertexIdx];
           neighborElemCoords[vertexIdx] = &(verticesInfo[address].coords);
@@ -58,8 +84,12 @@ void ReceiverBasedOutputBuilder::initBasisFunctions() {
 
         const auto neighborIndex = element.mpiIndices[faultSide];
 
-        elementIndicesGhost[std::pair<int, std::size_t>(neighborRank, neighborIndex)] =
-            std::pair<std::size_t, int>(elementIndex, faultSide);
+        const auto ghostIndex = std::pair<int, std::size_t>(neighborRank, neighborIndex);
+        if (elementIndicesGhost.find(ghostIndex) == elementIndicesGhost.end()) {
+          const auto index = elementIndicesGhost.size();
+          elementIndicesGhost[ghostIndex] =
+              GhostElement{std::pair<std::size_t, int>(elementIndex, faultSide), index};
+        }
 
         for (size_t vertexIdx = 0; vertexIdx < numVertices; ++vertexIdx) {
           const auto& array3d = ghostMetadataItr->second[neighborIndex].vertices[vertexIdx];
@@ -83,16 +113,15 @@ void ReceiverBasedOutputBuilder::initBasisFunctions() {
       reinterpret_cast<real**>(device::DeviceInstance::getInstance().api->allocGlobMem(
           sizeof(real*) * outputData->cellCount));
 
-  std::size_t arrayIndex = 0;
-  for (const auto& index : elementIndices) {
+  for (const auto& [arrayIndex, index] : elementIndices) {
     preDofPtr[arrayIndex] = wpLut->lookup(wpDescr->derivatives, index);
     assert(preDofPtr[arrayIndex] != nullptr);
-    ++arrayIndex;
   }
-  for (const auto& [_, neighbor] : elementIndicesGhost) {
+  for (const auto& [_, ghost] : elementIndicesGhost) {
+    const auto neighbor = ghost.data;
+    const auto arrayIndex = ghost.index + elementIndices.size();
     preDofPtr[arrayIndex] = wpLut->lookup(wpDescr->faceNeighbors, neighbor.first)[neighbor.second];
     assert(preDofPtr[arrayIndex] != nullptr);
-    ++arrayIndex;
   }
 
   device::DeviceInstance::getInstance().api->copyTo(
@@ -108,22 +137,18 @@ void ReceiverBasedOutputBuilder::initBasisFunctions() {
     if (point.isInside) {
       const auto elementIndex = faultInfo[point.faultFaceIndex].element;
       const auto& element = elementsInfo[elementIndex];
-      outputData->deviceDataPlus[pointCounter] =
-          std::distance(elementIndices.begin(), elementIndices.find(elementIndex));
+      outputData->deviceDataPlus[pointCounter] = elementIndices.at(elementIndex);
 
       const auto neighborElementIndex = faultInfo[point.faultFaceIndex].neighborElement;
       if (neighborElementIndex >= 0) {
-        outputData->deviceDataMinus[pointCounter] =
-            std::distance(elementIndices.begin(), elementIndices.find(neighborElementIndex));
+        outputData->deviceDataMinus[pointCounter] = elementIndices.at(neighborElementIndex);
       } else {
         const auto faultSide = faultInfo[point.faultFaceIndex].side;
         const auto neighborRank = element.neighborRanks[faultSide];
         const auto neighborIndex = element.mpiIndices[faultSide];
         outputData->deviceDataMinus[pointCounter] =
             elementIndices.size() +
-            std::distance(
-                elementIndicesGhost.begin(),
-                elementIndicesGhost.find(std::pair<int, std::size_t>(neighborRank, neighborIndex)));
+            elementIndicesGhost.at(std::pair<int, std::size_t>(neighborRank, neighborIndex)).index;
       }
 
       ++pointCounter;


### PR DESCRIPTION
Fixes #1026 .