### PR TITLE
Fix considering trailing zero characters in fixed-length strings for boundary inference

### DIFF
--- a/src/Initializer/InitProcedure/InitMesh.cpp
+++ b/src/Initializer/InitProcedure/InitMesh.cpp
@@ -125,7 +125,14 @@ static void readMeshPUML(const seissol::initializer::parameters::SeisSolParamete
           auto length = H5Tget_size(boundaryAttributeType);
           std::vector<char> data(length);
           _eh(H5Aread(boundaryAttribute, boundaryAttributeType, data.data()));
-          return std::string(data.begin(), data.end());
+          std::size_t actualLength = length;
+          for (std::size_t i = 0; i < length; ++i) {
+            if (data[i] == '\0') {
+              actualLength = i;
+              break;
+            }
+          }
+          return std::string(data.begin(), data.begin() + actualLength);
         }
       }();
 


### PR DESCRIPTION
As discussed in #1154, there were sometimes still null characters at the end of the read boundary condition strings. This PR caps the string at the first 0.