### PR TITLE
Add a Data Collector Class

### DIFF
--- a/.ci/format.sh
+++ b/.ci/format.sh
@@ -54,6 +54,7 @@ format() {
         src/Geometry/CubeGenerator.cpp
         src/Parallel/AcceleratorDevice.h
         src/Parallel/AcceleratorDevice.cpp
+        src/Parallel/DataCollector.h
         src/Parallel/Helper.hpp
         src/ResultWriter/WaveFieldWriter.h
         src/ResultWriter/EnergyOutput.h

--- a/src/DynamicRupture/Output/Builders/ReceiverBasedOutputBuilder.cpp
+++ b/src/DynamicRupture/Output/Builders/ReceiverBasedOutputBuilder.cpp
@@ -108,21 +108,21 @@ void ReceiverBasedOutputBuilder::initBasisFunctions() {
   outputData->cellCount = elementIndices.size() + elementIndicesGhost.size();
 
 #ifdef ACL_DEVICE
-  std::vector<real*> preDofPtr(outputData->cellCount);
+  std::vector<real*> indexPtrs(outputData->cellCount);
 
   for (const auto& [index, arrayIndex] : elementIndices) {
-    preDofPtr[arrayIndex] = wpLut->lookup(wpDescr->derivatives, index);
-    assert(preDofPtr[arrayIndex] != nullptr);
+    indexPtrs[arrayIndex] = wpLut->lookup(wpDescr->derivatives, index);
+    assert(indexPtrs[arrayIndex] != nullptr);
   }
   for (const auto& [_, ghost] : elementIndicesGhost) {
     const auto neighbor = ghost.data;
     const auto arrayIndex = ghost.index + elementIndices.size();
-    preDofPtr[arrayIndex] = wpLut->lookup(wpDescr->faceNeighbors, neighbor.first)[neighbor.second];
-    assert(preDofPtr[arrayIndex] != nullptr);
+    indexPtrs[arrayIndex] = wpLut->lookup(wpDescr->faceNeighbors, neighbor.first)[neighbor.second];
+    assert(indexPtrs[arrayIndex] != nullptr);
   }
 
   outputData->deviceDataCollector =
-      std::make_unique<seissol::parallel::DataCollector>(preDofPtr, seissol::tensor::Q::size());
+      std::make_unique<seissol::parallel::DataCollector>(indexPtrs, seissol::tensor::Q::size());
 #endif
 
   outputData->deviceDataPlus.resize(foundPoints);

--- a/src/DynamicRupture/Output/DataTypes.hpp
+++ b/src/DynamicRupture/Output/DataTypes.hpp
@@ -7,6 +7,7 @@
 #include "generated_code/tensor.h"
 #include <Eigen/Dense>
 #include <Initializer/Parameters/DRParameters.h>
+#include <Parallel/DataCollector.h>
 #include <array>
 #include <cassert>
 #include <cstring>
@@ -128,7 +129,7 @@ struct ReceiverOutputData {
   size_t maxCacheLevel{50};
   bool isActive{false};
 
-  real** deviceDataPtr{nullptr};
+  std::unique_ptr<parallel::DataCollector> deviceDataCollector;
   std::vector<std::size_t> deviceDataPlus;
   std::vector<std::size_t> deviceDataMinus;
   std::size_t cellCount{0};

--- a/src/DynamicRupture/Output/OutputManager.cpp
+++ b/src/DynamicRupture/Output/OutputManager.cpp
@@ -238,7 +238,6 @@ void OutputManager::init() {
   if (ppOutputBuilder) {
     initPickpointOutput();
   }
-  impl->allocateMemory({ppOutputData, ewOutputData});
 }
 
 void OutputManager::initFaceToLtsMap() {

--- a/src/DynamicRupture/Output/ReceiverBasedOutput.cpp
+++ b/src/DynamicRupture/Output/ReceiverBasedOutput.cpp
@@ -59,7 +59,7 @@ void ReceiverOutput::calcFaultOutput(
 
 #ifdef ACL_DEVICE
   void* stream = device::DeviceInstance::getInstance().api->getDefaultStream();
-  outputData->deviceDataCollector->gather(stream);
+  outputData->deviceDataCollector->gatherToHost(stream);
   device::DeviceInstance::getInstance().api->syncDefaultStreamWithHost();
 #endif
 

--- a/src/DynamicRupture/Output/ReceiverBasedOutput.cpp
+++ b/src/DynamicRupture/Output/ReceiverBasedOutput.cpp
@@ -46,30 +46,6 @@ void ReceiverOutput::getNeighbourDofs(real dofs[tensor::Q::size()], int meshId, 
 #endif
 }
 
-void ReceiverOutput::allocateMemory(
-    const std::vector<std::shared_ptr<ReceiverOutputData>>& states) {
-#ifdef ACL_DEVICE
-  std::size_t maxCellCount = 0;
-  for (const auto& state : states) {
-    if (state) {
-      maxCellCount = std::max(state->cellCount, maxCellCount);
-    }
-  }
-  deviceCopyMemory =
-      reinterpret_cast<real*>(device::DeviceInstance::getInstance().api->allocPinnedMem(
-          sizeof(real) * tensor::Q::size() * maxCellCount));
-#endif
-}
-
-ReceiverOutput::~ReceiverOutput() {
-  if (deviceCopyMemory != nullptr) {
-#ifdef ACL_DEVICE
-    device::DeviceInstance::getInstance().api->freePinnedMem(deviceCopyMemory);
-#endif
-    deviceCopyMemory = nullptr;
-  }
-}
-
 void ReceiverOutput::calcFaultOutput(
     seissol::initializer::parameters::OutputType outputType,
     seissol::initializer::parameters::SlipRateOutputType slipRateOutputType,
@@ -82,16 +58,9 @@ void ReceiverOutput::calcFaultOutput(
   const auto faultInfos = meshReader->getFault();
 
 #ifdef ACL_DEVICE
-  if (outputData->cellCount > 0) {
-    void* stream = device::DeviceInstance::getInstance().api->getDefaultStream();
-    device::DeviceInstance::getInstance().algorithms.copyScatterToUniform(outputData->deviceDataPtr,
-                                                                          deviceCopyMemory,
-                                                                          tensor::Q::size(),
-                                                                          tensor::Q::size(),
-                                                                          outputData->cellCount,
-                                                                          stream);
-    device::DeviceInstance::getInstance().api->syncDefaultStreamWithHost();
-  }
+  void* stream = device::DeviceInstance::getInstance().api->getDefaultStream();
+  outputData->deviceDataCollector->gather(stream);
+  device::DeviceInstance::getInstance().api->syncDefaultStreamWithHost();
 #endif
 
 #if defined(_OPENMP) && !NVHPC_AVOID_OMP
@@ -122,8 +91,8 @@ void ReceiverOutput::calcFaultOutput(
 
 #ifdef ACL_DEVICE
     {
-      real* dofsPlusData = deviceCopyMemory + tensor::Q::size() * outputData->deviceDataPlus[i];
-      real* dofsMinusData = deviceCopyMemory + tensor::Q::size() * outputData->deviceDataMinus[i];
+      real* dofsPlusData = outputData->deviceDataCollector->get(outputData->deviceDataPlus[i]);
+      real* dofsMinusData = outputData->deviceDataCollector->get(outputData->deviceDataMinus[i]);
 
       std::memcpy(dofsPlus, dofsPlusData, sizeof(dofsPlus));
       std::memcpy(dofsMinus, dofsMinusData, sizeof(dofsMinus));

--- a/src/DynamicRupture/Output/ReceiverBasedOutput.hpp
+++ b/src/DynamicRupture/Output/ReceiverBasedOutput.hpp
@@ -14,7 +14,7 @@
 namespace seissol::dr::output {
 class ReceiverOutput {
   public:
-  virtual ~ReceiverOutput();
+  virtual ~ReceiverOutput() = default;
 
   void setLtsData(seissol::initializer::LTSTree* userWpTree,
                   seissol::initializer::LTS* userWpDescr,
@@ -22,7 +22,6 @@ class ReceiverOutput {
                   seissol::initializer::LTSTree* userDrTree,
                   seissol::initializer::DynamicRupture* userDrDescr);
 
-  void allocateMemory(const std::vector<std::shared_ptr<ReceiverOutputData>>& states);
   void setMeshReader(seissol::geometry::MeshReader* userMeshReader) { meshReader = userMeshReader; }
   void setFaceToLtsMap(FaceToLtsMapType* map) { faceToLtsMap = map; }
   void calcFaultOutput(seissol::initializer::parameters::OutputType outputType,

--- a/src/Kernels/Receiver.cpp
+++ b/src/Kernels/Receiver.cpp
@@ -85,7 +85,7 @@ double seissol::kernels::ReceiverCluster::calcReceivers(  double time,
 #ifdef ACL_DEVICE
   if (deviceCollector.get() == nullptr) {
     deviceIndices.resize(m_receivers.size());
-    std::vector<real*> dofs(m_receivers.size());
+    std::vector<real*> dofs;
     std::unordered_map<real*, size_t> indexMap;
     for (size_t i = 0; i < m_receivers.size(); ++i) {
       real* currentDofs = m_receivers[i].data.dofs();

--- a/src/Kernels/Receiver.cpp
+++ b/src/Kernels/Receiver.cpp
@@ -45,10 +45,12 @@
 #include <Parallel/DataCollector.h>
 #include <Parallel/MPI.h>
 #include <SeisSol.h>
-#include <device.h>
 #include <generated_code/kernel.h>
-#include <optional>
 #include <unordered_map>
+
+#ifdef ACL_DEVICE
+#include <device.h>
+#endif
 
 void seissol::kernels::ReceiverCluster::addReceiver(  unsigned                          meshId,
                                                       unsigned                          pointId,

--- a/src/Kernels/Receiver.h
+++ b/src/Kernels/Receiver.h
@@ -136,6 +136,9 @@ namespace seissol {
         return 1 + ncols;
       }
 
+      void allocateData();
+      void freeData();
+
     private:
       std::unique_ptr<seissol::parallel::DataCollector> deviceCollector{nullptr};
       std::vector<size_t> deviceIndices;

--- a/src/Kernels/Receiver.h
+++ b/src/Kernels/Receiver.h
@@ -49,7 +49,9 @@
 #include <Kernels/Time.h>
 #include <Numerical_aux/BasisFunction.h>
 #include <Numerical_aux/Transformation.h>
+#include <Parallel/DataCollector.h>
 #include <generated_code/init.h>
+#include <optional>
 #include <vector>
 
 struct GlobalData;
@@ -135,6 +137,7 @@ namespace seissol {
       }
 
     private:
+      std::optional<parallel::DataCollector> deviceCollector;
       std::vector<Receiver> m_receivers;
       seissol::kernels::Time m_timeKernel;
       std::vector<unsigned> m_quantities;

--- a/src/Kernels/Receiver.h
+++ b/src/Kernels/Receiver.h
@@ -137,7 +137,8 @@ namespace seissol {
       }
 
     private:
-      std::optional<parallel::DataCollector> deviceCollector;
+      std::unique_ptr<seissol::parallel::DataCollector> deviceCollector{nullptr};
+      std::vector<size_t> deviceIndices;
       std::vector<Receiver> m_receivers;
       seissol::kernels::Time m_timeKernel;
       std::vector<unsigned> m_quantities;

--- a/src/Parallel/DataCollector.h
+++ b/src/Parallel/DataCollector.h
@@ -1,0 +1,83 @@
+#ifndef SEISSOL_PARALLEL_DATACOLLECTOR_H
+#define SEISSOL_PARALLEL_DATACOLLECTOR_H
+
+#include <cstddef>
+#include <vector>
+
+#include "Kernels/precision.hpp"
+#include "device.h"
+
+namespace seissol::parallel {
+
+class DataCollector {
+  public:
+  DataCollector(const std::vector<real*>& indexDataHost,
+                size_t elemSize,
+                bool hostAccessible = false)
+      : indexCount(indexDataHost.size()), indexDataHost(indexDataHost), elemSize(elemSize),
+        hostAccessible(hostAccessible) {
+#ifndef ACL_DEVICE
+    hostAccessible = true;
+#endif
+    if (!hostAccessible) {
+#ifdef ACL_DEVICE
+      indexDataDevice = reinterpret_cast<real**>(
+          device::DeviceInstance::getInstance().api->allocGlobMem(sizeof(real*) * indexCount));
+      device::DeviceInstance::getInstance().api->copyTo(
+          indexDataDevice, indexDataHost.data(), sizeof(real*) * indexCount);
+      copiedData =
+          reinterpret_cast<real*>(device::DeviceInstance::getInstance().api->allocPinnedMem(
+              sizeof(real) * elemSize * indexCount));
+#endif
+    }
+  }
+
+  DataCollector(const DataCollector&) = delete;
+
+  ~DataCollector() {
+    if (!hostAccessible) {
+#ifdef ACL_DEVICE
+      device::DeviceInstance::getInstance().api->freeMem(indexDataDevice);
+      device::DeviceInstance::getInstance().api->freePinnedMem(copiedData);
+#endif
+    }
+  }
+
+  void gather(void* stream) {
+    if (!hostAccessible) {
+#ifdef ACL_DEVICE
+      device::DeviceInstance::getInstance().algorithms.copyScatterToUniform(
+          indexDataDevice, copiedData, elemSize, elemSize, indexCount, stream);
+#endif
+    }
+  }
+
+  void scatter(void* stream) {
+    if (!hostAccessible) {
+#ifdef ACL_DEVICE
+      device::DeviceInstance::getInstance().algorithms.copyUniformToScatter(
+          copiedData, indexDataDevice, elemSize, elemSize, indexCount, stream);
+#endif
+    }
+  }
+
+  real* get(size_t index) {
+    if (hostAccessible) {
+      return indexDataHost[index];
+    } else {
+      return copiedData + index * elemSize;
+    }
+  }
+
+  private:
+  bool hostAccessible;
+  real** indexDataDevice;
+  std::vector<real*> indexDataHost;
+  size_t indexCount;
+  size_t elemSize;
+  real* copiedData;
+};
+
+} // namespace seissol::parallel
+
+#endif // SEISSOL_PARALLEL_DATACOLLECTOR_H

--- a/src/Parallel/DataCollector.h
+++ b/src/Parallel/DataCollector.h
@@ -19,7 +19,7 @@ class DataCollector {
 #ifndef ACL_DEVICE
     hostAccessible = true;
 #endif
-    if (!hostAccessible) {
+    if (!hostAccessible && indexCount > 0) {
 #ifdef ACL_DEVICE
       indexDataDevice = reinterpret_cast<real**>(
           device::DeviceInstance::getInstance().api->allocGlobMem(sizeof(real*) * indexCount));
@@ -35,7 +35,7 @@ class DataCollector {
   DataCollector(const DataCollector&) = delete;
 
   ~DataCollector() {
-    if (!hostAccessible) {
+    if (!hostAccessible && indexCount > 0) {
 #ifdef ACL_DEVICE
       device::DeviceInstance::getInstance().api->freeMem(indexDataDevice);
       device::DeviceInstance::getInstance().api->freePinnedMem(copiedData);
@@ -44,7 +44,7 @@ class DataCollector {
   }
 
   void gather(void* stream) {
-    if (!hostAccessible) {
+    if (!hostAccessible && indexCount > 0) {
 #ifdef ACL_DEVICE
       device::DeviceInstance::getInstance().algorithms.copyScatterToUniform(
           indexDataDevice, copiedData, elemSize, elemSize, indexCount, stream);
@@ -53,7 +53,7 @@ class DataCollector {
   }
 
   void scatter(void* stream) {
-    if (!hostAccessible) {
+    if (!hostAccessible && indexCount > 0) {
 #ifdef ACL_DEVICE
       device::DeviceInstance::getInstance().algorithms.copyUniformToScatter(
           copiedData, indexDataDevice, elemSize, elemSize, indexCount, stream);

--- a/src/Parallel/DataCollector.h
+++ b/src/Parallel/DataCollector.h
@@ -5,7 +5,10 @@
 #include <vector>
 
 #include "Kernels/precision.hpp"
+
+#ifdef ACL_DEVICE
 #include "device.h"
+#endif
 
 namespace seissol::parallel {
 

--- a/src/ResultWriter/ReceiverWriter.cpp
+++ b/src/ResultWriter/ReceiverWriter.cpp
@@ -179,7 +179,9 @@ void seissol::writer::ReceiverWriter::init(const std::string& fileNamePrefix, do
   m_samplingInterval = parameters.samplingInterval;
   m_computeRotation = parameters.computeRotation;
   setSyncInterval(std::min(endTime, parameters.interval));
+  Modules::registerHook(*this, ModuleHook::SimulationStart);
   Modules::registerHook(*this, ModuleHook::SynchronizationPoint);
+  Modules::registerHook(*this, ModuleHook::Shutdown);
 }
 
 void seissol::writer::ReceiverWriter::addPoints(seissol::geometry::MeshReader const& mesh,
@@ -230,6 +232,22 @@ void seissol::writer::ReceiverWriter::addPoints(seissol::geometry::MeshReader co
 
       writeHeader(point, points[point]);
       m_receiverClusters[layer][cluster].addReceiver(meshId, point, points[point], mesh, ltsLut, lts);
+    }
+  }
+}
+
+void seissol::writer::ReceiverWriter::simulationStart() {
+  for (auto& [layer, clusters] : m_receiverClusters) {
+    for (auto& cluster : clusters) {
+      cluster.allocateData();
+    }
+  }
+}
+
+void seissol::writer::ReceiverWriter::shutdown() {
+  for (auto& [layer, clusters] : m_receiverClusters) {
+    for (auto& cluster : clusters) {
+      cluster.freeData();
     }
   }
 }

--- a/src/ResultWriter/ReceiverWriter.h
+++ b/src/ResultWriter/ReceiverWriter.h
@@ -92,6 +92,8 @@ namespace seissol::writer {
       // Hooks
       //
       void syncPoint(double) override;
+      void simulationStart() override;
+      void shutdown() override;
 
     private:
       [[nodiscard]] std::string fileName(unsigned pointId) const;


### PR DESCRIPTION
Unifies the output for the receivers in the DR and the wave propagation part (since: we have a (usually sparse) gather operation of some device memory in both cases).

Plus, less stream/queue syncs for multiple receivers.