### PR TITLE
Change boundary format inference rules

### DIFF
--- a/Documentation/fault-tagging.rst
+++ b/Documentation/fault-tagging.rst
@@ -70,10 +70,10 @@ However, to prevent mistakes with reading the format, we nevertheless recommend 
 
 To do that, it suffices to specify ``pumlboundaryformat = $option`` in the ``&meshnml`` section of your SeisSol parameter file, where ``$option`` is one of the following:
 
-- ``'auto'``: SeisSol will try to infer the boundary format automatically. This is the default option.
+- ``'auto'``: SeisSol will try to infer the boundary format automatically. This is the default option. That is, if an attribute ``boundary-format`` is present, its value will be used (``i32x4 == 0``, ``i32 == 1``, ``i64 == 2``). Otherwise, the type will be inferred from the rank of the boundary storage array: if it is two-dimensional, then we choose ``i32x4``; if it is rank 1, then we choose ``i32`` (note that ``i64`` will not be chosen automatically in this case).
 - ``'i32'``: 8 bits per boundary face. That is, 189 dynamic rupture tags are possible (255 boundary condition types). It is (usually) stored as a one-dimensional 32-bit integer array (one entry per cell) in the Hdf5/binary file.
 - ``'i64'``: 16 bits per boundary face. That is, 65469 dynamic rupture tags (65535 boundary condition types). It is stored as a one-dimensional 64-bit integer array (one entry per cell) in the Hdf5/binary file.
 - ``'i32x4'``: 32 bits per boundary face. In short, you will have :math:`2^{32} - 65` different dynamic rupture tags available. The data is stored as a two-dimensional array (four entries per cell, one for each face) of 32-bit integers.
 
-To see which boundary format you have built your mesh for, you can use ``h5dump -H <yourmeshfile>.puml.h5``,
-and look at the datatype and the shape of the ``boundary`` dataset.
+To approximately see which boundary format you have built your mesh for, you can use ``h5dump -H <yourmeshfile>.puml.h5``,
+and look at the datatype and the shape of the ``boundary`` dataset. Note however, that some libraries may store ``i32`` boundaries in a 64-bit integer.

--- a/Documentation/fault-tagging.rst
+++ b/Documentation/fault-tagging.rst
@@ -75,5 +75,5 @@ To do that, it suffices to specify ``pumlboundaryformat = $option`` in the ``&me
 - ``'i64'``: 16 bits per boundary face. That is, 65469 dynamic rupture tags (65535 boundary condition types). It is stored as a one-dimensional 64-bit integer array (one entry per cell) in the Hdf5/binary file.
 - ``'i32x4'``: 32 bits per boundary face. In short, you will have :math:`2^{32} - 65` different dynamic rupture tags available. The data is stored as a two-dimensional array (four entries per cell, one for each face) of 32-bit integers.
 
-To approximately see which boundary format you have built your mesh for, you can use ``h5dump -H <yourmeshfile>.puml.h5``,
+To try inferring which boundary format you have built your mesh for (in case it is not indicated by an attribute), you can use ``h5dump -H <yourmeshfile>.puml.h5``,
 and look at the datatype and the shape of the ``boundary`` dataset. Note however, that some libraries may store ``i32`` boundaries in a 64-bit integer.

--- a/src/Initializer/InitProcedure/InitMesh.cpp
+++ b/src/Initializer/InitProcedure/InitMesh.cpp
@@ -107,25 +107,44 @@ static void readMeshPUML(const seissol::initializer::parameters::SeisSolParamete
     _eh(H5Pset_fapl_mpio(plist_id, seissol::MPI::mpi.comm(), info));
     hid_t dataFile =
         _eh(H5Fopen(seissolParams.mesh.meshFileName.c_str(), H5F_ACC_RDONLY, plist_id));
-    hid_t boundaryDataset = _eh(H5Dopen2(dataFile, "boundary", H5P_DEFAULT));
-    hid_t boundaryType = _eh(H5Dget_type(boundaryDataset));
-    hid_t boundarySpace = _eh(H5Dget_space(boundaryDataset));
+    hid_t existenceTest = _eh(H5Lexists(dataFile, "boundary-format", H5P_DEFAULT));
+    if (existenceTest > 0) {
+      logInfo(rank) << "Boundary format given in PUML file.";
+      hid_t boundaryAttribute = _eh(H5Aopen(dataFile, "boundary-format", H5P_DEFAULT));
 
-    auto boundaryTypeSize = _eh(H5Tget_size(boundaryType));
-    auto boundaryTypeRank = _eh(H5Sget_simple_extent_ndims(boundarySpace));
+      int format;
+      _eh(H5Aread(boundaryAttribute, H5T_NATIVE_INT, &format));
+      _eh(H5Aclose(boundaryAttribute));
+      if (format == 0) {
+        boundaryFormat = seissol::initializer::parameters::BoundaryFormat::I32x4;
+      } else if (format == 2) {
+        boundaryFormat = seissol::initializer::parameters::BoundaryFormat::I64;
+      } else if (format == 1) {
+        boundaryFormat = seissol::initializer::parameters::BoundaryFormat::I32;
+      } else {
+        logError() << "Unkown boundary format given in PUML file:" << format;
+      }
+    } else {
+      logInfo(rank) << "Boundary format not given in PUML file; inferring from array shape.";
+      hid_t boundaryDataset = _eh(H5Dopen2(dataFile, "boundary", H5P_DEFAULT));
+      hid_t boundarySpace = _eh(H5Dget_space(boundaryDataset));
+      auto boundaryTypeRank = _eh(H5Sget_simple_extent_ndims(boundarySpace));
 
-    _eh(H5Sclose(boundarySpace));
-    _eh(H5Dclose(boundaryDataset));
+      _eh(H5Sclose(boundarySpace));
+      _eh(H5Dclose(boundaryDataset));
+
+      // avoid checking the type size here
+      if (boundaryTypeRank == 2) {
+        boundaryFormat = seissol::initializer::parameters::BoundaryFormat::I32x4;
+      } else if (boundaryTypeRank == 1) {
+        boundaryFormat = seissol::initializer::parameters::BoundaryFormat::I32;
+      } else {
+        logError() << "Unknown boundary format of rank" << boundaryTypeRank;
+      }
+    }
+
     _eh(H5Fclose(dataFile));
     _eh(H5Pclose(plist_id));
-
-    if (boundaryTypeRank == 2) {
-      boundaryFormat = seissol::initializer::parameters::BoundaryFormat::I32x4;
-    } else if (boundaryTypeSize > 4) {
-      boundaryFormat = seissol::initializer::parameters::BoundaryFormat::I64;
-    } else {
-      boundaryFormat = seissol::initializer::parameters::BoundaryFormat::I32;
-    }
   }
 
   if (boundaryFormat == seissol::initializer::parameters::BoundaryFormat::I32) {


### PR DESCRIPTION
Fix/address #1083.

We add an option to check for an attribute in a PUML file which gives us the boundary type. Otherwise, we avoid `i64`, unless specified explicitly.