### PR TITLE
Remove Some Compiler Warnings

### DIFF
--- a/src/Checkpoint/mpio/WavefieldAsync.cpp
+++ b/src/Checkpoint/mpio/WavefieldAsync.cpp
@@ -43,7 +43,7 @@
 
 #include "WavefieldAsync.h"
 
-bool seissol::checkpoint::mpio::WavefieldAsync::init(unsigned long numDofs, unsigned int groupSize)
+bool seissol::checkpoint::mpio::WavefieldAsync::init(size_t, unsigned long numDofs, unsigned int groupSize)
 {
 	bool exists = Wavefield::init(numDofs, groupSize);
 

--- a/src/Checkpoint/mpio/WavefieldAsync.h
+++ b/src/Checkpoint/mpio/WavefieldAsync.h
@@ -78,7 +78,7 @@ public:
 	{
 	}
 
-	bool init(unsigned long numDofs, unsigned int groupSize = 1);
+	bool init(size_t, unsigned long numDofs, unsigned int groupSize = 1);
 
 	void writePrepare(const void* header, size_t headerSize);
 

--- a/src/DynamicRupture/FrictionLaws/BaseFrictionLaw.h
+++ b/src/DynamicRupture/FrictionLaws/BaseFrictionLaw.h
@@ -67,7 +67,7 @@ class BaseFrictionLaw : public FrictionSolver {
       TractionResults tractionResults = {};
 
       // loop over sub time steps (i.e. quadrature points in time)
-      for (unsigned timeIndex = 0; timeIndex < ConvergenceOrder; timeIndex++) {
+      for (std::size_t timeIndex = 0; timeIndex < ConvergenceOrder; timeIndex++) {
         common::adjustInitialStress(initialStressInFaultCS[ltsFace],
                                     nucleationStressInFaultCS[ltsFace],
                                     initialPressure[ltsFace],

--- a/src/DynamicRupture/FrictionLaws/FrictionSolver.cpp
+++ b/src/DynamicRupture/FrictionLaws/FrictionSolver.cpp
@@ -10,7 +10,7 @@ namespace seissol::dr::friction_law {
 void FrictionSolver::computeDeltaT(const double timePoints[ConvergenceOrder]) {
   deltaT[0] = timePoints[0];
   sumDt = deltaT[0];
-  for (unsigned timeIndex = 1; timeIndex < ConvergenceOrder; timeIndex++) {
+  for (std::size_t timeIndex = 1; timeIndex < ConvergenceOrder; timeIndex++) {
     deltaT[timeIndex] = timePoints[timeIndex] - timePoints[timeIndex - 1];
     sumDt += deltaT[timeIndex];
   }

--- a/src/DynamicRupture/FrictionLaws/FrictionSolver.cpp
+++ b/src/DynamicRupture/FrictionLaws/FrictionSolver.cpp
@@ -4,6 +4,7 @@
 #include "Initializer/DynamicRupture.h"
 #include "Initializer/Tree/Layer.h"
 #include "Kernels/Precision.h"
+#include <cstddef>
 
 namespace seissol::dr::friction_law {
 

--- a/src/Equations/elastic/Kernels/DirichletBoundary.cpp
+++ b/src/Equations/elastic/Kernels/DirichletBoundary.cpp
@@ -24,7 +24,7 @@ void computeAverageDisplacement(double deltaT,
   real factorial = 2.0;
   double power = deltaT * deltaT;
   
-  for (int der = 0; der < ConvergenceOrder; ++der) {
+  for (std::size_t der = 0; der < ConvergenceOrder; ++der) {
     intKrnl.power(der) = power / factorial;
 
     factorial *= der + 2.0;

--- a/src/Equations/elastic/Kernels/DirichletBoundary.h
+++ b/src/Equations/elastic/Kernels/DirichletBoundary.h
@@ -173,7 +173,7 @@ class DirichletBoundary {
     updateKernel.INodalUpdate = dofsFaceBoundaryNodalTmp;
     // Evaluate boundary conditions at precomputed nodes (in global coordinates).
   
-    for (int i = 0; i < ConvergenceOrder; ++i) {
+    for (unsigned i = 0; i < ConvergenceOrder; ++i) {
       boundaryDofsTmp.setZero();
       std::forward<Func>(evaluateBoundaryCondition)(boundaryMapping.nodes,
 						    timePoints[i],

--- a/src/Equations/elastic/Kernels/GravitationalFreeSurfaceBC.cpp
+++ b/src/Equations/elastic/Kernels/GravitationalFreeSurfaceBC.cpp
@@ -15,7 +15,7 @@ GravitationalFreeSurfaceBc::getFlopsDisplacementFace(unsigned int face, FaceType
   nonZeroFlops += 1 * numberOfNodes;
 
   // Before adjusting the range of the loop, check range of loop in computation!
-  for (int order = 1; order < ConvergenceOrder+ 1; ++order) {
+  for (std::size_t order = 1; order < ConvergenceOrder+ 1; ++order) {
 #ifdef USE_ELASTIC
     constexpr auto flopsPerQuadpoint =
         4 + // Computing coefficient

--- a/src/Equations/elastic/Kernels/GravitationalFreeSurfaceBC.h
+++ b/src/Equations/elastic/Kernels/GravitationalFreeSurfaceBC.h
@@ -119,7 +119,7 @@ public:
     const double Z = std::sqrt(materialData.local.getLambdaBar() * rho) ;
 
     // Note: Probably need to increase ConvergenceOrderby 1 here!
-    for (int order = 1; order < ConvergenceOrder+1; ++order) {
+    for (std::size_t order = 1; order < ConvergenceOrder+1; ++order) {
       dofsFaceNodal.setZero();
 
       projectKernel.execute(order - 1, faceIdx);
@@ -259,7 +259,7 @@ public:
       const double g = gravitationalAcceleration;
 
       auto** derivativesPtrs = dataTable[key].get(inner_keys::Wp::Id::Derivatives)->getDeviceDataPtr();
-      for (int order = 1; order < ConvergenceOrder+1; ++order) {
+      for (std::size_t order = 1; order < ConvergenceOrder+1; ++order) {
 
         factorEvaluated *= deltaT / (1.0 * order);
         factorInt *= deltaTInt / (order + 1.0);

--- a/src/Equations/elastic/Kernels/Time.cpp
+++ b/src/Equations/elastic/Kernels/Time.cpp
@@ -99,7 +99,7 @@ namespace seissol::kernels {
 
 TimeBase::TimeBase() {
   m_derivativesOffsets[0] = 0;
-  for (int order = 0; order < ConvergenceOrder; ++order) {
+  for (std::size_t order = 0; order < ConvergenceOrder; ++order) {
     if (order > 0) {
       m_derivativesOffsets[order] = tensor::dQ::size(order-1) + m_derivativesOffsets[order-1];
     }
@@ -116,7 +116,7 @@ void Time::setHostGlobalData(GlobalData const* global) {
 #ifdef USE_STP
   //Note: We could use the space time predictor for elasticity.
   //This is not tested and experimental
-  for (int n = 0; n < ConvergenceOrder; ++n) {
+  for (std::size_t n = 0; n < ConvergenceOrder; ++n) {
     if (n > 0) {
       for (int d = 0; d < 3; ++d) {
         m_krnlPrototype.kDivMTSub(d,n) = init::kDivMTSub::Values[tensor::kDivMTSub::index(d,n)];
@@ -203,7 +203,7 @@ void Time::computeAder(double timeStepWidth,
   krnl.I = timeIntegrated;
   // powers in the taylor-series expansion
   krnl.power(0) = timeStepWidth;
-  for (unsigned der = 1; der < ConvergenceOrder; ++der) {
+  for (std::size_t der = 1; der < ConvergenceOrder; ++der) {
     krnl.power(der) = krnl.power(der - 1) * timeStepWidth / real(der+1);
   }
 
@@ -286,7 +286,7 @@ void Time::computeBatchedAder(double timeStepWidth,
     real* tmpMem = reinterpret_cast<real*>(device.api->getStackMemory(maxTmpMem * numElements));
 
     derivativesKrnl.power(0) = timeStepWidth;
-    for (unsigned Der = 1; Der < ConvergenceOrder; ++Der) {
+    for (std::size_t Der = 1; Der < ConvergenceOrder; ++Der) {
       derivativesKrnl.power(Der) = derivativesKrnl.power(Der - 1) * timeStepWidth / real(Der + 1);
     }
     derivativesKrnl.linearAllocator.initialize(tmpMem);
@@ -369,7 +369,7 @@ void Time::computeIntegral( double                            expansionPoint,
   }
  
   // iterate over time derivatives
-  for(int der = 0; der < ConvergenceOrder; ++der ) {
+  for(std::size_t der = 0; der < ConvergenceOrder; ++der ) {
     firstTerm  *= deltaTUpper;
     secondTerm *= deltaTLower;
     factorial  *= (real)(der+1);
@@ -418,7 +418,7 @@ void Time::computeBatchedIntegral(double expansionPoint,
   }
 
   // iterate over time derivatives
-  for(int der = 0; der < ConvergenceOrder; ++der) {
+  for(std::size_t der = 0; der < ConvergenceOrder; ++der) {
     firstTerm *= deltaTUpper;
     secondTerm *= deltaTLower;
     factorial *= static_cast<real>(der + 1);
@@ -460,7 +460,7 @@ void Time::computeTaylorExpansion( real         time,
   intKrnl.power(0) = 1.0;
  
   // iterate over time derivatives
-  for(int derivative = 1; derivative < ConvergenceOrder; ++derivative) {
+  for(std::size_t derivative = 1; derivative < ConvergenceOrder; ++derivative) {
     intKrnl.power(derivative) = intKrnl.power(derivative - 1) * deltaT / real(derivative);
   }
 
@@ -491,7 +491,7 @@ void Time::computeBatchedTaylorExpansion(real time,
   // iterate over time derivatives
   const real deltaT = time - expansionPoint;
   intKrnl.power(0) = 1.0;
-  for(int derivative = 1; derivative < ConvergenceOrder; ++derivative) {
+  for(std::size_t derivative = 1; derivative < ConvergenceOrder; ++derivative) {
     intKrnl.power(derivative) = intKrnl.power(derivative - 1) * deltaT / static_cast<real>(derivative);
   }
 

--- a/src/Equations/poroelastic/Kernels/Time.cpp
+++ b/src/Equations/poroelastic/Kernels/Time.cpp
@@ -25,7 +25,7 @@ namespace seissol::kernels {
 
 TimeBase::TimeBase(){
   m_derivativesOffsets[0] = 0;
-  for (int order = 0; order < ConvergenceOrder; ++order) {
+  for (std::size_t order = 0; order < ConvergenceOrder; ++order) {
     if (order > 0) {
       m_derivativesOffsets[order] = tensor::dQ::size(order-1) + m_derivativesOffsets[order-1];
     }
@@ -33,7 +33,7 @@ TimeBase::TimeBase(){
 }
 
 void Time::setHostGlobalData(GlobalData const* global) {
-  for (int n = 0; n < ConvergenceOrder; ++n) {
+  for (std::size_t n = 0; n < ConvergenceOrder; ++n) {
     if (n > 0) {
       for (int d = 0; d < 3; ++d) {
         m_krnlPrototype.kDivMTSub(d,n) = init::kDivMTSub::Values[tensor::kDivMTSub::index(d,n)];
@@ -41,7 +41,7 @@ void Time::setHostGlobalData(GlobalData const* global) {
     }
     m_krnlPrototype.selectModes(n) = init::selectModes::Values[tensor::selectModes::index(n)];
   }
-  for (int k = 0; k < seissol::model::MaterialT::NumQuantities; k++) {
+  for (std::size_t k = 0; k < seissol::model::MaterialT::NumQuantities; k++) {
     m_krnlPrototype.selectQuantity(k) = init::selectQuantity::Values[tensor::selectQuantity::index(k)];
     m_krnlPrototype.selectQuantityG(k) = init::selectQuantityG::Values[tensor::selectQuantityG::index(k)];
   }
@@ -74,7 +74,7 @@ void Time::executeSTP( double                      timeStepWidth,
   real A_values[init::star::size(0)];
   real B_values[init::star::size(1)];
   real C_values[init::star::size(2)];
-  for (size_t i = 0; i < init::star::size(0); i++) {
+  for (std::size_t i = 0; i < init::star::size(0); i++) {
     A_values[i] = timeStepWidth * data.localIntegration().starMatrices[0][i];
     B_values[i] = timeStepWidth * data.localIntegration().starMatrices[1][i];
     C_values[i] = timeStepWidth * data.localIntegration().starMatrices[2][i];
@@ -100,13 +100,13 @@ void Time::executeSTP( double                      timeStepWidth,
     auto sourceMatrix = init::ET::view::create(data.localIntegration().specific.sourceMatrix);
     real ZinvData[seissol::model::MaterialT::NumQuantities][ConvergenceOrder*ConvergenceOrder];
     model::zInvInitializerForLoop<0, seissol::model::MaterialT::NumQuantities, decltype(sourceMatrix)>(ZinvData, sourceMatrix, timeStepWidth);
-    for (size_t i = 0; i < seissol::model::MaterialT::NumQuantities; i++) {
+    for (std::size_t i = 0; i < seissol::model::MaterialT::NumQuantities; i++) {
       krnl.Zinv(i) = ZinvData[i];
     }
     // krnl.execute has to be run here: ZinvData is only allocated locally
     krnl.execute();
   } else {
-    for (size_t i = 0; i < seissol::model::MaterialT::NumQuantities; i++) {
+    for (std::size_t i = 0; i < seissol::model::MaterialT::NumQuantities; i++) {
       krnl.Zinv(i) = data.localIntegration().specific.Zinv[i];
     }
     krnl.execute();
@@ -215,7 +215,7 @@ void Time::computeIntegral( double                            expansionPoint,
   }
  
   // iterate over time derivatives
-  for(int der = 0; der < ConvergenceOrder; ++der ) {
+  for(std::size_t der = 0; der < ConvergenceOrder; ++der ) {
     firstTerm  *= deltaTUpper;
     secondTerm *= deltaTLower;
     factorial  *= (real)(der+1);
@@ -251,7 +251,7 @@ void Time::computeTaylorExpansion( real         time,
   intKrnl.power(0) = 1.0;
  
   // iterate over time derivatives
-  for(int derivative = 1; derivative < ConvergenceOrder; ++derivative) {
+  for(std::size_t derivative = 1; derivative < ConvergenceOrder; ++derivative) {
     intKrnl.power(derivative) = intKrnl.power(derivative - 1) * deltaT / real(derivative);
   }
 

--- a/src/Equations/poroelastic/Model/PoroelasticSetup.h
+++ b/src/Equations/poroelastic/Model/PoroelasticSetup.h
@@ -261,8 +261,8 @@ namespace seissol {
       getTransposedCoefficientMatrix(material, 0, ATView);
       std::array<std::complex<double>, seissol::model::MaterialT::NumQuantities*seissol::model::MaterialT::NumQuantities> A;
       //transpose AT to get A
-      for (int i = 0; i < seissol::model::MaterialT::NumQuantities; i++) {
-        for (int j = 0; j < seissol::model::MaterialT::NumQuantities; j++) {
+      for (std::size_t i = 0; i < seissol::model::MaterialT::NumQuantities; i++) {
+        for (std::size_t j = 0; j < seissol::model::MaterialT::NumQuantities; j++) {
           A[i+seissol::model::MaterialT::NumQuantities*j] = AT[seissol::model::MaterialT::NumQuantities*i+j];
         }
       }
@@ -278,7 +278,7 @@ namespace seissol {
       //also check that the imaginary parts are zero
       int evNeg = 0;
       int evPos = 0;
-      for (int i = 0; i < seissol::model::MaterialT::NumQuantities; ++i) {
+      for (std::size_t i = 0; i < seissol::model::MaterialT::NumQuantities; ++i) {
         assert(std::abs(eigenvalues(i).imag()) < zeroThreshold);
         if (eigenvalues(i).real() < -zeroThreshold) {
           ++evNeg;
@@ -381,11 +381,11 @@ namespace seissol {
       }
 
       auto solver = Z.colPivHouseholderQr();
-      for(int col = 0; col < ConvergenceOrder; col++) {
+      for(std::size_t col = 0; col < ConvergenceOrder; col++) {
         Vector rhs = Vector::Zero();
         rhs(col) = 1.0;
         auto ZinvCol = solver.solve(rhs);
-        for(int row = 0; row < ConvergenceOrder; row++) {
+        for(std::size_t row = 0; row < ConvergenceOrder; row++) {
           //save as transposed
           Zinv(col,row) = ZinvCol(row);
         }

--- a/src/Equations/viscoelastic2/Kernels/Time.cpp
+++ b/src/Equations/viscoelastic2/Kernels/Time.cpp
@@ -127,7 +127,7 @@ void Time::computeAder(double timeStepWidth,
   // powers in the taylor-series expansion
   krnl.power(0) = timeStepWidth;
   
-  for (unsigned der = 1; der < ConvergenceOrder; ++der) {
+  for (std::size_t der = 1; der < ConvergenceOrder; ++der) {
     // update scalar for this derivative
     krnl.power(der) = krnl.power(der-1) * timeStepWidth / real(der+1);
   }
@@ -192,7 +192,7 @@ void Time::computeIntegral( double                                      expansio
   }
 
   // iterate over time derivatives
-  for(int der = 0; der < ConvergenceOrder; ++der ) {
+  for(std::size_t der = 0; der < ConvergenceOrder; ++der ) {
     firstTerm  *= deltaTUpper;
     secondTerm *= deltaTLower;
     factorial  *= static_cast<real>(der+1);
@@ -231,7 +231,7 @@ void Time::computeTaylorExpansion( real         time,
   intKrnl.power(0) = 1.0;
  
   // iterate over time derivatives
-  for(int derivative = 1; derivative < ConvergenceOrder; ++derivative) {
+  for(std::size_t derivative = 1; derivative < ConvergenceOrder; ++derivative) {
     intKrnl.power(derivative) = intKrnl.power(derivative - 1) * deltaT / real(derivative);
   }
 

--- a/src/Geometry/CubeGenerator.cpp
+++ b/src/Geometry/CubeGenerator.cpp
@@ -212,7 +212,6 @@ void seissol::geometry::CubeGenerator::cubeGenerator(
 
   // Setup MPI Communicator
 #ifdef USE_MPI
-  const int master = rank;
   MPI_Comm commMaster;
   MPI_Comm_split(seissol::MPI::mpi.comm(), rank % 1 == 0 ? 1 : MPI_UNDEFINED, rank, &commMaster);
 #endif // USE_MPI
@@ -1505,7 +1504,7 @@ void seissol::geometry::CubeGenerator::cubeGenerator(
   }
 
   // Copy buffers to vertices
-  for (int i = 0; i < uniqueVertices.size(); i++) {
+  for (std::size_t i = 0; i < uniqueVertices.size(); i++) {
     // VrtxCoord is defined as an int array of size 3
     memcpy(m_vertices[i].coords, &vrtxCoords[i * 3], sizeof(VrtxCoords));
   }

--- a/src/Geometry/PUMLReader.cpp
+++ b/src/Geometry/PUMLReader.cpp
@@ -225,7 +225,6 @@ void seissol::geometry::PUMLReader::read(PUML::TETPUML& puml, const char* meshFi
   } else if (boundaryFormat == seissol::initializer::parameters::BoundaryFormat::I32x4) {
     puml.addData<int>((file + ":/boundary").c_str(), PUML::CELL, {4});
   }
-  const auto numTotalCells = puml.numTotalCells();
 
   // TODO(David): change to uint64_t/size_t once we have an MPI module for that ready
   const size_t localCells = puml.numOriginalCells();

--- a/src/Initializer/CellLocalMatrices.cpp
+++ b/src/Initializer/CellLocalMatrices.cpp
@@ -620,7 +620,7 @@ void seissol::initializer::initializeDynamicRuptureMatrices( seissol::geometry::
           break;
         }
         case seissol::model::MaterialType::Anisotropic: {
-          logError() << "Dynamic Rupture does not work with anisotropy yet.";
+          logError() << "The Dynamic Rupture mechanism does not work with anisotropy yet.";
           //TODO(SW): Make DR work with anisotropy 
           break;
         }
@@ -632,6 +632,10 @@ void seissol::initializer::initializeDynamicRuptureMatrices( seissol::geometry::
         case seissol::model::MaterialType::Viscoelastic: {
           seissol::model::getTransposedCoefficientMatrix(*dynamic_cast<seissol::model::ViscoElasticMaterial*>(plusMaterial), 0, APlus);
           seissol::model::getTransposedCoefficientMatrix(*dynamic_cast<seissol::model::ViscoElasticMaterial*>(minusMaterial), 0, AMinus);
+          break;
+        }
+        default: {
+          logError() << "The Dynamic Rupture mechanism does not work with the given material yet.";
           break;
         }
       }
@@ -667,14 +671,14 @@ void seissol::initializer::initializeDynamicRuptureMatrices( seissol::geometry::
         surfaceArea = plusSurfaceArea;
       } else {
         /// Blow up solution on purpose if used by mistake
-        plusSurfaceArea = 1.e99; plusVolume = 1.0;
+        plusSurfaceArea = 1.e99; plusVolume = 1.0; surfaceArea = 1.e99;
       }
       if (fault[meshFace].neighborElement >= 0) {
         surfaceAreaAndVolume( i_meshReader, fault[meshFace].neighborElement, fault[meshFace].neighborSide, &minusSurfaceArea, &minusVolume );
         surfaceArea = minusSurfaceArea;
       } else {
         /// Blow up solution on purpose if used by mistake
-        minusSurfaceArea = 1.e99; minusVolume = 1.0;
+        minusSurfaceArea = 1.e99; minusVolume = 1.0; surfaceArea = 1.e99;
       }
       godunovData[ltsFace].doubledSurfaceArea = 2.0 * surfaceArea;
 

--- a/src/Initializer/InitProcedure/InitIO.cpp
+++ b/src/Initializer/InitProcedure/InitIO.cpp
@@ -17,7 +17,6 @@
 namespace {
 
 static void setupCheckpointing(seissol::SeisSol& seissolInstance) {
-  const auto& seissolParams = seissolInstance.getSeisSolParameters();
   auto& memoryManager = seissolInstance.getMemoryManager();
 
   auto* lts = memoryManager.getLts();

--- a/src/Initializer/InitProcedure/InitSideConditions.cpp
+++ b/src/Initializer/InitProcedure/InitSideConditions.cpp
@@ -20,6 +20,7 @@
 
 namespace {
 
+#if NUMBER_OF_RELAXATION_MECHANISMS == 0
 static TravellingWaveParameters getTravellingWaveInformation(seissol::SeisSol& seissolInstance) {
   const auto& initConditionParams = seissolInstance.getSeisSolParameters().initialization;
 
@@ -49,6 +50,7 @@ static AcousticTravellingWaveParametersITM
 
   return acousticTravellingWaveParametersITM;
 }
+#endif
 
 static std::vector<std::unique_ptr<physics::InitialField>>
     buildInitialConditionList(seissol::SeisSol& seissolInstance) {

--- a/src/Initializer/MemoryAllocator.h
+++ b/src/Initializer/MemoryAllocator.h
@@ -208,7 +208,7 @@ class MemkindArray {
     copyFrom(source);
   }
   MemkindArray(std::size_t capacity, Memkind memkind) : MemkindArray(memkind) { resize(capacity); }
-  MemkindArray(Memkind memkind) : memkind(memkind), dataPtr(nullptr), capacity(0) {}
+  MemkindArray(Memkind memkind) : memkind(memkind) {}
   void resize(std::size_t capacity) {
     this->capacity = capacity;
     free(dataPtr, memkind);
@@ -235,7 +235,7 @@ class MemkindArray {
 
   private:
   T* dataPtr{nullptr};
-  std::size_t capacity;
+  std::size_t capacity{0};
   enum Memkind memkind;
 };
 

--- a/src/Initializer/MemoryManager.cpp
+++ b/src/Initializer/MemoryManager.cpp
@@ -649,7 +649,7 @@ void seissol::initializer::MemoryManager::deriveFaceDisplacementsBucket()
           // Thanks to this hack, the array contains a constant plus the offset of the current
           // cell.
           displacements[cell][face] =
-              static_cast<real*>(nullptr) + 1 + numberOfFaces * tensor::faceDisplacement::size();
+              reinterpret_cast<real*>(1 + numberOfFaces * tensor::faceDisplacement::size());
           ++numberOfFaces;
         } else {
           displacements[cell][face] = nullptr;
@@ -757,7 +757,7 @@ void seissol::initializer::MemoryManager::initializeFaceDisplacements()
           // We then have the pointer offset that needs to be added to the bucket.
           // The final value of this pointer then points to a valid memory address
           // somewhere in the bucket.
-          auto offset = ((displacements[cell][face] - static_cast<real*>(nullptr)) - 1);
+          auto offset = (reinterpret_cast<std::intptr_t>(displacements[cell][face]) - 1);
           displacements[cell][face] = bucket + offset;
           displacementsDevice[cell][face] = bucketDevice + offset;
           for (unsigned dof = 0; dof < tensor::faceDisplacement::size(); ++dof) {

--- a/src/Initializer/ParameterDB.cpp
+++ b/src/Initializer/ParameterDB.cpp
@@ -174,7 +174,7 @@ seissol::initializer::ElementAverageGenerator::ElementAverageGenerator(
 
   std::copy(
       std::begin(quadratureWeights), std::end(quadratureWeights), std::begin(m_quadratureWeights));
-  for (int i = 0; i < NumQuadpoints; ++i) {
+  for (std::size_t i = 0; i < NumQuadpoints; ++i) {
     std::copy(std::begin(quadraturePoints[i]),
               std::end(quadraturePoints[i]),
               std::begin(m_quadraturePoints[i]));

--- a/src/Initializer/Parameters/DRParameters.cpp
+++ b/src/Initializer/Parameters/DRParameters.cpp
@@ -51,7 +51,6 @@ DRParameters readDRParameters(ParameterReader* baseReader) {
            "switching to SlipRateOutputType=0";
     slipRateOutputType = SlipRateOutputType::VelocityDifference;
   }
-  const auto backgroundType = reader->readWithDefault("backgroundtype", 0);
   const auto isThermalPressureOn = reader->readWithDefault("thermalpress", false);
   const auto healingThreshold =
       static_cast<real>(reader->readWithDefault("lsw_healingthreshold", -1.0));
@@ -103,7 +102,7 @@ DRParameters readDRParameters(ParameterReader* baseReader) {
 
   const double etaHack = outputReader->readWithDefault("etahack", 1.0);
 
-  reader->warnDeprecated({"rf_output_on"});
+  reader->warnDeprecated({"rf_output_on", "backgroundtype"});
 
   return DRParameters{isDynamicRuptureEnabled,
                       isThermalPressureOn,

--- a/src/Initializer/Parameters/InitializationParameters.cpp
+++ b/src/Initializer/Parameters/InitializationParameters.cpp
@@ -2,6 +2,7 @@
 #include <Equations/Datastructures.h>
 #include <Initializer/InputAux.h>
 #include <Initializer/Parameters/ParameterReader.h>
+#include <cstddef>
 #include <limits>
 
 namespace seissol::initializer::parameters {

--- a/src/Initializer/Parameters/InitializationParameters.cpp
+++ b/src/Initializer/Parameters/InitializationParameters.cpp
@@ -31,7 +31,7 @@ InitializationParameters readInitializationParameters(ParameterReader* baseReade
   const auto kVecRaw = seissol::initializer::convertStringToArray<double, 3>(kVecString);
   const Eigen::Vector3d kVec(kVecRaw.data());
   std::string defaultAmpFieldString;
-  for (int i = 0; i < seissol::model::MaterialT::NumQuantities; ++i) {
+  for (std::size_t i = 0; i < seissol::model::MaterialT::NumQuantities; ++i) {
     defaultAmpFieldString += " 0.0";
   }
   const auto ampFieldString = reader->readWithDefault("ampfield", defaultAmpFieldString);

--- a/src/Initializer/Parameters/LtsParameters.cpp
+++ b/src/Initializer/Parameters/LtsParameters.cpp
@@ -168,8 +168,6 @@ TimeSteppingParameters readTimeSteppingParameters(ParameterReader* baseReader) {
     maxTimestepWidth = reader->readWithDefault("fixtimestep", 5000.0);
   }
 
-  auto abortReader = baseReader->readSubNode("abortcriteria");
-
   auto* timeReader = baseReader->readSubNode("abortcriteria");
   const double endTime = timeReader->readWithDefault("endtime", 15.0);
 

--- a/src/Initializer/TimeStepping/LtsLayout.cpp
+++ b/src/Initializer/TimeStepping/LtsLayout.cpp
@@ -599,9 +599,6 @@ void seissol::initializer::time_stepping::LtsLayout::normalizeClustering() {
   unsigned int l_maximumDifference      = 0;
   unsigned int l_dynamicRupture         = 0;
   unsigned int l_singleBuffer           = 0;
-  unsigned int l_totalMaximumDifference = 0;
-  unsigned int l_totalDynamicRupture    = 0;
-  unsigned int l_totalSingleBuffer      = 0;
 
   int l_globalContinue = 1;
 
@@ -624,10 +621,6 @@ void seissol::initializer::time_stepping::LtsLayout::normalizeClustering() {
     // TODO: missing implementation (works only for max. difference 0 or 1)
     l_singleBuffer = enforceSingleBuffer();
 
-    l_totalMaximumDifference += l_maximumDifference;
-    l_totalDynamicRupture    += l_dynamicRupture;
-    l_totalSingleBuffer      += l_singleBuffer;
-
     // check if this rank requires another iteration
     int l_localContinue = l_maximumDifference + l_dynamicRupture + l_singleBuffer;
 
@@ -638,8 +631,6 @@ void seissol::initializer::time_stepping::LtsLayout::normalizeClustering() {
     l_globalContinue = l_localContinue;
 #endif
   }
-
-  //logInfo() << "Performed a total of" << l_totalMaximumDifference << "reductions (max. diff.) for" << m_cells.size() << "cells," << l_totalDynamicRupture << "reductions (dyn. rup.) for" << m_fault.size() << "faces.";
   
   int* localClusterHistogram = new int[m_numberOfGlobalClusters];
   for (unsigned cluster = 0; cluster < m_numberOfGlobalClusters; ++cluster) {

--- a/src/Initializer/TimeStepping/LtsWeights/LtsWeights.h
+++ b/src/Initializer/TimeStepping/LtsWeights/LtsWeights.h
@@ -123,7 +123,6 @@ protected:
   virtual void setAllowedImbalances() = 0;
   virtual int evaluateNumberOfConstraints() = 0;
 
-  seissol::initializer::parameters::BoundaryFormat boundaryFormat;
   std::string m_velocityModel{};
   unsigned m_rate{};
   std::vector<int> m_vertexWeights{};
@@ -137,6 +136,7 @@ protected:
   std::vector<int> m_clusterIds{};
   double wiggleFactor = 1.0;
   std::map<double, decltype(m_clusterIds)> clusteringCache; // Maps wiggle factor to clustering
+  seissol::initializer::parameters::BoundaryFormat boundaryFormat;
   struct ComputeWiggleFactorResult {
     int maxClusterId;
     double wiggleFactor;

--- a/src/Kernels/DynamicRupture.cpp
+++ b/src/Kernels/DynamicRupture.cpp
@@ -161,7 +161,7 @@ void DynamicRupture::spaceTimeInterpolation(
   alignas(PagesizeStack) real degreesOfFreedomMinus[tensor::Q::size()];
 
   dynamicRupture::kernel::evaluateAndRotateQAtInterpolationPoints krnl = m_krnlPrototype;
-  for (unsigned timeInterval = 0; timeInterval < ConvergenceOrder; ++timeInterval) {
+  for (std::size_t timeInterval = 0; timeInterval < ConvergenceOrder; ++timeInterval) {
 #ifdef USE_STP
     m_timeKernel.evaluateAtTime(
         timeBasisFunctions[timeInterval], timeDerivativePlus, degreesOfFreedomPlus);

--- a/src/Kernels/Receiver.cpp
+++ b/src/Kernels/Receiver.cpp
@@ -159,8 +159,6 @@ void ReceiverCluster::addReceiver(unsigned meshId,
 double ReceiverCluster::calcReceivers(
     double time, double expansionPoint, double timeStepWidth, Executor executor, void* stream) {
 
-  const std::size_t ncols = this->ncols();
-
   double outReceiverTime = time;
   while (outReceiverTime < expansionPoint + timeStepWidth) {
     outReceiverTime += m_samplingInterval;
@@ -175,8 +173,8 @@ double ReceiverCluster::calcReceivers(
 
   if (time >= expansionPoint && time < expansionPoint + timeStepWidth) {
     // heuristic; to avoid the overhead from the parallel region
-    auto threshold = std::max(1000, omp_get_num_threads() * 100);
-    auto recvCount = m_receivers.size();
+    const std::size_t threshold = std::max(1000, omp_get_num_threads() * 100);
+    const std::size_t recvCount = m_receivers.size();
 #ifdef _OPENMP
 #pragma omp parallel for schedule(static) if (recvCount >= threshold)
 #endif

--- a/src/Numerical/Transformation.cpp
+++ b/src/Numerical/Transformation.cpp
@@ -255,31 +255,31 @@ void seissol::transformations::chiTau2XiEtaZeta(unsigned face,
 void seissol::transformations::XiEtaZeta2chiTau(unsigned face,
                                                 const double xiEtaZeta[3],
                                                 double chiTau[2]) {
-  constexpr double EPS = 1e-6;
+  [[maybe_unused]] constexpr double Eps = 1e-6;
 
   switch (face) {
   case 0: {
     chiTau[1] = xiEtaZeta[0];
     chiTau[0] = xiEtaZeta[1];
-    assert((std::abs(xiEtaZeta[2]) < EPS) && "reference coord is not on the 1st face");
+    assert((std::abs(xiEtaZeta[2]) < Eps) && "reference coord is not on the 1st face");
     break;
   }
   case 1: {
     chiTau[0] = xiEtaZeta[0];
     chiTau[1] = xiEtaZeta[2];
-    assert((std::abs(xiEtaZeta[1]) < EPS) && "reference coord is not on the 2nd face");
+    assert((std::abs(xiEtaZeta[1]) < Eps) && "reference coord is not on the 2nd face");
     break;
   }
   case 2: {
     chiTau[1] = xiEtaZeta[1];
     chiTau[0] = xiEtaZeta[2];
-    assert((std::abs(xiEtaZeta[0]) < EPS) && "reference coord is not on the 3rd face");
+    assert((std::abs(xiEtaZeta[0]) < Eps) && "reference coord is not on the 3rd face");
     break;
   }
   case 3: {
     chiTau[0] = xiEtaZeta[1];
     chiTau[1] = xiEtaZeta[2];
-    assert((std::abs(xiEtaZeta[0] + xiEtaZeta[1] + xiEtaZeta[2] - 1.0) < EPS) &&
+    assert((std::abs(xiEtaZeta[0] + xiEtaZeta[1] + xiEtaZeta[2] - 1.0) < Eps) &&
            "reference coord is not on the 4th face");
     break;
   }

--- a/src/Parallel/Pin.cpp
+++ b/src/Parallel/Pin.cpp
@@ -126,7 +126,7 @@ CpuMask seissol::parallel::Pinning::computeOnlineCpuMask() {
     mask = std::deque<bool>(get_nprocs_conf(), true);
   }
 
-  assert(mask.size() == get_nprocs_conf());
+  assert(static_cast<int>(mask.size()) == get_nprocs_conf());
   for (unsigned cpu = 0; cpu < mask.size(); ++cpu) {
     if (mask[cpu]) {
       CPU_SET(cpu, &onlineMask.set);

--- a/src/ResultWriter/EnergyOutput.cpp
+++ b/src/ResultWriter/EnergyOutput.cpp
@@ -355,20 +355,21 @@ void EnergyOutput::computeDynamicRuptureEnergies() {
 }
 
 void EnergyOutput::computeVolumeEnergies() {
-  auto& totalGravitationalEnergyLocal = energiesStorage.gravitationalEnergy();
-  auto& totalAcousticEnergyLocal = energiesStorage.acousticEnergy();
-  auto& totalAcousticKineticEnergyLocal = energiesStorage.acousticKineticEnergy();
-  auto& totalMomentumX = energiesStorage.totalMomentumX();
-  auto& totalMomentumY = energiesStorage.totalMomentumY();
-  auto& totalMomentumZ = energiesStorage.totalMomentumZ();
-  auto& totalElasticEnergyLocal = energiesStorage.elasticEnergy();
-  auto& totalElasticKineticEnergyLocal = energiesStorage.elasticKineticEnergy();
-  auto& totalPlasticMoment = energiesStorage.plasticMoment();
+  // TODO: abstract energy calculation, and implement it for anisotropic and poroelastic
+  [[maybe_unused]] auto& totalGravitationalEnergyLocal = energiesStorage.gravitationalEnergy();
+  [[maybe_unused]] auto& totalAcousticEnergyLocal = energiesStorage.acousticEnergy();
+  [[maybe_unused]] auto& totalAcousticKineticEnergyLocal = energiesStorage.acousticKineticEnergy();
+  [[maybe_unused]] auto& totalMomentumX = energiesStorage.totalMomentumX();
+  [[maybe_unused]] auto& totalMomentumY = energiesStorage.totalMomentumY();
+  [[maybe_unused]] auto& totalMomentumZ = energiesStorage.totalMomentumZ();
+  [[maybe_unused]] auto& totalElasticEnergyLocal = energiesStorage.elasticEnergy();
+  [[maybe_unused]] auto& totalElasticKineticEnergyLocal = energiesStorage.elasticKineticEnergy();
+  [[maybe_unused]] auto& totalPlasticMoment = energiesStorage.plasticMoment();
 
   const std::vector<Element>& elements = meshReader->getElements();
   const std::vector<Vertex>& vertices = meshReader->getVertices();
 
-  const auto g = seissolInstance.getGravitationSetup().acceleration;
+  [[maybe_unused]] const auto g = seissolInstance.getGravitationSetup().acceleration;
 
   // Note: Default(none) is not possible, clang requires data sharing attribute for g, gcc forbids
   // it

--- a/src/ResultWriter/EnergyOutput.cpp
+++ b/src/ResultWriter/EnergyOutput.cpp
@@ -250,11 +250,11 @@ void EnergyOutput::computeDynamicRuptureEnergies() {
 #ifdef ACL_DEVICE
   void* stream = device::DeviceInstance::getInstance().api->getDefaultStream();
 #endif
-  constexpr auto QSize = tensor::Q::size();
   for (auto it = dynRupTree->beginLeaf(); it != dynRupTree->endLeaf(); ++it) {
     /// \todo timeDerivativePlus and timeDerivativeMinus are missing the last timestep.
     /// (We'd need to send the dofs over the network in order to fix this.)
 #ifdef ACL_DEVICE
+    constexpr auto QSize = tensor::Q::size();
     const ConditionalKey timeIntegrationKey(*KernelNames::DrTime);
     auto& table = it->getConditionalTable<inner_keys::Dr>();
     if (table.find(timeIntegrationKey) != table.end()) {
@@ -532,11 +532,7 @@ void EnergyOutput::computeVolumeEnergies() {
     if (isPlasticityEnabled) {
       // plastic moment
       real* pstrainCell = ltsLut->lookup(lts->pstrain, elementId);
-#ifdef USE_ANISOTROPIC
-      real mu = (material.local.c44 + material.local.c55 + material.local.c66) / 3.0;
-#else
-      const real mu = material.local.mu;
-#endif
+      const real mu = material.local.getMuBar();
       totalPlasticMoment += mu * volume * pstrainCell[tensor::QStress::size()];
     }
   }

--- a/src/ResultWriter/EnergyOutput.h
+++ b/src/ResultWriter/EnergyOutput.h
@@ -111,10 +111,13 @@ class EnergyOutput : public Module {
   std::string outputFileName;
   std::ofstream out;
 
+#ifdef ACL_DEVICE
   real* timeDerivativePlusHost = nullptr;
   real* timeDerivativeMinusHost = nullptr;
   real* timeDerivativePlusHostMapped = nullptr;
   real* timeDerivativeMinusHostMapped = nullptr;
+#endif
+
   const GlobalData* global = nullptr;
   seissol::initializer::DynamicRupture* dynRup = nullptr;
   seissol::initializer::LTSTree* dynRupTree = nullptr;

--- a/src/Solver/time_stepping/AbstractGhostTimeCluster.cpp
+++ b/src/Solver/time_stepping/AbstractGhostTimeCluster.cpp
@@ -96,7 +96,6 @@ void AbstractGhostTimeCluster::reset() {
 }
 
 void AbstractGhostTimeCluster::printTimeoutMessage(std::chrono::seconds timeSinceLastUpdate) {
-  const auto rank = MPI::mpi.rank();
   logError()
       << "Ghost: No update since " << timeSinceLastUpdate.count()
       << "[s] for global cluster " << globalClusterId

--- a/src/Solver/time_stepping/AbstractTimeCluster.cpp
+++ b/src/Solver/time_stepping/AbstractTimeCluster.cpp
@@ -214,7 +214,7 @@ void AbstractTimeCluster::reset() {
 
   // There can be pending messages from before the sync point
   processMessages();
-  for (auto& neighbor : neighbors) {
+  for ([[maybe_unused]] const auto& neighbor : neighbors) {
     assert(!neighbor.inbox->hasMessages());
   }
   ct.stepsSinceLastSync = 0;

--- a/src/Solver/time_stepping/AbstractTimeCluster.h
+++ b/src/Solver/time_stepping/AbstractTimeCluster.h
@@ -20,7 +20,6 @@ protected:
   ClusterTimes ct;
   std::vector<NeighborCluster> neighbors;
   double syncTime = 0.0;
-  Executor executor;
 
   [[nodiscard]] double timeStepSize() const;
 
@@ -44,6 +43,7 @@ protected:
   long timeStepRate;
   //! number of time steps
   long numberOfTimeSteps;
+  Executor executor;
 
 public:
   virtual ~AbstractTimeCluster() = default;

--- a/src/Solver/time_stepping/TimeManager.cpp
+++ b/src/Solver/time_stepping/TimeManager.cpp
@@ -191,9 +191,9 @@ void seissol::time_stepping::TimeManager::addClusters(TimeStepping& i_timeSteppi
         return static_cast<unsigned>(neighbor[1]) == otherGlobalClusterId;
       });
       if (hasNeighborRegions) {
-        assert(otherGlobalClusterId >= std::max(globalClusterId - 1, 0));
+        assert(static_cast<int>(otherGlobalClusterId) >= std::max(globalClusterId - 1, 0));
         assert(
-            otherGlobalClusterId <
+            static_cast<int>(otherGlobalClusterId) <
             std::min(globalClusterId + 2, static_cast<int>(m_timeStepping.numberOfGlobalClusters)));
         const auto otherTimeStepSize = m_timeStepping.globalCflTimeStepWidths[otherGlobalClusterId];
         const long otherTimeStepRate =

--- a/src/tests/Geometry/VariableSubsampler.t.h
+++ b/src/tests/Geometry/VariableSubsampler.t.h
@@ -37,7 +37,7 @@ TEST_CASE("Variable Subsampler") {
     // For order 3 there are 108 DOFs (taking alignment into account)
     std::array<real, 108> dofs;
     for (int i = 0; i < 108; i++) {
-      dofs[i] = (real)std::rand() / RAND_MAX;
+      dofs[i] = static_cast<real>(std::rand()) / static_cast<real>(RAND_MAX);
     }
     unsigned int cellMap[1] = {0};
     // A triangle is divided into four subtriangles there are 9 quantities.


### PR DESCRIPTION
We just remove most of the warnings that appear with `-Wall`. Excluding, most notably, the vectorization failures for the DR code, as well as the errors in the libxsmm-generated code.

(note that some of them occur because the energy computation isn't yet implemented for anisotropic elastic and poroelastic material)