### PR TITLE
Allocate Buffer for Energy/DR Output Only Once

### DIFF
--- a/src/ResultWriter/EnergyOutput.cpp
+++ b/src/ResultWriter/EnergyOutput.cpp
@@ -73,6 +73,7 @@ void EnergyOutput::init(
 
   isPlasticityEnabled = newIsPlasticityEnabled;
 
+#ifdef ACL_DEVICE
   unsigned maxCells = 0;
   for (auto it = dynRupTree->beginLeaf(); it != dynRupTree->endLeaf(); ++it) {
     maxCells = std::max(it->getNumberOfCells(), maxCells);
@@ -89,6 +90,7 @@ void EnergyOutput::init(
     timeDerivativeMinusHostMapped = reinterpret_cast<real*>(
         device::DeviceInstance::getInstance().api->devicePointer(timeDerivativeMinusHost));
   }
+#endif
 
   Modules::registerHook(*this, ModuleHook::SimulationStart);
   Modules::registerHook(*this, ModuleHook::SynchronizationPoint);
@@ -142,12 +144,12 @@ void EnergyOutput::simulationStart() {
 
 EnergyOutput::~EnergyOutput() {
 #ifdef ACL_DEVICE
-if (timeDerivativePlusHost != nullptr) {
-  device::DeviceInstance::getInstance().api->freePinnedMem(timeDerivativePlusHost);
-}
-if (timeDerivativeMinusHost != nullptr) {
-  device::DeviceInstance::getInstance().api->freePinnedMem(timeDerivativeMinusHost);
-}
+  if (timeDerivativePlusHost != nullptr) {
+    device::DeviceInstance::getInstance().api->freePinnedMem(timeDerivativePlusHost);
+  }
+  if (timeDerivativeMinusHost != nullptr) {
+    device::DeviceInstance::getInstance().api->freePinnedMem(timeDerivativeMinusHost);
+  }
 #endif
 }
 

--- a/src/ResultWriter/EnergyOutput.cpp
+++ b/src/ResultWriter/EnergyOutput.cpp
@@ -73,6 +73,23 @@ void EnergyOutput::init(
 
   isPlasticityEnabled = newIsPlasticityEnabled;
 
+  unsigned maxCells = 0;
+  for (auto it = dynRupTree->beginLeaf(); it != dynRupTree->endLeaf(); ++it) {
+    maxCells = std::max(it->getNumberOfCells(), maxCells);
+  }
+
+  if (maxCells > 0) {
+    constexpr auto qSize = tensor::Q::size();
+    timeDerivativePlusHost = reinterpret_cast<real*>(
+        device::DeviceInstance::getInstance().api->allocPinnedMem(maxCells * qSize * sizeof(real)));
+    timeDerivativeMinusHost = reinterpret_cast<real*>(
+        device::DeviceInstance::getInstance().api->allocPinnedMem(maxCells * qSize * sizeof(real)));
+    timeDerivativePlusHostMapped = reinterpret_cast<real*>(
+        device::DeviceInstance::getInstance().api->devicePointer(timeDerivativePlusHost));
+    timeDerivativeMinusHostMapped = reinterpret_cast<real*>(
+        device::DeviceInstance::getInstance().api->devicePointer(timeDerivativeMinusHost));
+  }
+
   Modules::registerHook(*this, ModuleHook::SimulationStart);
   Modules::registerHook(*this, ModuleHook::SynchronizationPoint);
   setSyncInterval(parameters.interval);
@@ -121,6 +138,17 @@ void EnergyOutput::simulationStart() {
     writeHeader();
   }
   syncPoint(0.0);
+}
+
+EnergyOutput::~EnergyOutput() {
+#ifdef ACL_DEVICE
+if (timeDerivativePlusHost != nullptr) {
+  device::DeviceInstance::getInstance().api->freePinnedMem(timeDerivativePlusHost);
+}
+if (timeDerivativeMinusHost != nullptr) {
+  device::DeviceInstance::getInstance().api->freePinnedMem(timeDerivativeMinusHost);
+}
+#endif
 }
 
 real EnergyOutput::computeStaticWork(const real* degreesOfFreedomPlus,
@@ -184,28 +212,10 @@ void EnergyOutput::computeDynamicRuptureEnergies() {
   double& potency = energiesStorage.potency();
   minTimeSinceSlipRateBelowThreshold = std::numeric_limits<real>::max();
 
-  unsigned maxCells = 0;
-  for (auto it = dynRupTree->beginLeaf(); it != dynRupTree->endLeaf(); ++it) {
-    maxCells = std::max(it->getNumberOfCells(), maxCells);
-  }
-
-  if (maxCells == 0) {
-    return;
-  }
-
 #ifdef ACL_DEVICE
   void* stream = device::DeviceInstance::getInstance().api->getDefaultStream();
-
-  constexpr auto qSize = tensor::Q::size();
-  real* timeDerivativePlusHost = reinterpret_cast<real*>(
-      device::DeviceInstance::getInstance().api->allocPinnedMem(maxCells * qSize * sizeof(real)));
-  real* timeDerivativeMinusHost = reinterpret_cast<real*>(
-      device::DeviceInstance::getInstance().api->allocPinnedMem(maxCells * qSize * sizeof(real)));
-  real* timeDerivativePlusHostMapped = reinterpret_cast<real*>(
-      device::DeviceInstance::getInstance().api->devicePointer(timeDerivativePlusHost));
-  real* timeDerivativeMinusHostMapped = reinterpret_cast<real*>(
-      device::DeviceInstance::getInstance().api->devicePointer(timeDerivativeMinusHost));
 #endif
+  constexpr auto qSize = tensor::Q::size();
   for (auto it = dynRupTree->beginLeaf(); it != dynRupTree->endLeaf(); ++it) {
     /// \todo timeDerivativePlus and timeDerivativeMinus are missing the last timestep.
     /// (We'd need to send the dofs over the network in order to fix this.)
@@ -307,10 +317,6 @@ void EnergyOutput::computeDynamicRuptureEnergies() {
     }
     minTimeSinceSlipRateBelowThreshold = std::min(localMin, minTimeSinceSlipRateBelowThreshold);
   }
-#ifdef ACL_DEVICE
-  device::DeviceInstance::getInstance().api->freePinnedMem(timeDerivativePlusHost);
-  device::DeviceInstance::getInstance().api->freePinnedMem(timeDerivativeMinusHost);
-#endif
 }
 
 void EnergyOutput::computeVolumeEnergies() {

--- a/src/ResultWriter/EnergyOutput.h
+++ b/src/ResultWriter/EnergyOutput.h
@@ -68,6 +68,8 @@ class EnergyOutput : public Module {
 
   EnergyOutput(seissol::SeisSol& seissolInstance) : seissolInstance(seissolInstance) {}
 
+  ~EnergyOutput();
+
   private:
   real computeStaticWork(const real* degreesOfFreedomPlus,
                          const real* degreesOfFreedomMinus,
@@ -109,6 +111,10 @@ class EnergyOutput : public Module {
   std::string outputFileName;
   std::ofstream out;
 
+  real* timeDerivativePlusHost = nullptr;
+  real* timeDerivativeMinusHost = nullptr;
+  real* timeDerivativePlusHostMapped = nullptr;
+  real* timeDerivativeMinusHostMapped = nullptr;
   const GlobalData* global = nullptr;
   seissol::initializer::DynamicRupture* dynRup = nullptr;
   seissol::initializer::LTSTree* dynRupTree = nullptr;


### PR DESCRIPTION
Instead of allocating and de-allocating pinned memory at each sync point, we allocate it at the start of the simulation.

That should improve the performance with frequent synchronization points.