### PR TITLE
Use Persistent MPI by default

### DIFF
--- a/src/Parallel/Helper.hpp
+++ b/src/Parallel/Helper.hpp
@@ -27,7 +27,7 @@ bool useCommThread(const T& mpiBasic) {
   return useThread && !mpiBasic.isSingleProcess();
 }
 
-inline bool usePersistentMpi() { return utils::Env::get<bool>("SEISSOL_MPI_PERSISTENT", false); }
+inline bool usePersistentMpi() { return utils::Env::get<bool>("SEISSOL_MPI_PERSISTENT", true); }
 
 template <typename T>
 void printPersistentMpiInfo(const T& mpiBasic) {


### PR DESCRIPTION
@davschneller please feel free to reject it if we are not ready to use Persistent MPI by default everywhere