### PR TITLE
Set up HLRS codehub mirror

### DIFF
--- a/.github/workflows/github-to-gitlab-push-sync.yml
+++ b/.github/workflows/github-to-gitlab-push-sync.yml
@@ -1,0 +1,23 @@
+name: codehub-hlrs-sync
+
+on: 
+  push:
+    branches:
+      - 'master'
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    name: Git Repo Sync
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    - uses: wangchucheng/git-repo-sync@master
+      with:
+        target-url: 'https://codehub.hlrs.de/coes/cheese-2p/SeisSol/SeisSol.git'
+        target-username: ${{ secrets.ACCESS_TOKEN_NAME }}
+        target-token: ${{ secrets.ACCESS_TOKEN }}
+


### PR DESCRIPTION
ChEESE-2 collaborates with the CASTIEL-2 COE to gather all European exascale codes in a centralized gitlab at HLRS.
This PR sets up a push mirror from this github repository to the gitlab mirror. 