### PR TITLE
Allow easi files to be used as initial conditions

### DIFF
--- a/src/Initializer/InitialFieldProjection.cpp
+++ b/src/Initializer/InitialFieldProjection.cpp
@@ -46,11 +46,13 @@
 #include "Initializer/MemoryManager.h"
 #include "Numerical/Quadrature.h"
 #include "Numerical/Transformation.h"
+#include "ParameterDB.h"
 #include "generated_code/kernel.h"
 #include "generated_code/tensor.h"
 
 #include "Initializer/PreProcessorMacros.h"
 #include <Common/Constants.h>
+#include <Equations/Datastructures.h>
 #include <Geometry/MeshReader.h>
 #include <Initializer/LTS.h>
 #include <Initializer/Tree/Lut.h>
@@ -60,8 +62,11 @@
 #include <Physics/InitialField.h>
 #include <array>
 #include <cstddef>
+#include <easi/YAMLParser.h>
+#include <easi/util/AsagiReader.h>
 #include <init.h>
 #include <memory>
+#include <set>
 #include <vector>
 
 GENERATE_HAS_MEMBER(selectAneFull)
@@ -73,6 +78,37 @@ namespace seissol::init {
 class selectAneFull;
 class selectElaFull;
 } // namespace seissol::init
+
+namespace {
+struct EasiLoader {
+  bool hasTime;
+  std::vector<std::unique_ptr<easi::Component>> components;
+  std::unique_ptr<easi::AsagiReader> asagiReader;
+  std::unique_ptr<easi::YAMLParser> parser;
+  EasiLoader(bool hasTime, const std::vector<std::string>& files) : hasTime(hasTime) {
+#ifdef USE_ASAGI
+    asagiReader = std::make_unique<seissol::asagi::AsagiReader>("SEISSOL_ASAGI");
+#else
+    asagiReader.reset();
+#endif
+
+    // NOTE: easi currently sorts the dimension names lexicographically (due to using std::set)
+    // hence: if we have time as a dimension, it will come first
+    const auto dimensions = hasTime ? 4 : 3;
+    const auto dimensionNames =
+        hasTime ? std::set<std::string>{"t", "x", "y", "z"} : std::set<std::string>{"x", "y", "z"};
+#if EASI_VERSION_MINOR < 5
+    parser = std::make_unique<easi::YAMLParser>(dimensions, asagiReader.get(), 'x');
+#else
+    parser = std::make_unique<easi::YAMLParser>(dimensionNames, asagiReader.get());
+#endif
+    components.resize(files.size());
+    for (std::size_t i = 0; i < files.size(); ++i) {
+      components[i] = std::unique_ptr<easi::Component>(parser->parse(files.at(i)));
+    }
+  }
+};
+} // namespace
 
 namespace seissol::initializer {
 
@@ -134,6 +170,131 @@ void projectInitialField(const std::vector<std::unique_ptr<physics::InitialField
 #else
     iniFields[0]->evaluate(0.0, quadraturePointsXyz, material, iniCond);
 #endif
+
+      krnl.Q = ltsLut.lookup(lts.dofs, meshId);
+      if constexpr (kernels::HasSize<tensor::Qane>::Value) {
+        kernels::set_Qane(krnl, &ltsLut.lookup(lts.dofsAne, meshId)[0]);
+      }
+      krnl.execute();
+    }
+#if defined(_OPENMP) && !NVHPC_AVOID_OMP
+  }
+#endif
+
+  seissol::initializer::synchronizeLTSTreeDuplicates(lts.dofs, memoryManager);
+  if (kernels::size<tensor::Qane>() > 0) {
+    seissol::initializer::synchronizeLTSTreeDuplicates(lts.dofsAne, memoryManager);
+  }
+}
+
+std::vector<double> projectEasiFields(const std::vector<std::string>& iniFields,
+                                      double time,
+                                      const seissol::geometry::MeshReader& meshReader) {
+  const auto& vertices = meshReader.getVertices();
+  const auto& elements = meshReader.getElements();
+
+  constexpr auto QuadPolyDegree = ConvergenceOrder + 1;
+  constexpr auto NumQuadPoints = QuadPolyDegree * QuadPolyDegree * QuadPolyDegree;
+
+  const bool hasTime = false;
+
+  const int dimensions = hasTime ? 4 : 3;
+  const int spaceStart = hasTime ? 1 : 0;
+  easi::Query query(elements.size() * NumQuadPoints, dimensions);
+
+  {
+    double quadraturePoints[NumQuadPoints][3];
+    double quadratureWeights[NumQuadPoints];
+    seissol::quadrature::TetrahedronQuadrature(quadraturePoints, quadratureWeights, QuadPolyDegree);
+#ifdef _OPENMP
+#pragma omp parallel for schedule(static)
+#endif
+    for (std::size_t elem = 0; elem < elements.size(); ++elem) {
+      const double* elementCoords[4];
+      for (size_t v = 0; v < 4; ++v) {
+        elementCoords[v] = vertices[elements[elem].vertices[v]].coords;
+      }
+      for (size_t i = 0; i < NumQuadPoints; ++i) {
+        std::array<double, 3> transformed;
+        seissol::transformations::tetrahedronReferenceToGlobal(elementCoords[0],
+                                                               elementCoords[1],
+                                                               elementCoords[2],
+                                                               elementCoords[3],
+                                                               quadraturePoints[i],
+                                                               transformed.data());
+        query.x(elem * NumQuadPoints + i, spaceStart + 0) = transformed[0];
+        query.x(elem * NumQuadPoints + i, spaceStart + 1) = transformed[1];
+        query.x(elem * NumQuadPoints + i, spaceStart + 2) = transformed[2];
+        if (hasTime) {
+          query.x(elem * NumQuadPoints + i, 0) = 0;
+        }
+        query.group(elem * NumQuadPoints + i) = elements[elem].group;
+      }
+    }
+  }
+
+  std::vector<double> data(NumQuadPoints * iniFields.size() * model::MaterialT::Quantities.size() *
+                           elements.size());
+  const auto dataPointStride = iniFields.size() * model::MaterialT::Quantities.size();
+  {
+    auto models = EasiLoader(hasTime, iniFields);
+    for (std::size_t i = 0; i < iniFields.size(); ++i) {
+      auto adapter = easi::ArraysAdapter();
+      for (std::size_t j = 0; j < model::MaterialT::Quantities.size(); ++j) {
+        const auto& quantity = model::MaterialT::Quantities.at(j);
+        const std::size_t bindOffset = i + j * iniFields.size();
+        adapter.addBindingPoint(quantity, data.data() + bindOffset, dataPointStride);
+      }
+      models.components.at(i)->evaluate(query, adapter);
+    }
+  }
+
+  return data;
+}
+
+void projectEasiInitialField(const std::vector<std::string>& iniFields,
+                             const GlobalData& globalData,
+                             const seissol::geometry::MeshReader& meshReader,
+                             seissol::initializer::MemoryManager& memoryManager,
+                             LTS const& lts,
+                             const Lut& ltsLut) {
+  const auto& vertices = meshReader.getVertices();
+  const auto& elements = meshReader.getElements();
+
+  constexpr auto QuadPolyDegree = ConvergenceOrder + 1;
+  constexpr auto NumQuadPoints = QuadPolyDegree * QuadPolyDegree * QuadPolyDegree;
+
+  const auto data = projectEasiFields(iniFields, 0, meshReader);
+
+  const auto dataStride = NumQuadPoints * iniFields.size() * model::MaterialT::Quantities.size();
+  const auto quantityCount = model::MaterialT::Quantities.size();
+
+#if defined(_OPENMP) && !NVHPC_AVOID_OMP
+#pragma omp parallel
+  {
+#endif
+    alignas(Alignment) real iniCondData[tensor::iniCond::size()] = {};
+    auto iniCond = init::iniCond::view::create(iniCondData);
+
+    std::vector<std::array<double, 3>> quadraturePointsXyz;
+    quadraturePointsXyz.resize(NumQuadPoints);
+
+    kernel::projectIniCond krnl;
+    krnl.projectQP = globalData.projectQPMatrix;
+    krnl.iniCond = iniCondData;
+    kernels::set_selectAneFull(krnl, kernels::get_static_ptr_Values<init::selectAneFull>());
+    kernels::set_selectElaFull(krnl, kernels::get_static_ptr_Values<init::selectElaFull>());
+
+#if defined(_OPENMP) && !NVHPC_AVOID_OMP
+#pragma omp for schedule(static)
+#endif
+    for (unsigned int meshId = 0; meshId < elements.size(); ++meshId) {
+      // TODO: multisim loop
+      for (std::size_t i = 0; i < NumQuadPoints; ++i) {
+        for (std::size_t j = 0; j < quantityCount; ++j) {
+          iniCond(i, j) = data.at(meshId * dataStride + quantityCount * i + j);
+        }
+      }
 
       krnl.Q = ltsLut.lookup(lts.dofs, meshId);
       if constexpr (kernels::HasSize<tensor::Qane>::Value) {

--- a/src/Initializer/InitialFieldProjection.h
+++ b/src/Initializer/InitialFieldProjection.h
@@ -42,6 +42,7 @@
 #define INITIALIZER_INITIALFIELDPROJECTION_H_
 
 #include <memory>
+#include <vector>
 
 #include "Geometry/MeshReader.h"
 #include "Initializer/LTS.h"
@@ -57,6 +58,17 @@ void projectInitialField(const std::vector<std::unique_ptr<physics::InitialField
                          seissol::initializer::MemoryManager& memoryManager,
                          LTS const& lts,
                          const Lut& ltsLut);
+
+std::vector<double> projectEasiFields(const std::vector<std::string>& iniFields,
+                                      double time,
+                                      const seissol::geometry::MeshReader& meshReader);
+
+void projectEasiInitialField(const std::vector<std::string>& iniFields,
+                             const GlobalData& globalData,
+                             const seissol::geometry::MeshReader& meshReader,
+                             seissol::initializer::MemoryManager& memoryManager,
+                             LTS const& lts,
+                             const Lut& ltsLut);
 } // namespace seissol::initializer
 
 #endif

--- a/src/Initializer/Parameters/InitializationParameters.cpp
+++ b/src/Initializer/Parameters/InitializationParameters.cpp
@@ -24,6 +24,7 @@ InitializationParameters readInitializationParameters(ParameterReader* baseReade
           {"ocean_1", InitializationType::Ocean1},
           {"ocean_2", InitializationType::Ocean2},
           {"pressureinjection", InitializationType::PressureInjection},
+          {"easi", InitializationType::Easi},
       });
   const auto originString = reader->readWithDefault("origin", std::string("0.0 0.0 0.0"));
   const auto originRaw = seissol::initializer::convertStringToArray<double, 3>(originString);
@@ -46,6 +47,8 @@ InitializationParameters readInitializationParameters(ParameterReader* baseReade
   const auto width = reader->readWithDefault("width", std::numeric_limits<double>::infinity());
   const auto k = reader->readWithDefault("k", 0.0);
 
-  return InitializationParameters{type, origin, kVec, ampField, magnitude, width, k};
+  const auto filename = reader->readPath("filename").value_or("");
+
+  return InitializationParameters{type, origin, kVec, ampField, magnitude, width, k, filename};
 }
 } // namespace seissol::initializer::parameters

--- a/src/Initializer/Parameters/InitializationParameters.h
+++ b/src/Initializer/Parameters/InitializationParameters.h
@@ -20,7 +20,8 @@ enum class InitializationType : int {
   Ocean0,
   Ocean1,
   Ocean2,
-  PressureInjection
+  PressureInjection,
+  Easi
 };
 
 struct InitializationParameters {
@@ -31,6 +32,7 @@ struct InitializationParameters {
   double magnitude;
   double width;
   double k;
+  std::string filename;
 };
 
 InitializationParameters readInitializationParameters(ParameterReader* baseReader);

--- a/src/ResultWriter/AnalysisWriter.cpp
+++ b/src/ResultWriter/AnalysisWriter.cpp
@@ -3,6 +3,7 @@
 #include <Common/Constants.h>
 #include <Geometry/MeshDefinition.h>
 #include <Geometry/MeshTools.h>
+#include <Initializer/InitialFieldProjection.h>
 #include <Initializer/Parameters/InitializationParameters.h>
 #include <Initializer/Typedefs.h>
 #include <Kernels/Precision.h>
@@ -96,6 +97,15 @@ void AnalysisWriter::printAnalysis(double simulationTime) {
   constexpr auto QuadPolyDegree = ConvergenceOrder + 1;
   constexpr auto NumQuadPoints = QuadPolyDegree * QuadPolyDegree * QuadPolyDegree;
 
+  std::vector<double> data;
+
+  if (initialConditionType == seissol::initializer::parameters::InitializationType::Easi) {
+    data = initializer::projectEasiFields(
+        {seissolInstance.getSeisSolParameters().initialization.filename},
+        simulationTime,
+        *meshReader);
+  }
+
   double quadraturePoints[NumQuadPoints][3];
   double quadratureWeights[NumQuadPoints];
   seissol::quadrature::TetrahedronQuadrature(quadraturePoints, quadratureWeights, QuadPolyDegree);
@@ -177,19 +187,39 @@ void AnalysisWriter::printAnalysis(double simulationTime) {
       const auto volume = MeshTools::volume(elements[meshId], vertices);
       const auto jacobiDet = 6 * volume;
 
-      // Compute global position of quadrature points.
-      const double* elementCoords[4];
-      for (unsigned v = 0; v < 4; ++v) {
-        elementCoords[v] = vertices[elements[meshId].vertices[v]].coords;
+      if (initialConditionType != seissol::initializer::parameters::InitializationType::Easi) {
+        // Compute global position of quadrature points.
+        const double* elementCoords[4];
+        for (unsigned v = 0; v < 4; ++v) {
+          elementCoords[v] = vertices[elements[meshId].vertices[v]].coords;
+        }
+        for (unsigned int i = 0; i < NumQuadPoints; ++i) {
+          seissol::transformations::tetrahedronReferenceToGlobal(elementCoords[0],
+                                                                 elementCoords[1],
+                                                                 elementCoords[2],
+                                                                 elementCoords[3],
+                                                                 quadraturePoints[i],
+                                                                 quadraturePointsXyz[i].data());
+        }
+
+        // Evaluate analytical solution at quad. nodes
+        const CellMaterialData& material = ltsLut->lookup(lts->material, meshId);
+        iniFields[sim % iniFields.size()]->evaluate(
+            simulationTime, quadraturePointsXyz, material, analyticalSolution);
+      } else {
+        for (std::size_t i = 0; i < NumQuadPoints; ++i) {
+          for (std::size_t j = 0; j < NumQuantities; ++j) {
+            analyticalSolution(i, j) =
+                data.at(meshId * NumQuadPoints * NumQuantities + NumQuantities * i + j);
+          }
+        }
       }
-      for (unsigned int i = 0; i < NumQuadPoints; ++i) {
-        seissol::transformations::tetrahedronReferenceToGlobal(elementCoords[0],
-                                                               elementCoords[1],
-                                                               elementCoords[2],
-                                                               elementCoords[3],
-                                                               quadraturePoints[i],
-                                                               quadraturePointsXyz[i].data());
-      }
+
+#ifdef MULTIPLE_SIMULATIONS
+      auto numSub = numericalSolution.subtensor(sim, yateto::slice<>(), yateto::slice<>());
+#else
+      auto numSub = numericalSolution;
+#endif
 
       // Evaluate numerical solution at quad. nodes
       kernel::evalAtQP krnl;
@@ -197,16 +227,6 @@ void AnalysisWriter::printAnalysis(double simulationTime) {
       krnl.dofsQP = numericalSolutionData;
       krnl.Q = ltsLut->lookup(lts->dofs, meshId);
       krnl.execute();
-
-      // Evaluate analytical solution at quad. nodes
-      const CellMaterialData& material = ltsLut->lookup(lts->material, meshId);
-      iniFields[sim % iniFields.size()]->evaluate(
-          simulationTime, quadraturePointsXyz, material, analyticalSolution);
-#ifdef MULTIPLE_SIMULATIONS
-      auto numSub = numericalSolution.subtensor(sim, yateto::slice<>(), yateto::slice<>());
-#else
-      auto numSub = numericalSolution;
-#endif
 
       for (size_t i = 0; i < NumQuadPoints; ++i) {
         const auto curWeight = jacobiDet * quadratureWeights[i];

--- a/src/sources.cmake
+++ b/src/sources.cmake
@@ -44,6 +44,7 @@ src/DynamicRupture/Initializer/RateAndStateInitializer.cpp
 src/DynamicRupture/Misc.cpp
 
 src/Equations/elastic/Kernels/GravitationalFreeSurfaceBC.cpp
+src/Initializer/InitialFieldProjection.cpp
 src/Initializer/PointMapper.cpp
 src/Modules/Module.cpp
 src/Modules/Modules.cpp
@@ -117,7 +118,6 @@ src/Initializer/InitProcedure/InitMesh.cpp
 src/Initializer/InitProcedure/InitModel.cpp
 src/Initializer/InitProcedure/InitIO.cpp
 src/Initializer/InitProcedure/InitSideConditions.cpp
-src/Initializer/InitialFieldProjection.cpp
 src/Initializer/InternalState.cpp
 src/Initializer/MemoryAllocator.cpp
 src/Initializer/MemoryManager.cpp


### PR DESCRIPTION
Use `easi` files for initial condition setup, instead of having them hard-coded in the C++ files. With [easi/#62 ](https://github.com/SeisSol/easi/pull/62), time-dependent input is also possible (it would be also before; if you'd name the time variable `'w'`), if you want to check against a pre-defined solution after some time (cf. `AnalysisWriter.cpp`).
All equations are supported (using the same names as for the receiver quantities each). Multiple simulations _may_ in principle also be easily addable, but you'd have to use easi for all of them right now. Plasticity is not yet implemented; though it could probably be added quite easily as well.

Maybe it's of use for someone—it currently still uses a rather different code path than the existent initial condition implementation (i.e. gather all quadrature points in advance, run easi on them, process the result; instead of calling the initial condition on every cell directly). It's probably possible to merge it with the existent implementation in `Physics/InitialField.h` (plus/minus the analytical boundary condition)—if that's wanted. If we give the material parameters to the initial condition easi as input, we can probably convert/remove all existing conditions (maybe keep some `yaml` files in the SeisSol repository for backwards compatibility). At the cost of a tiny bit longer runtime.

May not be completely merge-ready yet and probably requires some better verification. Hence draft.
