### PR TITLE
harmonize documentation and code regarding tpProxyExponent

### DIFF
--- a/Documentation/dynamic-rupture.rst
+++ b/Documentation/dynamic-rupture.rst
@@ -211,7 +211,7 @@ The fault strength is determined by
 
 All variables are the same as defined in previous section for :code:`FL=16`.
 The friction law also supports forced rupture time.
-You can modify the default value (-1/3) of :math:`\alpha`, by adjusting the :code:`TpProxyExponent` parameter in the main parameter file (namelist: :code:`DynamicRupture`).
+You can modify the default value 1/3 of :math:`\alpha`, by adjusting the :code:`TpProxyExponent` parameter in the main parameter file (namelist: :code:`DynamicRupture`).
 
 Rate-and-state friction
 ^^^^^^^^^^^^^^^^^^^^^^^

--- a/Documentation/parameters.par
+++ b/Documentation/parameters.par
@@ -54,7 +54,7 @@ etahack = 1                 ! use any value smaller than one to mitigate quasi-d
 OutputPointType = 5         ! Type (0: no output, 3: ascii file, 4: paraview file, 5: 3+4)
 SlipRateOutputType=0        ! 0: (smoother) slip rate output evaluated from the difference between the velocity on both side of the fault
                             ! 1: slip rate output evaluated from the fault tractions and the failure criterion (less smooth but usually more accurate where the rupture front is well developped)
-TpProxyExponent = 0.33333333 ! exponent alpha in the TP proxy slip weakening law (default is 1/3)
+TpProxyExponent = 0.3333333333333333 ! exponent alpha in the TP proxy slip weakening law (default is 1/3)
 /
 
 !see: https://seissol.readthedocs.io/en/latest/fault-output.html

--- a/Documentation/parameters.par
+++ b/Documentation/parameters.par
@@ -54,7 +54,7 @@ etahack = 1                 ! use any value smaller than one to mitigate quasi-d
 OutputPointType = 5         ! Type (0: no output, 3: ascii file, 4: paraview file, 5: 3+4)
 SlipRateOutputType=0        ! 0: (smoother) slip rate output evaluated from the difference between the velocity on both side of the fault
                             ! 1: slip rate output evaluated from the fault tractions and the failure criterion (less smooth but usually more accurate where the rupture front is well developped)
-TpProxyExponent = -0.33333333 ! exponent alpha in the TP proxy slip weakening law (default is -1/3)
+TpProxyExponent = 0.33333333 ! exponent alpha in the TP proxy slip weakening law (default is 1/3)
 /
 
 !see: https://seissol.readthedocs.io/en/latest/fault-output.html

--- a/src/DynamicRupture/FrictionLaws/GpuImpl/LinearSlipWeakening.h
+++ b/src/DynamicRupture/FrictionLaws/GpuImpl/LinearSlipWeakening.h
@@ -413,7 +413,7 @@ class TPApprox {
                                 size_t ltsFace,
                                 size_t pointIndex) {
     const real factor = (1.0 + sycl::fabs(localAccumulatedSlip) / localDc);
-    return 1.0 - sycl::pow(factor, tpProxyExponent);
+    return 1.0 - sycl::pow(factor, -tpProxyExponent);
   };
 
   static real strengthHook(Details details,

--- a/src/DynamicRupture/FrictionLaws/LinearSlipWeakening.cpp
+++ b/src/DynamicRupture/FrictionLaws/LinearSlipWeakening.cpp
@@ -41,7 +41,7 @@ real TPApprox::stateVariableHook(real localAccumulatedSlip,
                                  unsigned int ltsFace,
                                  unsigned int pointIndex) {
   const real factor = (1.0 + std::fabs(localAccumulatedSlip) / localDc);
-  return 1.0 - std::pow(factor, drParameters->tpProxyExponent);
+  return 1.0 - std::pow(factor, -drParameters->tpProxyExponent);
 }
 
 } // namespace seissol::dr::friction_law

--- a/src/Initializer/Parameters/DRParameters.cpp
+++ b/src/Initializer/Parameters/DRParameters.cpp
@@ -53,7 +53,7 @@ DRParameters readDRParameters(ParameterReader* baseReader) {
       static_cast<real>(reader->readWithDefault("lsw_healingthreshold", -1.0));
   const auto t0 = static_cast<real>(reader->readWithDefault("t_0", 0.0));
   const auto tpProxyExponent =
-      static_cast<real>(reader->readWithDefault("tpproxyexponent", -1. / 3.));
+      static_cast<real>(reader->readWithDefault("tpproxyexponent", 1. / 3.));
 
   const bool isRateAndState =
       (frictionLawType == FrictionLawType::RateAndStateAgingLaw) or


### PR DESCRIPTION
(it was either I change the documentation and move the denominator to the numerator in the equation: 
![image](https://github.com/SeisSol/SeisSol/assets/13536910/12c9dc9f-6e1e-4715-8d00-847dad10193d)
or changing the sign of alpha in the code. I propose changing the code, as the formula looks clearer like that.)