### PR TITLE
Fix amdclang builds: Place `alignas` clause in front of type

### DIFF
--- a/src/Equations/viscoelastic2/Kernels/Local.cpp
+++ b/src/Equations/viscoelastic2/Kernels/Local.cpp
@@ -86,7 +86,7 @@ void Local::computeIntegral(real i_timeIntegratedDegreesOfFreedom[tensor::I::siz
   assert( ((uintptr_t)data.dofs())           % Alignment == 0 );
 #endif
 
-  real Qext[tensor::Qext::size()] alignas(Alignment);
+  alignas(Alignment) real Qext[tensor::Qext::size()];
 
   kernel::volumeExt volKrnl = m_volumeKernelPrototype;
   volKrnl.Qext = Qext;

--- a/src/Equations/viscoelastic2/Kernels/Neighbor.cpp
+++ b/src/Equations/viscoelastic2/Kernels/Neighbor.cpp
@@ -97,7 +97,7 @@ void Neighbor::computeNeighborsIntegral(  NeighborData&                     data
   // alignment of the degrees of freedom
   assert( ((uintptr_t)data.dofs()) % Alignment == 0 );
 
-  real Qext[tensor::Qext::size()] alignas(PagesizeStack) = {};
+  alignas(PagesizeStack) real Qext[tensor::Qext::size()] = {};
 
   kernel::neighbourFluxExt nfKrnl = m_nfKrnlPrototype;
   nfKrnl.Qext = Qext;

--- a/src/Equations/viscoelastic2/Kernels/Time.cpp
+++ b/src/Equations/viscoelastic2/Kernels/Time.cpp
@@ -88,9 +88,9 @@ void Time::computeAder(double i_timeStepWidth,
    */
   // temporary result
   // TODO(David): move these temporary buffers into the Yateto kernel, maybe
-  real temporaryBuffer[2][tensor::dQ::size(0)] alignas(PagesizeStack);
-  real temporaryBufferExt[2][tensor::dQext::size(1)] alignas(PagesizeStack);
-  real temporaryBufferAne[2][tensor::dQane::size(0)] alignas(PagesizeStack);
+  alignas(PagesizeStack) real temporaryBuffer[2][tensor::dQ::size(0)];
+  alignas(PagesizeStack) real temporaryBufferExt[2][tensor::dQext::size(1)];
+  alignas(PagesizeStack) real temporaryBufferAne[2][tensor::dQane::size(0)];
 
   kernel::derivative krnl = m_krnlPrototype;
 

--- a/src/Initializer/InitialFieldProjection.cpp
+++ b/src/Initializer/InitialFieldProjection.cpp
@@ -83,7 +83,7 @@ void seissol::initializer::projectInitialField(std::vector<std::unique_ptr<physi
   #pragma omp parallel
   {
 #endif
-  real iniCondData[tensor::iniCond::size()] alignas(Alignment) = {};
+  alignas(Alignment) real iniCondData[tensor::iniCond::size()] = {};
   auto iniCond = init::iniCond::view::create(iniCondData);
 
   std::vector<std::array<double, 3>> quadraturePointsXyz;

--- a/src/Kernels/Plasticity.cpp
+++ b/src/Kernels/Plasticity.cpp
@@ -66,15 +66,15 @@ namespace seissol::kernels {
     assert(reinterpret_cast<uintptr_t>(global->vandermondeMatrix) % Alignment == 0);
     assert(reinterpret_cast<uintptr_t>(global->vandermondeMatrixInverse) % Alignment == 0);
 
-    real QStressNodal[tensor::QStressNodal::size()] alignas(Alignment);
-    real QEtaNodal[tensor::QEtaNodal::size()] alignas(Alignment);
-    real QEtaModal[tensor::QEtaModal::size()] alignas(Alignment);
-    real meanStress[tensor::meanStress::size()] alignas(Alignment);
-    real secondInvariant[tensor::secondInvariant::size()] alignas(Alignment);
-    real tau[tensor::secondInvariant::size()] alignas(Alignment);
-    real taulim[tensor::meanStress::size()] alignas(Alignment);
-    real yieldFactor[tensor::yieldFactor::size()] alignas(Alignment);
-    real dudt_pstrain[tensor::QStress::size()] alignas(Alignment);
+    alignas(Alignment) real QStressNodal[tensor::QStressNodal::size()];
+    alignas(Alignment) real QEtaNodal[tensor::QEtaNodal::size()];
+    alignas(Alignment) real QEtaModal[tensor::QEtaModal::size()];
+    alignas(Alignment) real meanStress[tensor::meanStress::size()];
+    alignas(Alignment) real secondInvariant[tensor::secondInvariant::size()];
+    alignas(Alignment) real tau[tensor::secondInvariant::size()];
+    alignas(Alignment) real taulim[tensor::meanStress::size()];
+    alignas(Alignment) real yieldFactor[tensor::yieldFactor::size()];
+    alignas(Alignment) real dudt_pstrain[tensor::QStress::size()];
 
     static_assert(tensor::secondInvariant::size() == tensor::meanStress::size(),
                   "Second invariant tensor and mean stress tensor must be of the same size().");


### PR DESCRIPTION
The merge of #1086 broke the build with amdclang (and possibly other clang-based compilers); since it does not allow the `alignas` to be placed behind the variable name. Thus, we hereby fix that (commit ported from #1122 ).