### PR TITLE
Allow CPU Codegen without GEMM Tools

### DIFF
--- a/cmake/FindGemmTools.cmake
+++ b/cmake/FindGemmTools.cmake
@@ -67,6 +67,11 @@ foreach(component ${_GEMM_TOOLS_LIST})
     elseif ("${component}" STREQUAL "Eigen")
         # already included by default!
 
+    elseif ("${component}" MATCHES "^[ \t\r\n]*[Nn][Oo][Nn][Ee][ \t\r\n]*$")
+        # (cf. https://cmake.org/cmake/help/latest/command/string.html#regex-specification)
+
+        # no includes necessary
+
     elseif ("${component}" STREQUAL "GemmForge")
         execute_process(COMMAND python3 -c "import gemmforge; gemmforge.print_cmake_path()"
                         OUTPUT_VARIABLE GEMMFORGE_PATH)

--- a/cmake/process_users_input.cmake
+++ b/cmake/process_users_input.cmake
@@ -86,7 +86,8 @@ set_property(CACHE LOG_LEVEL_MASTER PROPERTY STRINGS ${LOG_LEVEL_MASTER_OPTIONS}
 
 
 set(GEMM_TOOLS_LIST "auto" CACHE STRING "GEMM tool(s) used for CPU code generation")
-set(GEMM_TOOLS_OPTIONS "auto" "LIBXSMM,PSpaMM" "LIBXSMM" "MKL" "OpenBLAS" "BLIS" "PSpaMM" "Eigen" "LIBXSMM,PSpaMM,GemmForge" "Eigen,GemmForge"
+set(GEMM_TOOLS_OPTIONS "auto" "none"
+        "LIBXSMM,PSpaMM" "LIBXSMM" "MKL" "OpenBLAS" "BLIS" "PSpaMM" "Eigen" "LIBXSMM,PSpaMM,GemmForge" "Eigen,GemmForge"
         "LIBXSMM_JIT,PSpaMM" "LIBXSMM_JIT" "LIBXSMM_JIT,PSpaMM,GemmForge")
 set_property(CACHE GEMM_TOOLS_LIST PROPERTY STRINGS ${GEMM_TOOLS_OPTIONS})
 

--- a/generated_code/generate.py
+++ b/generated_code/generate.py
@@ -165,7 +165,7 @@ for tool in gemm_tool_list:
       gemm_generators.append(specific_gemm_class(arch, cmdLineArgs.executable_pspamm))
     else:
       gemm_generators.append(specific_gemm_class(arch))
-  else:
+  elif tool.strip().lower() != 'none':
     print("YATETO::ERROR: unknown \"{}\" GEMM tool. "
           "Please, refer to the documentation".format(tool))
     sys.exit("failure")


### PR DESCRIPTION
We add an explicit `none` option to the GEMM tools list (which gets ignored during gemm tool finding).

(note that it was possible right now already implicitly ; e.g. when using `noarch` together with `PSpaMM` )