### PR TITLE
IWYU export filesystem (fix #1108)

### DIFF
--- a/src/Common/filesystem.h
+++ b/src/Common/filesystem.h
@@ -6,7 +6,7 @@
 #include "utils/timeutils.h"
 
 #ifdef EXPERIMENTAL_FS
-#include <experimental/filesystem>
+#include <experimental/filesystem> // IWYU pragma: export
 #include <sys/types.h>
 #include <sys/stat.h>
 
@@ -22,7 +22,7 @@ inline bool directoryExists(seissol::filesystem::directory_entry entry) {
 
 #else
 
-#include <filesystem>
+#include <filesystem> // IWYU pragma: export
 namespace seissol {
 namespace filesystem = std::filesystem;
 

--- a/src/DynamicRupture/Output/OutputManager.cpp
+++ b/src/DynamicRupture/Output/OutputManager.cpp
@@ -22,7 +22,6 @@
 #include <algorithm>
 #include <cstddef>
 #include <ctime>
-#include <filesystem>
 #include <fstream>
 #include <iomanip>
 #include <ios>


### PR DESCRIPTION
Adds an IWYU export for the filesystem header, so that it doesn't complain when it's used somewhere else.