### PR TITLE
updates on GME script

### DIFF
--- a/postprocessing/science/GroundMotionParametersMaps/ComputeGroundMotionParametersFromSurfaceOutput_Hybrid.py
+++ b/postprocessing/science/GroundMotionParametersMaps/ComputeGroundMotionParametersFromSurfaceOutput_Hybrid.py
@@ -300,5 +300,10 @@ if irank==0:
     if nranks > 1:
         myres = np.concatenate(myres, axis=0)
     geom = sx.ReadGeometry()
-    sxw.write_seissol_output(f"{prefixGME}{prefixType}", geom, connect, dataName,
-                             [myres[:,i] for i in range(myres.shape[1])], 0, [0])
+    sxw.write(
+        f"{prefixGME}{prefixType}",
+        geom,
+        connect,
+        {name: myres[:,i] for i, name in enumerate(dataName)},
+        dictTime=None,
+    )


### PR DESCRIPTION
- fix warning in scipy with cumtrapz
- add no_gmrotdpp option for CAV (cumulative absolute velocity), to use the same calculation as the DRV SCEC group.
- use the latest interface of seissolxdmfwriter