### PR TITLE
Add NoRefiner

### DIFF
--- a/src/DynamicRupture/Output/FaultRefiner/FaultRefiners.cpp
+++ b/src/DynamicRupture/Output/FaultRefiner/FaultRefiners.cpp
@@ -51,9 +51,7 @@ void FaultRefiner::addReceiver(Data data, TrianglePair& face) {
   points.push_back(receiver);
 }
 
-void NoRefiner::refineAndAccumulate(Data data, TrianglePair face) {
-  addReceiver(data, face);
-}
+void NoRefiner::refineAndAccumulate(Data data, TrianglePair face) { addReceiver(data, face); }
 
 void FaultFaceTripleRefiner::refineAndAccumulate(Data data, TrianglePair face) {
 

--- a/src/DynamicRupture/Output/FaultRefiner/FaultRefiners.cpp
+++ b/src/DynamicRupture/Output/FaultRefiner/FaultRefiners.cpp
@@ -17,6 +17,7 @@ std::unique_ptr<FaultRefiner> get(seissol::initializer::parameters::FaultRefinem
   case seissol::initializer::parameters::FaultRefinement::None:
     return std::make_unique<NoRefiner>();
   default:
+    logError() << "Unknown refinement strategy for Fault Face Refiner";
     return nullptr;
   }
 }

--- a/src/DynamicRupture/Output/FaultRefiner/FaultRefiners.cpp
+++ b/src/DynamicRupture/Output/FaultRefiner/FaultRefiners.cpp
@@ -8,19 +8,6 @@
 #include "Initializer/Parameters/OutputParameters.h"
 
 namespace seissol::dr::output::refiner {
-seissol::initializer::parameters::FaultRefinement castToRefinerType(int strategy) {
-  switch (strategy) {
-  case 1:
-    return seissol::initializer::parameters::FaultRefinement::Triple;
-  case 2:
-    return seissol::initializer::parameters::FaultRefinement::Quad;
-  default:
-    logError() << "Unknown refinement strategy for Fault Face Refiner";
-    // return something to suppress a compiler warning
-    return seissol::initializer::parameters::FaultRefinement::None;
-  }
-}
-
 std::unique_ptr<FaultRefiner> get(seissol::initializer::parameters::FaultRefinement strategy) {
   switch (strategy) {
   case seissol::initializer::parameters::FaultRefinement::Triple:
@@ -28,6 +15,7 @@ std::unique_ptr<FaultRefiner> get(seissol::initializer::parameters::FaultRefinem
   case seissol::initializer::parameters::FaultRefinement::Quad:
     return std::make_unique<FaultFaceQuadRefiner>();
   case seissol::initializer::parameters::FaultRefinement::None:
+    return std::make_unique<NoRefiner>();
   default:
     return nullptr;
   }
@@ -60,6 +48,10 @@ void FaultRefiner::addReceiver(Data data, TrianglePair& face) {
   receiver.globalTriangle = std::get<global>(face);
 
   points.push_back(receiver);
+}
+
+void NoRefiner::refineAndAccumulate(Data data, TrianglePair face) {
+  addReceiver(data, face);
 }
 
 void FaultFaceTripleRefiner::refineAndAccumulate(Data data, TrianglePair face) {

--- a/src/DynamicRupture/Output/FaultRefiner/FaultRefiners.hpp
+++ b/src/DynamicRupture/Output/FaultRefiner/FaultRefiners.hpp
@@ -18,7 +18,7 @@ class FaultRefiner {
   using PointsPair = std::pair<ExtVrtxCoords, ExtVrtxCoords>;
   using TrianglePair = std::pair<ExtTriangle, ExtTriangle>;
 
-  virtual int getNumSubTriangles() = 0;
+  virtual int getNumSubTriangles() const = 0;
   virtual void refineAndAccumulate(Data data, TrianglePair face) = 0;
   virtual ~FaultRefiner() = default;
 
@@ -37,20 +37,20 @@ class FaultRefiner {
 
 class NoRefiner : public FaultRefiner {
   public:
-  int getNumSubTriangles() final { return 1; }
+  int getNumSubTriangles() const final { return 1; }
   void refineAndAccumulate(Data data, TrianglePair face) final;
 };
 
 
 class FaultFaceTripleRefiner : public FaultRefiner {
   public:
-  int getNumSubTriangles() final { return 3; }
+  int getNumSubTriangles() const final { return 3; }
   void refineAndAccumulate(Data data, TrianglePair face) final;
 };
 
 class FaultFaceQuadRefiner : public FaultRefiner {
   public:
-  int getNumSubTriangles() final { return 4; }
+  int getNumSubTriangles() const final { return 4; }
   void refineAndAccumulate(Data data, TrianglePair face) final;
 };
 

--- a/src/DynamicRupture/Output/FaultRefiner/FaultRefiners.hpp
+++ b/src/DynamicRupture/Output/FaultRefiner/FaultRefiners.hpp
@@ -35,6 +35,13 @@ class FaultRefiner {
   inline void addReceiver(Data data, TrianglePair& face);
 };
 
+class NoRefiner : public FaultRefiner {
+  public:
+  int getNumSubTriangles() final { return 1; }
+  void refineAndAccumulate(Data data, TrianglePair face) final;
+};
+
+
 class FaultFaceTripleRefiner : public FaultRefiner {
   public:
   int getNumSubTriangles() final { return 3; }
@@ -47,7 +54,6 @@ class FaultFaceQuadRefiner : public FaultRefiner {
   void refineAndAccumulate(Data data, TrianglePair face) final;
 };
 
-seissol::initializer::parameters::FaultRefinement castToRefinerType(int strategy);
 std::unique_ptr<FaultRefiner> get(seissol::initializer::parameters::FaultRefinement strategy);
 } // namespace seissol::dr::output::refiner
 #endif // SEISSOL_DR_OUTPUT_REFINERS_HPP

--- a/src/DynamicRupture/Output/FaultRefiner/FaultRefiners.hpp
+++ b/src/DynamicRupture/Output/FaultRefiner/FaultRefiners.hpp
@@ -41,7 +41,6 @@ class NoRefiner : public FaultRefiner {
   void refineAndAccumulate(Data data, TrianglePair face) final;
 };
 
-
 class FaultFaceTripleRefiner : public FaultRefiner {
   public:
   int getNumSubTriangles() const final { return 3; }


### PR DESCRIPTION
#1046 has revealed that omitting the `fault_refiner´ flag in the parameter file (or explicitly setting it to _no refinement_), causes SeisSol to crash. This PR adds the "NoRefiner", which just adds one receiver at the barycenter.