### PR TITLE
Include the CMake `yaml-cpp::yaml-cpp` library list, not the file itself

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -353,8 +353,14 @@ target_include_directories(SeisSol-common-properties SYSTEM INTERFACE
 )
 
 find_package(Eigen3 3.4 REQUIRED)
+target_link_libraries(SeisSol-common-properties INTERFACE Eigen3::Eigen)
+
 find_package(yaml-cpp REQUIRED)
-target_link_libraries(SeisSol-common-properties INTERFACE Eigen3::Eigen yaml-cpp)
+
+# required for yaml-cpp@0.6 . With yaml-cpp@0.8 , we can use `yaml-cpp::yaml-cpp`
+if (YAML_CPP_LIBRARIES)
+  target_link_libraries(SeisSol-common-properties INTERFACE ${YAML_CPP_LIBRARIES})
+endif()
 
 # Note: eigen3 enables cuda support in its headers by default.
 # The problem happens in `eigen3/Eigen/src/Core/util/Meta.h` while

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -357,9 +357,20 @@ target_link_libraries(SeisSol-common-properties INTERFACE Eigen3::Eigen)
 
 find_package(yaml-cpp REQUIRED)
 
-# required for yaml-cpp@0.6 . With yaml-cpp@0.8 , we can use `yaml-cpp::yaml-cpp`
-if (YAML_CPP_LIBRARIES)
-  target_link_libraries(SeisSol-common-properties INTERFACE ${YAML_CPP_LIBRARIES})
+if (${yaml-cpp_VERSION} VERSION_GREATER_EQUAL 0.7)
+  target_link_libraries(SeisSol-common-properties INTERFACE yaml-cpp::yaml-cpp)
+else()
+  # fallback code for old versions
+  if (YAML_CPP_INCLUDE_DIR AND EXISTS "${YAML_CPP_INCLUDE_DIR}")
+    target_include_directories(SeisSol-common-properties INTERFACE ${YAML_CPP_INCLUDE_DIR})
+  endif()
+  if (YAML_CPP_LIBRARIES)
+    # use the YAML_CPP_LIBRARIES, if available (though it may just say `yaml-cpp`)
+    target_link_libraries(SeisSol-common-properties INTERFACE ${YAML_CPP_LIBRARIES})
+  else()
+    # fallback
+    target_link_libraries(SeisSol-common-properties INTERFACE yaml-cpp)
+  endif()
 endif()
 
 # Note: eigen3 enables cuda support in its headers by default.
@@ -373,10 +384,6 @@ target_compile_definitions(SeisSol-common-properties INTERFACE EIGEN_NO_CUDA)
 
 if (EIGEN3_INCLUDE_DIR)
   target_include_directories(SeisSol-common-properties INTERFACE ${EIGEN3_INCLUDE_DIR})
-endif()
-
-if (YAML_CPP_INCLUDE_DIR AND EXISTS "${YAML_CPP_INCLUDE_DIR}")
-  target_include_directories(SeisSol-common-properties INTERFACE ${YAML_CPP_INCLUDE_DIR})
 endif()
 
 target_include_directories(SeisSol-common-properties INTERFACE

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -357,7 +357,7 @@ target_link_libraries(SeisSol-common-properties INTERFACE Eigen3::Eigen)
 
 find_package(yaml-cpp REQUIRED)
 
-if (${yaml-cpp_VERSION} VERSION_GREATER_EQUAL 0.7)
+if ("${yaml-cpp_VERSION}" VERSION_GREATER_EQUAL "0.8")
   target_link_libraries(SeisSol-common-properties INTERFACE yaml-cpp::yaml-cpp)
 else()
   # fallback code for old versions

--- a/src/Solver/FreeSurfaceIntegrator.cpp
+++ b/src/Solver/FreeSurfaceIntegrator.cpp
@@ -117,7 +117,7 @@ void seissol::solver::FreeSurfaceIntegrator::calculateOutput()
     #pragma omp parallel for schedule(static) default(none) shared(offset, surfaceLayer, dofs, displacementDofs, side)
 #endif // _OPENMP
     for (unsigned face = 0; face < surfaceLayer->getNumberOfCells(); ++face) {
-      real subTriangleDofs[tensor::subTriangleDofs::size(FREESURFACE_MAX_REFINEMENT)] alignas(Alignment);
+      alignas(Alignment) real subTriangleDofs[tensor::subTriangleDofs::size(FREESURFACE_MAX_REFINEMENT)];
 
       kernel::subTriangleVelocity vkrnl;
       vkrnl.Q = dofs[face];

--- a/src/Solver/time_stepping/TimeCluster.cpp
+++ b/src/Solver/time_stepping/TimeCluster.cpp
@@ -355,7 +355,7 @@ void seissol::time_stepping::TimeCluster::computeLocalIntegration(seissol::initi
   m_loopStatistics->begin(m_regionComputeLocalIntegration);
 
   // local integration buffer
-  real l_integrationBuffer[tensor::I::size()] alignas(Alignment);
+  alignas(Alignment) real l_integrationBuffer[tensor::I::size()];
 
   // pointer for the call of the ADER-function
   real* l_bufferPointer;


### PR DESCRIPTION
Load yaml-cpp libraries from CMake starting with yaml-cpp version 0.8, instead of specifying the file explicitly.

(note that the `yaml-cpp` CMake seems to be à priori using the library name instead of a path when querying the `YAML_CPP_LIBRARIES` variable directly)

Also, we move two `alignas` attributes (?) which weren't moved by #1133 .

(note that for this patch to work will also require `easi` to be recompiled. Then the explicitly-needed `LIBRARY_PATH`/`LD_LIBRARY_PATH` specification can be left away.)