### PR TITLE
alpham fixed in Receiver output

### DIFF
--- a/src/DynamicRupture/Output/ReceiverBasedOutput.cpp
+++ b/src/DynamicRupture/Output/ReceiverBasedOutput.cpp
@@ -5,6 +5,7 @@
 #include "generated_code/kernel.h"
 #include "generated_code/tensor.h"
 #include <Initializer/Parameters/ModelParameters.h>
+#include <Kernels/common.hpp>
 #include <cstring>
 
 using namespace seissol::dr::misc::quantity_indices;
@@ -276,7 +277,7 @@ void ReceiverOutput::calcFaultOutput(
                         (dofsNMinus[4 * NUMBER_OF_ALIGNED_BASIS_FUNCTIONS + q] + epsInityz) +
                     2 * (dofsNMinus[5 * NUMBER_OF_ALIGNED_BASIS_FUNCTIONS + q] + epsInitzx) *
                         (dofsNMinus[5 * NUMBER_OF_ALIGNED_BASIS_FUNCTIONS + q] + epsInitzx);
-      real alpham = dofsNMinus[9];
+      real alpham = dofsNMinus[9*NUMBER_OF_ALIGNED_BASIS_FUNCTIONS + q];
       real xim;
       if (EspIIm > 1e-30) {
         xim = EspIIm / std::sqrt(EspIIm);


### PR DESCRIPTION
This works now but the P_n0 on the fault receivers look a little more different from the reference. But the reference has the wrong implementation for dynamic rupture receiver output too. So, I think it makes sense to update the precomputed repository with this updated calculation after the PR is merged.

![image](https://github.com/SeisSol/SeisSol/assets/7347463/a79b0b0e-1097-4bd0-92e1-1eb501b86336)
