### PR TITLE
fix many clang warnings

### DIFF
--- a/src/Initializer/Parameters/LtsParameters.h
+++ b/src/Initializer/Parameters/LtsParameters.h
@@ -33,12 +33,12 @@ class LtsParameters {
   double wiggleFactorMinimum;
   double wiggleFactorStepsize;
   bool wiggleFactorEnforceMaximumDifference;
+  int maxNumberOfClusters = std::numeric_limits<int>::max() - 1;
   bool autoMergeClusters;
   double allowedPerformanceLossRatioAutoMerge;
   AutoMergeCostBaseline autoMergeCostBaseline = AutoMergeCostBaseline::BestWiggleFactor;
   LtsWeightsTypes ltsWeightsType;
   double finalWiggleFactor = 1.0;
-  int maxNumberOfClusters = std::numeric_limits<int>::max() - 1;
 
   public:
   [[nodiscard]] unsigned int getRate() const;

--- a/src/Initializer/Parameters/ParameterReader.h
+++ b/src/Initializer/Parameters/ParameterReader.h
@@ -111,8 +111,8 @@ class ParameterReader {
     }
   }
 
-  bool empty;
   YAML::Node node; // apparently the YAML nodes use a reference semantic. Hence, we do it like this.
+  bool empty;
   std::unordered_set<std::string> visited;
   std::unordered_map<std::string, std::shared_ptr<ParameterReader>> subreaders;
 };

--- a/src/Initializer/time_stepping/LtsLayout.cpp
+++ b/src/Initializer/time_stepping/LtsLayout.cpp
@@ -54,13 +54,13 @@
 #include <iomanip>
 
 seissol::initializer::time_stepping::LtsLayout::LtsLayout(const seissol::initializer::parameters::SeisSolParameters& parameters):
- seissolParams(parameters),
  m_cellClusterIds(           NULL ),
  m_globalTimeStepWidths(     NULL ),
  m_globalTimeStepRates(      NULL ),
  m_plainCopyRegions(         NULL ),
  m_numberOfPlainGhostCells(  NULL ),
- m_plainGhostCellClusterIds( NULL ) {}
+ m_plainGhostCellClusterIds( NULL ),
+ seissolParams(parameters) {}
 
 seissol::initializer::time_stepping::LtsLayout::~LtsLayout() {
   // free memory of member variables

--- a/src/Initializer/time_stepping/LtsWeights/LtsWeights.cpp
+++ b/src/Initializer/time_stepping/LtsWeights/LtsWeights.cpp
@@ -143,11 +143,10 @@ int computeMaxClusterIdAfterAutoMerge(const std::vector<int>& clusterIds,
 }
 
 LtsWeights::LtsWeights(const LtsWeightsConfig& config, seissol::SeisSol& seissolInstance)
-    : m_velocityModel(config.velocityModel), m_rate(config.rate),
+    : seissolInstance(seissolInstance), m_velocityModel(config.velocityModel), m_rate(config.rate),
       m_vertexWeightElement(config.vertexWeightElement),
       m_vertexWeightDynamicRupture(config.vertexWeightDynamicRupture),
-      m_vertexWeightFreeSurfaceWithGravity(config.vertexWeightFreeSurfaceWithGravity),
-      seissolInstance(seissolInstance) { }
+      m_vertexWeightFreeSurfaceWithGravity(config.vertexWeightFreeSurfaceWithGravity) { }
 
 void LtsWeights::computeWeights(PUML::TETPUML const& mesh, double maximumAllowedTimeStep) {
   const auto rank = seissol::MPI::mpi.rank();

--- a/src/Kernels/Receiver.h
+++ b/src/Kernels/Receiver.h
@@ -135,7 +135,6 @@ namespace seissol {
       }
 
     private:
-      seissol::SeisSol& seissolInstance;
       std::vector<Receiver> m_receivers;
       seissol::kernels::Time m_timeKernel;
       std::vector<unsigned> m_quantities;
@@ -144,6 +143,7 @@ namespace seissol {
       double m_samplingInterval;
       double m_syncPointInterval;
       bool m_computeRotation;
+      seissol::SeisSol& seissolInstance;
 
     };
   }

--- a/src/Monitoring/ActorStateStatistics.cpp
+++ b/src/Monitoring/ActorStateStatistics.cpp
@@ -4,8 +4,8 @@
 namespace seissol {
 
 ActorStateStatistics::ActorStateStatistics(unsigned globalClusterId, LoopStatistics& loopStatistics)
-    : currentSample(time_stepping::ActorState::Synced), loopStatistics(loopStatistics),
-      globalClusterId(globalClusterId) {}
+    : currentSample(time_stepping::ActorState::Synced), globalClusterId(globalClusterId),
+      loopStatistics(loopStatistics) {}
 
 void ActorStateStatistics::enter(time_stepping::ActorState actorState) {
   if (actorState == currentSample.state) {

--- a/src/Monitoring/ActorStateStatistics.h
+++ b/src/Monitoring/ActorStateStatistics.h
@@ -27,7 +27,6 @@ class ActorStateStatistics {
   };
 
   Sample currentSample;
-  bool started = false;
 
   unsigned globalClusterId;
   LoopStatistics& loopStatistics;

--- a/src/Monitoring/FlopCounter.cpp
+++ b/src/Monitoring/FlopCounter.cpp
@@ -61,7 +61,7 @@ namespace seissol::monitoring {
 void FlopCounter::init(std::string outputFileNamePrefix) {
   const std::string outputFileName = outputFileNamePrefix + "-flops.csv";
   const int rank = seissol::MPI::mpi.rank();
-  const int worldSize = seissol::MPI::mpi.size();
+  const size_t worldSize = static_cast<size_t>(seissol::MPI::mpi.size());
   if (rank == 0) {
     out.open(outputFileName);
     out << "time,";
@@ -76,7 +76,7 @@ void FlopCounter::init(std::string outputFileNamePrefix) {
 
 void FlopCounter::printPerformanceUpdate(double wallTime) {
   const int rank = seissol::MPI::mpi.rank();
-  const int worldSize = seissol::MPI::mpi.size();
+  const size_t worldSize = static_cast<size_t>(seissol::MPI::mpi.size());
 
   const long long newTotalFlops = hardwareFlopsLocal + hardwareFlopsNeighbor + hardwareFlopsOther +
                                   hardwareFlopsDynamicRupture + hardwareFlopsPlasticity;

--- a/src/Parallel/Pin.cpp
+++ b/src/Parallel/Pin.cpp
@@ -73,7 +73,7 @@ void Pinning::checkEnvVariables() {
 
       bool isMaskGood{true};
       const auto numLocalProcesses = MPI::mpi.sharedMemMpiSize();
-      if (numLocalProcesses > parsedFreeCPUsMask.size()) {
+      if (numLocalProcesses > static_cast<int>(parsedFreeCPUsMask.size())) {
         logInfo(rank) << "There are more communication (and/or output-writing) threads"
                       << "to pin than locations defined in `SEISSOL_FREE_CPUS_MASK`";
 
@@ -81,7 +81,7 @@ void Pinning::checkEnvVariables() {
       }
       else {
         const auto maxCpuId = get_nprocs();
-        for (auto localProcessId = 0; localProcessId < parsedFreeCPUsMask.size(); ++localProcessId) {
+        for (auto localProcessId = 0; localProcessId < static_cast<int>(parsedFreeCPUsMask.size()); ++localProcessId) {
           for (auto cpu : parsedFreeCPUsMask[localProcessId]) {
             if (cpu > maxCpuId) {
               logInfo(rank) << "Free cpu mask of the local process"

--- a/src/Physics/InitialField.cpp
+++ b/src/Physics/InitialField.cpp
@@ -298,7 +298,6 @@ void seissol::physics::PressureInjection::evaluate(
     const auto x_2 = x[1];
     const auto x_3 = x[2];
     const auto r_squared = std::pow(x_1 - o_1, 2) + std::pow(x_2 - o_2, 2) + std::pow(x_3 - o_3, 2);
-    const auto t = time;
     dofsQp(i, 0) = 0.0;                                      // sigma_xx
     dofsQp(i, 1) = 0.0;                                      // sigma_yy
     dofsQp(i, 2) = 0.0;                                      // sigma_yy

--- a/src/ResultWriter/PostProcessor.cpp
+++ b/src/ResultWriter/PostProcessor.cpp
@@ -52,13 +52,11 @@ void seissol::writer::PostProcessor::integrateQuantities(const double i_timestep
 }
 
 void seissol::writer::PostProcessor::setIntegrationMask(const std::array<bool, 9>& i_integrationMask) {
-	unsigned int nextId = 0;
 	for (int i = 0; i < 9; i++) {
 		m_integrationMask[i] = i_integrationMask[i];
 		if (m_integrationMask[i]) {
 			m_integerMap.push_back(i);
 			m_numberOfVariables++;
-			nextId++;
 		}
 	}
 	m_integrals.count = m_numberOfVariables;

--- a/src/Solver/time_stepping/AbstractTimeCluster.cpp
+++ b/src/Solver/time_stepping/AbstractTimeCluster.cpp
@@ -11,8 +11,8 @@ double AbstractTimeCluster::timeStepSize() const {
 }
 
 AbstractTimeCluster::AbstractTimeCluster(double maxTimeStepSize, long timeStepRate)
-    : timeStepRate(timeStepRate), numberOfTimeSteps(0),
-      timeOfLastStageChange(std::chrono::steady_clock::now()) {
+    : timeOfLastStageChange(std::chrono::steady_clock::now()),
+      timeStepRate(timeStepRate), numberOfTimeSteps(0) {
   ct.maxTimeStepSize = maxTimeStepSize;
   ct.timeStepRate = timeStepRate;
 }

--- a/src/Solver/time_stepping/MiniSeisSol.cpp
+++ b/src/Solver/time_stepping/MiniSeisSol.cpp
@@ -274,7 +274,7 @@ double seissol::miniSeisSol(initializer::MemoryManager& memoryManager, bool useP
 
   Stopwatch stopwatch;
   stopwatch.start();
-  for (unsigned t = 0; t < config.numRepeats; ++t) {
+  for (int t = 0; t < config.numRepeats; ++t) {
     runBenchmark();
   }
   syncBenchmark();

--- a/src/Solver/time_stepping/TimeCluster.cpp
+++ b/src/Solver/time_stepping/TimeCluster.cpp
@@ -109,6 +109,7 @@ seissol::time_stepping::TimeCluster::TimeCluster(unsigned int i_clusterId, unsig
     AbstractTimeCluster(maxTimeStepSize, timeStepRate),
     // cluster ids
     usePlasticity(usePlasticity),
+    seissolInstance(seissolInstance),
     m_globalDataOnHost( i_globalData.onHost ),
     m_globalDataOnDevice(i_globalData.onDevice ),
     m_clusterData(i_clusterData),
@@ -129,8 +130,7 @@ seissol::time_stepping::TimeCluster::TimeCluster(unsigned int i_clusterId, unsig
     m_clusterId(i_clusterId),
     m_globalClusterId(i_globalClusterId),
     m_profilingId(profilingId),
-    dynamicRuptureScheduler(dynamicRuptureScheduler),
-    seissolInstance(seissolInstance)
+    dynamicRuptureScheduler(dynamicRuptureScheduler)
 {
     // assert all pointers are valid
     assert( m_clusterData                              != nullptr );

--- a/src/Solver/time_stepping/TimeManager.cpp
+++ b/src/Solver/time_stepping/TimeManager.cpp
@@ -50,8 +50,8 @@
 #include "Parallel/Helper.hpp"
 
 seissol::time_stepping::TimeManager::TimeManager(seissol::SeisSol& seissolInstance):
-  seissolInstance(seissolInstance),
-  m_logUpdates(std::numeric_limits<unsigned int>::max()), actorStateStatisticsManager(m_loopStatistics)
+  m_logUpdates(std::numeric_limits<unsigned int>::max()), seissolInstance(seissolInstance),
+   actorStateStatisticsManager(m_loopStatistics)
 {
   m_loopStatistics.addRegion("computeLocalIntegration");
   m_loopStatistics.addRegion("computeNeighboringIntegration");


### PR DESCRIPTION
Mostly warnings of  this kind:
```
/export/dump/ulrich/myLibs/seissol/src/Initializer/time_stepping/LtsLayout.cpp:57:2: warning: field 'seissolParams' will be initialized after field 'm_cellClusterIds' [-Wreorder-ctor]
   57 |  seissolParams(parameters),
      |  ^~~~~~~~~~~~~~~~~~~~~~~~~
      |  m_cellClusterIds(           NULL )
   58 |  m_cellClusterIds(           NULL ),
      |  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |  m_globalTimeStepWidths(     NULL )
   59 |  m_globalTimeStepWidths(     NULL ),
      |  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |  m_globalTimeStepRates(      NULL )
   60 |  m_globalTimeStepRates(      NULL ),
      |  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |  m_plainCopyRegions(         NULL )
   61 |  m_plainCopyRegions(         NULL ),
      |  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |  m_numberOfPlainGhostCells(  NULL )
   62 |  m_numberOfPlainGhostCells(  NULL ),
      |  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |  m_plainGhostCellClusterIds( NULL )
   63 |  m_plainGhostCellClusterIds( NULL ) {}
      |  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |  seissolParams(parameters)
```
but also unused variables and different type comparisons.
