### PR TITLE
Replace Docker builds by Kaniko

### DIFF
--- a/.ci/docker-gpu/Dockerfile.base
+++ b/.ci/docker-gpu/Dockerfile.base
@@ -58,7 +58,7 @@ cd .. && rm -rf ./hdf5*
 
 
 RUN export VERSION=4.7.4 && \
-wget --progress=bar:force:noscroll ftp://ftp.unidata.ucar.edu/pub/netcdf/netcdf-c-${VERSION}.tar.gz && \
+wget --progress=bar:force:noscroll https://github.com/Unidata/netcdf-c/archive/refs/tags/v{VERSION}.tar.gz && \
 tar -xvf netcdf-c-${VERSION}.tar.gz && \
 cd netcdf-c-${VERSION} && \
 CFLAGS="-fPIC" CC=/usr/bin/h5pcc ./configure --enable-shared=no --prefix=/usr --disable-dap && \
@@ -78,7 +78,7 @@ cp metis/include/metis.h /usr/include && \
 cd .. && rm -rf ./parmetis-*
 
 
-RUN export VERSION=1.16.1 && \
+RUN export VERSION=1.17 && \
 git clone https://github.com/hfp/libxsmm.git && \
 cd libxsmm && \
 git checkout ${VERSION} && \

--- a/.ci/docker-gpu/Dockerfile.base
+++ b/.ci/docker-gpu/Dockerfile.base
@@ -59,7 +59,7 @@ cd .. && rm -rf ./hdf5*
 
 RUN export VERSION=4.7.4 && \
 wget --progress=bar:force:noscroll https://github.com/Unidata/netcdf-c/archive/refs/tags/v${VERSION}.tar.gz && \
-tar -xvf netcdf-c-${VERSION}.tar.gz && \
+tar -xvf v${VERSION}.tar.gz && \
 cd netcdf-c-${VERSION} && \
 CFLAGS="-fPIC" CC=/usr/bin/h5pcc ./configure --enable-shared=no --prefix=/usr --disable-dap && \
 make -j $(nproc) && make install && \

--- a/.ci/docker-gpu/Dockerfile.base
+++ b/.ci/docker-gpu/Dockerfile.base
@@ -58,7 +58,7 @@ cd .. && rm -rf ./hdf5*
 
 
 RUN export VERSION=4.7.4 && \
-wget --progress=bar:force:noscroll https://github.com/Unidata/netcdf-c/archive/refs/tags/v{VERSION}.tar.gz && \
+wget --progress=bar:force:noscroll https://github.com/Unidata/netcdf-c/archive/refs/tags/v${VERSION}.tar.gz && \
 tar -xvf netcdf-c-${VERSION}.tar.gz && \
 cd netcdf-c-${VERSION} && \
 CFLAGS="-fPIC" CC=/usr/bin/h5pcc ./configure --enable-shared=no --prefix=/usr --disable-dap && \

--- a/.ci/docker-gpu/Dockerfile.compilers
+++ b/.ci/docker-gpu/Dockerfile.compilers
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:11.2.1-devel-ubuntu18.04
+FROM nvidia/cuda:11.2.2-devel-ubuntu18.04
 
 
 RUN apt-get update -yqq && \

--- a/.ci/docker-gpu/Dockerfile.compilers
+++ b/.ci/docker-gpu/Dockerfile.compilers
@@ -53,7 +53,7 @@ cd ../.. && rm -rf ./googletest
 RUN apt-get install -yqq libnuma-dev gnupg2 && \
 wget --progress=bar:force:noscroll https://repo.radeon.com/amdgpu-install/22.20/ubuntu/bionic/amdgpu-install_22.20.50200-1_all.deb && \
 apt-get install -y ./amdgpu-install_22.20.50200-1_all.deb && \
-amdgpu-install -y --usecase=hiplibsdk,rocm && \
+amdgpu-install -y --usecase=hiplibsdk --no-dkms && \
 rm ./amdgpu-install_22.20.50200-1_all.deb && \
 echo 'export PATH=$PATH:/opt/rocm/bin:/opt/rocm/rocprofiler/bin:/opt/rocm/opencl/bin' | tee -a /etc/profile.d/rocm.sh && \
 echo 'export HIPCC_VERBOSE=7' | tee -a /etc/profile.d/rocm.sh && \

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -7,7 +7,7 @@ variables:
   cpu_image_name: "cpu-ci-image"
   cpu_image_version: "v0.0.6"
   gpu_image_name: "gpu-ci-image"
-  gpu_image_version: "v0.0.4"
+  gpu_image_version: "v0.0.5"
 
 Building_Docker_Images:
   stage: build

--- a/gitlab-cpu-pipeline.yml
+++ b/gitlab-cpu-pipeline.yml
@@ -1,7 +1,4 @@
 default:
-    tags:
-        - sccs
-        - helper
     image:
         name: $CI_REGISTRY_USER/$cpu_image_name:$cpu_image_version
         entrypoint: [""]
@@ -17,6 +14,9 @@ stages:
         
 fetch_submodules:
     stage: pre_build
+    tags:
+        - sccs
+        - helper
     variables:
         GIT_STRATEGY: clone
     before_script:
@@ -156,6 +156,9 @@ run_tpv:
 check_faultoutput:
     stage: check
     allow_failure: false
+    tags:
+        - sccs
+        - helper
     needs:
         - job: run_tpv
     variables:
@@ -178,6 +181,9 @@ check_faultoutput:
 check_receivers:
     stage: check
     allow_failure: false
+    tags:
+        - sccs
+        - helper
     needs:
         - job: run_tpv
     variables:
@@ -199,6 +205,9 @@ check_receivers:
 check_energies:
     stage: check
     allow_failure: false
+    tags:
+        - sccs
+        - helper
     needs:
         - job: run_tpv
     variables:

--- a/gitlab-docker-images.yml
+++ b/gitlab-docker-images.yml
@@ -26,17 +26,17 @@ check-images:
     - echo "$CI_REGISTRY_PASSWORD" | docker login -u "$CI_REGISTRY_USER" --password-stdin "$CI_REGISTRY"
   script:
     - export full_image_name="${CI_REGISTRY_USER}/${cpu_image_name}:${cpu_image_version}"
-    - export CPU_REBUILD=$(sh ${CI_PROJECT_DIR}/.ci/does_image_exist.sh "${full_image_name}")
-    - echo "CPU image ${full_image_name} exists = ${image_exists}. Rebuild = ${CPU_REBUILD}"
+    - export CPU_EXISTS=$(sh ${CI_PROJECT_DIR}/.ci/does_image_exist.sh "${full_image_name}")
+    - echo "CPU image ${full_image_name} exists = ${CPU_EXISTS}"
     - export full_compiler_image_name="${CI_REGISTRY_USER}/gpu-ci-compiler-image:${gpu_image_version}" ;
-    - export GPU_COMPILER_REBUILD=$(sh ${CI_PROJECT_DIR}/.ci/does_image_exist.sh "${full_compiler_image_name}")
-    - echo "GPU compiler image ${full_compiler_image_name} exists = ${GPU_COMPILER_REBUILD}"
+    - export GPU_COMPILER_EXISTS=$(sh ${CI_PROJECT_DIR}/.ci/does_image_exist.sh "${full_compiler_image_name}")
+    - echo "GPU compiler image ${full_compiler_image_name} exists = ${GPU_COMPILER_EXISTS}"
     - export full_image_name="${CI_REGISTRY_USER}/${gpu_image_name}:${gpu_image_version}"
-    - export GPU_REBUILD=$(sh ${CI_PROJECT_DIR}/.ci/does_image_exist.sh "${full_image_name}")
-    - echo "GPU image ${full_image_name} exists = ${GPU_REBUILD}"
-    - echo "CPU_REBUILD=${CPU_REBUILD}" > rebuild.env
-    - echo "GPU_COMPILER_REBUILD=${GPU_COMPILER_REBUILD}" >> rebuild.env
-    - echo "GPU_REBUILD=${GPU_REBUILD}" >> rebuild.env
+    - export GPU_EXISTS=$(sh ${CI_PROJECT_DIR}/.ci/does_image_exist.sh "${full_image_name}")
+    - echo "GPU image ${full_image_name} exists = ${GPU_EXISTS}"
+    - echo "CPU_EXISTS=${CPU_EXISTS}" > rebuild.env
+    - echo "GPU_COMPILER_EXISTS=${GPU_COMPILER_EXISTS}" >> rebuild.env
+    - echo "GPU_EXISTS=${GPU_EXISTS}" >> rebuild.env
   artifacts:
     reports:
       dotenv: rebuild.env
@@ -52,7 +52,7 @@ build-images:
   script:
     # cf. https://docs.gitlab.com/ee/ci/docker/using_kaniko.html
     - >
-      if [ $CPU_REBUILD == 1 ]; then
+      if [ $CPU_EXISTS == 0 ]; then
         mkdir -p /kaniko/.docker ;
         export CI_REGISTRY_LOCATION="https://index.docker.io/v1/" ;
         echo "{\"auths\":{\"$CI_REGISTRY_LOCATION\":{\"auth\":\"$(echo -n $CI_REGISTRY_USER:$CI_REGISTRY_PASSWORD | base64)\"}}}" > /kaniko/.docker/config.json ;
@@ -63,7 +63,7 @@ build-images:
         echo "No CPU image changes; skipping build."
       fi
     - >
-      if [ $GPU_COMPILER_REBUILD == 1 ]; then
+      if [ $GPU_COMPILER_EXISTS == 0 ]; then
         mkdir -p /kaniko/.docker ;
         export CI_REGISTRY_LOCATION="https://index.docker.io/v1/" ;
         echo "{\"auths\":{\"$CI_REGISTRY_LOCATION\":{\"auth\":\"$(echo -n $CI_REGISTRY_USER:$CI_REGISTRY_PASSWORD | base64)\"}}}" > /kaniko/.docker/config.json ;
@@ -74,7 +74,7 @@ build-images:
         echo "No GPU compiler image changes; skipping build."
       fi
     - >
-      if [ $GPU_REBUILD == 1 ]; then
+      if [ $GPU_EXISTS == 0 ]; then
         mkdir -p /kaniko/.docker ;
         export CI_REGISTRY_LOCATION="https://index.docker.io/v1/" ;
         echo "{\"auths\":{\"$CI_REGISTRY_LOCATION\":{\"auth\":\"$(echo -n $CI_REGISTRY_USER:$CI_REGISTRY_PASSWORD | base64)\"}}}" > /kaniko/.docker/config.json ;

--- a/gitlab-docker-images.yml
+++ b/gitlab-docker-images.yml
@@ -41,11 +41,12 @@ check-images:
     reports:
       dotenv: rebuild.env
 
-build-cpu-image:
+build-images:
   stage: build
   dependencies:
     - check-images
   allow_failure: false
+  timeout: 12 hours # building the compiler image may take a very long time
   variables:
     GIT_STRATEGY: clone
   script:
@@ -61,17 +62,6 @@ build-cpu-image:
       else
         echo "No CPU image changes; skipping build."
       fi
-
-build-gpu-image:
-  stage: build
-  timeout: 6 hours # building the compiler image may take a very long time
-  dependencies:
-    - check-images
-  allow_failure: false
-  variables:
-    GIT_STRATEGY: clone
-  script:
-    # cf. https://docs.gitlab.com/ee/ci/docker/using_kaniko.html
     - >
       if [ $GPU_COMPILER_REBUILD == 1 ]; then
         mkdir -p /kaniko/.docker ;
@@ -83,6 +73,7 @@ build-gpu-image:
       else
         echo "No GPU compiler image changes; skipping build."
       fi
+    - >
       if [ $GPU_REBUILD == 1 ]; then
         mkdir -p /kaniko/.docker ;
         export CI_REGISTRY_LOCATION="https://index.docker.io/v1/" ;

--- a/gitlab-docker-images.yml
+++ b/gitlab-docker-images.yml
@@ -1,63 +1,87 @@
 stages:
-    - build
+  - check
+  - build
 
-# (split this one here, if the nvidia docker container needs it)
 default:
   tags:
     - sccs
     - build
   image:
+    name: gcr.io/kaniko-project/executor:v1.14.0-debug
+    entrypoint: [""]
+
+check-images:
+  stage: check
+  allow_failure: false
+  tags:
+    - sccs
+    - helper
+  variables:
+    GIT_STRATEGY: clone
+  image:
     name: docker:24.0.5-git
     entrypoint: [""]
+  before_script:
+    - git branch -vva
+    - echo "$CI_REGISTRY_PASSWORD" | docker login -u "$CI_REGISTRY_USER" --password-stdin "$CI_REGISTRY"
+  script:
+    - export full_image_name="${CI_REGISTRY_USER}/${cpu_image_name}:${cpu_image_version}"
+    - export file_changed=$(sh ${CI_PROJECT_DIR}/.ci/is_changed.sh ${CI_PROJECT_DIR}/.ci/docker-cpu/Dockerfile.base)
+    - export image_exists=$(sh ${CI_PROJECT_DIR}/.ci/does_image_exist.sh "${full_image_name}")
+    - export CPU_REBUILD=$(($file_changed == 1 || $image_exists == 0))
+    - echo "file changed=${file_changed}, image exists=${image_exists}, cpu_rebuild=${CPU_REBUILD}"
+    - export full_image_name="${CI_REGISTRY_USER}/${gpu_image_name}:${gpu_image_version}"
+    - export file_changed=$(sh ${CI_PROJECT_DIR}/.ci/is_changed.sh ${CI_PROJECT_DIR}/.ci/docker-gpu)
+    - export image_exists=$(sh ${CI_PROJECT_DIR}/.ci/does_image_exist.sh "${full_image_name}")
+    - export GPU_REBUILD=$(($file_changed == 1 || $image_exists == 0))
+    - echo "file changed=${file_changed}, image exists=${image_exists}, gpu_rebuild=${GPU_REBUILD}"
+    - echo "CPU_REBUILD=${CPU_REBUILD}" > rebuild.env
+    - echo "GPU_REBUILD=${GPU_REBUILD}" >> rebuild.env
+  artifacts:
+    reports:
+      dotenv: rebuild.env
 
 build-cpu-image:
   stage: build
+  dependencies:
+    - check-images
   allow_failure: false
   variables:
     GIT_STRATEGY: clone
-  before_script:
-    - git branch -vva
-    - echo "$CI_REGISTRY_PASSWORD" | docker login -u "$CI_REGISTRY_USER" --password-stdin "$CI_REGISTRY"
   script:
-    # (cf. https://stackoverflow.com/a/957978 )
-    - export git_root=$(git rev-parse --show-toplevel)
-    - export full_image_name="${CI_REGISTRY_USER}/${cpu_image_name}:${cpu_image_version}"
-    - export file_changed=$(sh ${git_root}/.ci/is_changed.sh ${git_root}/.ci/docker-cpu/Dockerfile.base)
-    - export image_exists=$(sh ${git_root}/.ci/does_image_exist.sh "${full_image_name}")
-    - echo "file changed=${file_changed}, image exists=${image_exists}"
+    # cf. https://docs.gitlab.com/ee/ci/docker/using_kaniko.html
     - >
-      if [ $file_changed -eq 1 ] || [ $image_exists -eq 0 ]; then
-        echo "building a new image - ${full_image_name}" ;
-        docker build -t "${full_image_name}" -f ${git_root}/.ci/docker-cpu/Dockerfile.base . ;
-        docker push "${full_image_name}"
+      if [ $CPU_REBUILD == 1 ]; then
+        mkdir -p /kaniko/.docker ;
+        export CI_REGISTRY_LOCATION="https://index.docker.io/v1/" ;
+        echo "{\"auths\":{\"$CI_REGISTRY_LOCATION\":{\"auth\":\"$(echo -n $CI_REGISTRY_USER:$CI_REGISTRY_PASSWORD | base64)\"}}}" > /kaniko/.docker/config.json ;
+        export full_image_name="${CI_REGISTRY_USER}/${cpu_image_name}:${cpu_image_version}" ;
+        echo "Building CPU image: ${full_image_name} (published then using ${CI_REGISTRY_LOCATION} )" ;
+        /kaniko/executor --context "${CI_PROJECT_DIR}" --build-arg "SEISSOL_SHA_COMMIT=$CI_COMMIT_SHA" --dockerfile "${CI_PROJECT_DIR}/.ci/docker-cpu/Dockerfile.base" --destination "${full_image_name}" ;
       else
-        echo "image exists, Dockerfile was not modified. Skipping this step"
+        echo "No CPU image changes; skipping build."
       fi
-
 
 build-gpu-image:
   stage: build
+  dependencies:
+    - check-images
   allow_failure: false
   variables:
     GIT_STRATEGY: clone
-  before_script:
-    - git branch -vva
-    - pwd
-    - echo "$CI_REGISTRY_PASSWORD" | docker login -u "$CI_REGISTRY_USER" --password-stdin "$CI_REGISTRY"
   script:
-    # (cf. https://stackoverflow.com/a/957978 )
-    - export git_root=$(git rev-parse --show-toplevel)
-    - export full_image_name="${CI_REGISTRY_USER}/${gpu_image_name}:${gpu_image_version}"
-    - export full_compiler_image_name="${CI_REGISTRY_USER}/gpu-ci-compiler-image:${gpu_image_version}"
-    - export file_changed=$(sh ${git_root}/.ci/is_changed.sh ${git_root}/.ci/docker-gpu)
-    - export image_exists=$(sh ${git_root}/.ci/does_image_exist.sh "${full_image_name}")
-    - echo "file changed=${file_changed}, image exists=${image_exists}"
+    # cf. https://docs.gitlab.com/ee/ci/docker/using_kaniko.html
     - >
-      if [ $file_changed -eq 1 ] || [ $image_exists -eq 0 ]; then
-        echo "building a new image - ${full_image_name}" ;
-        docker build -t "${full_compiler_image_name}" -f ${git_root}/.ci/docker-gpu/Dockerfile.compilers . ;
-        docker build -t "${full_image_name}" --build-arg BASE_IMAGE_NAME=$full_compiler_image_name --build-arg SEISSOL_SHA_COMMIT=$CI_COMMIT_SHA -f ${git_root}/.ci/docker-gpu/Dockerfile.base . ;
-        docker push "${full_image_name}"
+      if [ $GPU_REBUILD == 1 ]; then
+        mkdir -p /kaniko/.docker ;
+        export CI_REGISTRY_LOCATION="https://index.docker.io/v1/" ;
+        echo "{\"auths\":{\"$CI_REGISTRY_LOCATION\":{\"auth\":\"$(echo -n $CI_REGISTRY_USER:$CI_REGISTRY_PASSWORD | base64)\"}}}" > /kaniko/.docker/config.json ;
+        export full_image_name="${CI_REGISTRY_USER}/${gpu_image_name}:${gpu_image_version}" ;
+        export full_compiler_image_name="${CI_REGISTRY_USER}/gpu-ci-compiler-image:${gpu_image_version}" ;
+        echo "Building GPU compiler image: ${full_compiler_image_name}" ;
+        /kaniko/executor --context "${CI_PROJECT_DIR}" --dockerfile "${CI_PROJECT_DIR}/.ci/docker-gpu/Dockerfile.compilers" --no-push --destination "${full_compiler_image_name}" ;
+        echo "Building GPU image: ${full_image_name} (published then using ${CI_REGISTRY_LOCATION} )" ;
+        /kaniko/executor --context "${CI_PROJECT_DIR}" --build-arg "BASE_IMAGE_NAME=$full_compiler_image_name" --build-arg "SEISSOL_SHA_COMMIT=$CI_COMMIT_SHA" --dockerfile "${CI_PROJECT_DIR}/.ci/docker-gpu/Dockerfile.base" --destination "${full_image_name}" ;
       else
-        echo "image exists, Dockerfile was not modified. Skipping this step"
+        echo "No GPU image changes; skipping build."
       fi

--- a/gitlab-docker-images.yml
+++ b/gitlab-docker-images.yml
@@ -26,16 +26,16 @@ check-images:
     - echo "$CI_REGISTRY_PASSWORD" | docker login -u "$CI_REGISTRY_USER" --password-stdin "$CI_REGISTRY"
   script:
     - export full_image_name="${CI_REGISTRY_USER}/${cpu_image_name}:${cpu_image_version}"
-    - export file_changed=$(sh ${CI_PROJECT_DIR}/.ci/is_changed.sh ${CI_PROJECT_DIR}/.ci/docker-cpu/Dockerfile.base)
-    - export image_exists=$(sh ${CI_PROJECT_DIR}/.ci/does_image_exist.sh "${full_image_name}")
-    - export CPU_REBUILD=$(($file_changed == 1 || $image_exists == 0))
-    - echo "file changed=${file_changed}, image exists=${image_exists}, cpu_rebuild=${CPU_REBUILD}"
+    - export CPU_REBUILD=$(sh ${CI_PROJECT_DIR}/.ci/does_image_exist.sh "${full_image_name}")
+    - echo "CPU image ${full_image_name} exists = ${image_exists}. Rebuild = ${CPU_REBUILD}"
+    - export full_compiler_image_name="${CI_REGISTRY_USER}/gpu-ci-compiler-image:${gpu_image_version}" ;
+    - export GPU_COMPILER_REBUILD=$(sh ${CI_PROJECT_DIR}/.ci/does_image_exist.sh "${full_compiler_image_name}")
+    - echo "GPU compiler image ${full_compiler_image_name} exists = ${GPU_COMPILER_REBUILD}"
     - export full_image_name="${CI_REGISTRY_USER}/${gpu_image_name}:${gpu_image_version}"
-    - export file_changed=$(sh ${CI_PROJECT_DIR}/.ci/is_changed.sh ${CI_PROJECT_DIR}/.ci/docker-gpu)
-    - export image_exists=$(sh ${CI_PROJECT_DIR}/.ci/does_image_exist.sh "${full_image_name}")
-    - export GPU_REBUILD=$(($file_changed == 1 || $image_exists == 0))
-    - echo "file changed=${file_changed}, image exists=${image_exists}, gpu_rebuild=${GPU_REBUILD}"
+    - export GPU_REBUILD=$(sh ${CI_PROJECT_DIR}/.ci/does_image_exist.sh "${full_image_name}")
+    - echo "GPU image ${full_image_name} exists = ${GPU_REBUILD}"
     - echo "CPU_REBUILD=${CPU_REBUILD}" > rebuild.env
+    - echo "GPU_COMPILER_REBUILD=${GPU_COMPILER_REBUILD}" >> rebuild.env
     - echo "GPU_REBUILD=${GPU_REBUILD}" >> rebuild.env
   artifacts:
     reports:
@@ -64,6 +64,7 @@ build-cpu-image:
 
 build-gpu-image:
   stage: build
+  timeout: 6 hours # building the compiler image may take a very long time
   dependencies:
     - check-images
   allow_failure: false
@@ -72,14 +73,22 @@ build-gpu-image:
   script:
     # cf. https://docs.gitlab.com/ee/ci/docker/using_kaniko.html
     - >
+      if [ $GPU_COMPILER_REBUILD == 1 ]; then
+        mkdir -p /kaniko/.docker ;
+        export CI_REGISTRY_LOCATION="https://index.docker.io/v1/" ;
+        echo "{\"auths\":{\"$CI_REGISTRY_LOCATION\":{\"auth\":\"$(echo -n $CI_REGISTRY_USER:$CI_REGISTRY_PASSWORD | base64)\"}}}" > /kaniko/.docker/config.json ;
+        export full_compiler_image_name="${CI_REGISTRY_USER}/gpu-ci-compiler-image:${gpu_image_version}" ;
+        echo "Building GPU compiler image: ${full_compiler_image_name} (published then using ${CI_REGISTRY_LOCATION} )" ;
+        /kaniko/executor --context "${CI_PROJECT_DIR}" --dockerfile "${CI_PROJECT_DIR}/.ci/docker-gpu/Dockerfile.compilers" --destination "${full_compiler_image_name}" ;
+      else
+        echo "No GPU compiler image changes; skipping build."
+      fi
       if [ $GPU_REBUILD == 1 ]; then
         mkdir -p /kaniko/.docker ;
         export CI_REGISTRY_LOCATION="https://index.docker.io/v1/" ;
         echo "{\"auths\":{\"$CI_REGISTRY_LOCATION\":{\"auth\":\"$(echo -n $CI_REGISTRY_USER:$CI_REGISTRY_PASSWORD | base64)\"}}}" > /kaniko/.docker/config.json ;
         export full_image_name="${CI_REGISTRY_USER}/${gpu_image_name}:${gpu_image_version}" ;
         export full_compiler_image_name="${CI_REGISTRY_USER}/gpu-ci-compiler-image:${gpu_image_version}" ;
-        echo "Building GPU compiler image: ${full_compiler_image_name}" ;
-        /kaniko/executor --context "${CI_PROJECT_DIR}" --dockerfile "${CI_PROJECT_DIR}/.ci/docker-gpu/Dockerfile.compilers" --no-push --destination "${full_compiler_image_name}" ;
         echo "Building GPU image: ${full_image_name} (published then using ${CI_REGISTRY_LOCATION} )" ;
         /kaniko/executor --context "${CI_PROJECT_DIR}" --build-arg "BASE_IMAGE_NAME=$full_compiler_image_name" --build-arg "SEISSOL_SHA_COMMIT=$CI_COMMIT_SHA" --dockerfile "${CI_PROJECT_DIR}/.ci/docker-gpu/Dockerfile.base" --destination "${full_image_name}" ;
       else

--- a/gitlab-docker-images.yml
+++ b/gitlab-docker-images.yml
@@ -5,7 +5,7 @@ stages:
 default:
   tags:
     - sccs
-    - build
+    - imagebuild
   image:
     name: gcr.io/kaniko-project/executor:v1.14.0-debug
     entrypoint: [""]

--- a/gitlab-gpu-pipeline.yml
+++ b/gitlab-gpu-pipeline.yml
@@ -1,7 +1,4 @@
 default:
-    tags:
-        - sccs
-        - helper
     image:
         name: $CI_REGISTRY_USER/$gpu_image_name:$gpu_image_version
         entrypoint: [""]
@@ -182,6 +179,9 @@ gpu_run_tpv:
 check_faultoutput:
     stage: check
     allow_failure: false
+    tags:
+        - sccs
+        - helper
     needs:
         - job: gpu_run_tpv
     variables:
@@ -206,6 +206,9 @@ check_faultoutput:
 check_receivers:
     stage: check
     allow_failure: false
+    tags:
+        - sccs
+        - helper
     needs:
         - job: gpu_run_tpv
     variables:
@@ -228,6 +231,9 @@ check_receivers:
 gpu_check_energies:
     stage: check
     allow_failure: false
+    tags:
+        - sccs
+        - helper
     needs:
         - job: gpu_run_tpv
     variables:

--- a/gitlab-gpu-pipeline.yml
+++ b/gitlab-gpu-pipeline.yml
@@ -7,7 +7,7 @@ default:
         entrypoint: [""]
 
 variables:
-    HOST: "wsm"
+    HOST: "snb"
     GPU_VENDOR: "nvidia"
     GPU_MODEL: "sm_60"
 

--- a/gitlab-gpu-pipeline.yml
+++ b/gitlab-gpu-pipeline.yml
@@ -4,7 +4,7 @@ default:
         entrypoint: [""]
 
 variables:
-    HOST: "snb"
+    HOST: "noarch" # actually possible: snb
     GPU_VENDOR: "nvidia"
     GPU_MODEL: "sm_60"
 


### PR DESCRIPTION
The image building now works again, thanks to replacing `docker build` by a call to Kaniko, basically building Docker images without a Docker socket in the background (so we don't have to install Docker on the CI node). With that, we've also fully ported our CI to the SCCS CI systems.

Also, we now only re-build the image, if the version number gets updated (and by nothing else). That's mostly to prevent the long times when re-building the GPU compiler image by accident.