### PR TITLE
Fix Hangup When Creating Folder for IO

### DIFF
--- a/src/Initializer/InitProcedure/InitIO.cpp
+++ b/src/Initializer/InitProcedure/InitIO.cpp
@@ -214,8 +214,8 @@ void seissol::initializer::initprocedure::initIO(seissol::SeisSol& seissolInstan
     if (rank == 0) {
       filesystem::create_directory(outputDir);
     }
-    MPI::mpi.barrier(MPI::mpi.comm());
   }
+  MPI::mpi.barrier(MPI::mpi.comm());
 
   // always enable checkpointing first
   enableCheckpointing(seissolInstance);

--- a/src/Initializer/InitProcedure/InitModel.cpp
+++ b/src/Initializer/InitProcedure/InitModel.cpp
@@ -99,7 +99,7 @@ void initializeCellMaterial(seissol::SeisSol& seissolInstance) {
   // we need to compute all model parameters before we can use them...
   // TODO(David): integrate this with the Viscoelastic material class or the ParameterDB directly?
   logDebug() << "Initializing attenuation.";
-#ifdef OPENMP
+#ifdef _OPENMP
 #pragma omp parallel for schedule(static)
 #endif
   for (size_t i = 0; i < materialsDB.size(); ++i) {
@@ -107,7 +107,7 @@ void initializeCellMaterial(seissol::SeisSol& seissolInstance) {
     seissol::physics::fitAttenuation(
         cellMat, seissolParams.model.freqCentral, seissolParams.model.freqRatio);
   }
-#ifdef OPENMP
+#ifdef _OPENMP
 #pragma omp parallel for schedule(static)
 #endif
   for (size_t i = 0; i < materialsDBGhost.size(); ++i) {


### PR DESCRIPTION
We had a barrier in an `if` when creating the output directories. Now if one rank was slower than all others and happened to check for directory existence after it had already been created, it would skip that very barrier, causing a desync in the whole MPI communication. Thus, we put the barrier outside the if.

Also, we fix two typos on OpenMP pragma statements.

Thanks goes to @montrie for finding these issues.