### PR TITLE
Add Pre-Build GHA CI Dependency Image

### DIFF
--- a/.ci/gha-cpu/Dockerfile
+++ b/.ci/gha-cpu/Dockerfile
@@ -1,0 +1,111 @@
+# ## boilerplate
+
+FROM ubuntu:24.04
+
+ENV TZ=UTC
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update -y && apt-get upgrade -y && \
+    apt-get install -y --no-install-recommends --fix-missing \
+    apt-utils \
+    build-essential \
+    bash \
+    wget \
+    git \
+    curl \
+    tar \
+    unzip \
+    patch \
+    gzip \
+    bzip2 \
+    file \
+    gfortran \
+    coreutils \
+    libopenblas-dev \
+    liblapack-dev \
+    pkg-config \
+    automake \
+    make \
+    cmake \
+    gnupg \
+    cmake-curses-gui \
+    libreadline-dev \
+    libxml2-dev \
+    software-properties-common \
+    python3.10 python3-dev python3-pip \
+    python3-setuptools python3-numpy python3-scipy \
+    libeigen3-dev libyaml-cpp-dev libopenmpi-dev libparmetis-dev libmetis-dev ninja-build && \
+    wget -O llvm-snapshot.gpg.key https://apt.llvm.org/llvm-snapshot.gpg.key && \
+    apt-key add llvm-snapshot.gpg.key && \
+    rm -f llvm-snapshot.gpg.key && \
+    add-apt-repository "deb http://apt.llvm.org/noble/ llvm-toolchain-noble-19 main" && \
+    add-apt-repository "deb-src http://apt.llvm.org/noble/ llvm-toolchain-noble-19 main" && \
+    apt-get -y update && \
+    apt-get -y install clang-19 clang-tidy-19 libomp-19-dev
+
+# ## IO
+
+# HDF5
+RUN wget https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.12/hdf5-1.12.3/src/hdf5-1.12.3.tar.bz2 && \
+    tar -xf hdf5-1.12.3.tar.bz2 && cd hdf5-1.12.3 && \
+    CPPFLAGS="-fPIC ${CPPFLAGS}" CC=mpicc FC=mpif90 ./configure --enable-parallel --prefix=/usr --with-zlib --disable-shared && \
+    make -j $(nproc) install && \
+    cd .. && rm -rf hdf5-1.12.3
+
+# Netcdf
+RUN wget https://downloads.unidata.ucar.edu/netcdf-c/4.9.2/netcdf-c-4.9.2.tar.gz && \
+    tar -xf netcdf-c-4.9.2.tar.gz && cd netcdf-c-4.9.2 && \
+    CFLAGS="-fPIC ${CFLAGS}" CC=h5pcc ./configure --enable-shared=no --prefix=/usr --disable-dap --disable-byterange && \
+    make -j $(nproc) install && \
+    cd .. && rm -rf netcdf-c-4.9.2
+
+# ## input data
+
+# ImpalaJIT
+RUN git clone --depth 1 https://github.com/uphoffc/ImpalaJIT.git gitbuild && \
+    mkdir -p gitbuild/build && cd gitbuild/build && \
+    cmake .. -GNinja && \
+    ninja install && \
+    cd ../.. && rm -rf gitbuild
+
+# ASAGI
+RUN git clone --recursive --depth 1 https://github.com/TUM-I5/ASAGI.git gitbuild && \
+mkdir -p gitbuild/build && cd gitbuild/build && \
+    cmake .. -DSHARED_LIB=OFF -DFORTRAN_SUPPORT=OFF -DSTATIC_LIB=ON -GNinja && \
+    ninja install && \
+    cd ../.. && rm -rf gitbuild
+
+# Lua
+RUN wget https://www.lua.org/ftp/lua-5.3.6.tar.gz && \
+    tar -xzvf lua-5.3.6.tar.gz && cd lua-5.3.6/ &&\
+    make linux CC=mpicc && make local && \
+    cp -r install/* /usr && \
+    cd .. && rm -rf lua-5.3.6
+
+# easi
+RUN git clone --recursive --depth 1 --branch v1.3.0 https://github.com/SeisSol/easi.git gitbuild && \
+    mkdir -p gitbuild/build && cd gitbuild/build && \
+    cmake .. -GNinja -DLUA=ON -DIMPALAJIT=ON -DASAGI=ON && \
+    ninja install && \
+    cd ../.. && rm -rf gitbuild
+
+# ## code generators
+
+# libxsmm
+RUN git clone --depth 1 --branch 1.17 https://github.com/libxsmm/libxsmm.git gitbuild && \
+    mkdir -p gitbuild && cd gitbuild && \
+    make generator -j $(nproc) && cp bin/libxsmm_gemm_generator /usr/bin && \
+    cd .. && rm -rf gitbuild
+
+# PSpaMM
+RUN pip3 install --break-system-packages git+https://github.com/SeisSol/PSpaMM.git
+
+# ## setup and cleanup
+
+WORKDIR /app
+
+COPY . /app
+
+RUN chmod +x /usr/bin/*
+
+RUN apt-get clean && rm -rf /var/lib/apt/lists/*

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -1,0 +1,39 @@
+name: build-docker
+
+on:
+  - workflow_dispatch
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v2
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2
+    - name: Log into dockerhub
+      uses: docker/login-action@v2
+      with:
+        username: ${{ secrets.SEISSOL_DOCKER_USERNAME }}
+        password: ${{ secrets.SEISSOL_DOCKER_PASSWORD }}
+
+    - name: Extract metadata for Docker
+      id: meta
+      uses: docker/metadata-action@v4
+      with:
+        images: seissol/gha-cpu
+        tags: type=sha
+    
+    - name: Build and push Docker image
+      uses: docker/build-push-action@v4
+      with:
+        context: .
+        file: .ci/gha-cpu/Dockerfile
+        platforms: linux/amd64
+        push: true
+        tags: ${{ steps.meta.outputs.tags }}
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
+        labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/build-seissol.yml
+++ b/.github/workflows/build-seissol.yml
@@ -3,98 +3,10 @@ on:
   - push
 
 jobs:
-  dependencies:
-    name: dependencies
-    runs-on: ubuntu-22.04
-    steps:
-      - name: apt-get
-        run: |
-          sudo apt-get install libeigen3-dev libyaml-cpp-dev libopenmpi-dev
-          sudo mkdir -p /opt/dependencies
-
-      - name: build-hdf5
-        run: |
-          wget --progress=bar:force:noscroll https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.10/hdf5-1.10.11/src/hdf5-1.10.11.tar.bz2
-          tar -xf hdf5-1.10.11.tar.bz2 && cd hdf5-1.10.11
-          CFLAGS="-fPIC" CC=mpicc FC=mpif90 ./configure --enable-parallel --with-zlib --disable-shared --enable-fortran --prefix=/opt/dependencies
-          make -j$(nproc) && make install 
-
-      - name: build-netcdf
-        run: |
-          wget --progress=bar:force:noscroll https://github.com/Unidata/netcdf-c/archive/refs/tags/v4.9.2.tar.gz
-          tar -xf v4.9.2.tar.gz && cd netcdf-c-4.9.2
-          CFLAGS="-fPIC" CC=/opt/dependencies/bin/h5pcc ./configure --enable-shared=no --disable-dap --disable-libxml2 --disable-byterange --prefix=/opt/dependencies
-          make -j$(nproc) && make install
-
-      - name: checkout-impalajit
-        uses: actions/checkout@master
-        with:
-          repository: uphoffc/ImpalaJIT
-
-      - name: build-impalajit
-        run: |
-          mkdir build && cd build
-          cmake ..  -DCMAKE_INSTALL_PREFIX=/opt/dependencies
-          make -j $(nproc) && make install
-
-      - name: build-lua
-        run: |
-          # allow failure
-          set +e
-          wget https://www.lua.org/ftp/lua-5.3.6.tar.gz
-          retval=$?
-
-          set -e
-          if [ $retval -ne 0 ]; then
-            wget https://www.tecgraf.puc-rio.br/lua/mirror/ftp/lua-5.3.6.tar.gz
-          fi
-          tar -xzvf lua-5.3.6.tar.gz && cd lua-5.3.6/
-          make linux CC=mpicc && make local
-          cp -r install/* /opt/dependencies
-
-      - name: checkout-asagi
-        uses: actions/checkout@master
-        with:
-          repository: TUM-I5/ASAGI
-
-      - name: build-asagi
-        run: |
-            mkdir build && cd build
-            git submodule update --init
-            cmake .. -DSHARED_LIB=no -DSTATIC_LIB=yes -DCMAKE_INSTALL_PREFIX=/opt/dependencies
-            make -j $(nproc) && make install
-
-      - name: checkout-easi
-        uses: actions/checkout@master
-        with:
-          repository: SeisSol/easi
-
-      - name: build-easi
-        run: |
-          mkdir build && cd build
-          CMAKE_PREFIX_PATH=/opt/dependencies cmake .. -DCMAKE_INSTALL_PREFIX=/opt/dependencies -DASAGI=ON -DLUA=ON -DEASICUBE=OFF
-          make -j $(nproc) && make install
-
-      - name: checkout-libxsmm
-        uses: actions/checkout@master
-        with:
-          repository: libxsmm/libxsmm
-          ref: 1.17
-
-      - name: build-libxsmm
-        run: |
-          make generator -j $(nproc) && cp bin/libxsmm_gemm_generator /opt/dependencies/bin
-
-      - name: upload-artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: dependencies
-          path: /opt/dependencies
-
   seissol:
     name: seissol
-    runs-on: ubuntu-22.04
-    needs: dependencies
+    runs-on: ubuntu-24.04
+    container: seissol/gha-cpu:sha-44e8ec6
     strategy:
       matrix:
         build_type:
@@ -109,24 +21,13 @@ jobs:
           - single
           - double
     steps:
-      - uses: actions/checkout@v4
-
-      - name: apt-get
-        run: |
-          sudo apt-get update
-          sudo apt-get install libeigen3-dev libyaml-cpp-dev libopenmpi-dev libparmetis-dev libmetis-dev python3-pip ninja-build
-          pip3 install numpy scipy
-
-      - name: download-artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: dependencies
-          path: /opt/dependencies
+      - name: checkout-seissol
+        uses: actions/checkout@v4
 
       - name: build-seissol
         run: |
+          git config --global --add safe.directory '*'
           git submodule update --init
-          chmod +x /opt/dependencies/bin/*
           mkdir build && cd build
           if [ "${{ matrix.equations }}" = viscoelastic2 ]; then
               mechanisms=3
@@ -134,7 +35,7 @@ jobs:
               mechanisms=0
           fi
           CMAKE_PREFIX_PATH=/opt/dependencies cmake .. -GNinja -DTESTING=ON -DCMAKE_BUILD_TYPE=${{matrix.build_type}} -DEQUATIONS=${{matrix.equations}} -DPRECISION=${{matrix.precision}} -DNUMBER_OF_MECHANISMS=$mechanisms
-          ninja -j $(nproc)
+          ninja
 
       - name: test-seissol
         run: |


### PR DESCRIPTION
Replace the always-running dependency build with a Docker image, thus removing this startup time.