### PR TITLE
Upgrade to Clang Format 19

### DIFF
--- a/.ci/format.sh
+++ b/.ci/format.sh
@@ -108,9 +108,9 @@ format() {
     fi
 
     local formatter_version=$(${formatter} --version)
-    if [ "${formatter_version}" != "clang-format version 18.1.5" ]; then
-        echo "Your clang-format tool in \"${formatter}\" does not have the correct version (should be 18.1.5). Given: ${formatter_version}"
-        echo "Hint: you may install the required clang-format via pip, by typing: pip3 install clang-format==18.1.5"
+    if [ "${formatter_version}" != "clang-format version 19.1.0" ]; then
+        echo "Your clang-format tool in \"${formatter}\" does not have the correct version (should be 19.1.0). Given: ${formatter_version}"
+        echo "Hint: you may install the required clang-format via pip, by typing: pip3 install clang-format==19.1.0"
         exit 176
     fi
 

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2024 SeisSol Group
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
 name: build-docker
 
 on:

--- a/.github/workflows/build-seissol.yml
+++ b/.github/workflows/build-seissol.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2024 SeisSol Group
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
 name: build-seissol
 on:
   - push

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2024 SeisSol Group
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
 name: clang-format
 on:
   - push
@@ -5,7 +9,7 @@ on:
 jobs:
   clang-format:
     name: clang-format
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
 
@@ -15,7 +19,7 @@ jobs:
           sudo apt-get -y install python3 python3-pip
 
           # fix version here for now
-          pip3 install clang-format==18.1.5
+          pip3 install clang-format==19.1.0 --break-system-packages
 
       - name: run-clang-format
         run: |

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2024 SeisSol Group
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
 name: clang-tidy
 on:
   - push
@@ -5,22 +9,22 @@ on:
 jobs:
   clang-tidy:
     name: clang-tidy
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: apt-get
         run: |
           sudo apt-get update
-          sudo apt-get install hdf5-tools libeigen3-dev libhdf5-openmpi-103 libhdf5-openmpi-dev libmetis-dev libomp-dev libopenmpi-dev libparmetis-dev libyaml-cpp-dev openmpi-bin openmpi-common python3 python3-pip
+          sudo apt-get install hdf5-tools libeigen3-dev libhdf5-openmpi-dev libmetis-dev libomp-dev libopenmpi-dev libparmetis-dev libyaml-cpp-dev openmpi-bin openmpi-common python3.10 python3-pip
 
           # keep, for once clang-19 or higher is needed
           wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-          sudo add-apt-repository "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-18 main"
-          sudo add-apt-repository "deb-src http://apt.llvm.org/jammy/ llvm-toolchain-jammy-18 main"
+          sudo add-apt-repository "deb http://apt.llvm.org/noble/ llvm-toolchain-noble-18 main"
+          sudo add-apt-repository "deb-src http://apt.llvm.org/noble/ llvm-toolchain-noble-18 main"
           sudo apt-get update
 
           sudo apt-get -y install clang-18 clang-tidy-18 libomp-18-dev
 
-          sudo pip3 install numpy
+          sudo pip3 install numpy --break-system-packages
           sudo mkdir -p /opt/dependencies
 
       - name: checkout-libxsmm

--- a/.github/workflows/doc-template.yml
+++ b/.github/workflows/doc-template.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2024 SeisSol Group
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
 name: seissol-documentation
 on:
   - push
@@ -5,7 +9,7 @@ on:
 jobs:
   seissol-documentation:
     name: seissol-documentation
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
 
@@ -15,9 +19,7 @@ jobs:
           export IFS=$'\n\t'
           sudo apt-get update
           sudo apt-get install -qq python3 python3-pip
-          sudo pip3 install --upgrade pip
-          sudo pip3 install sphinx
-          sudo pip3 install sphinx_rtd_theme
+          sudo pip3 install sphinx sphinx_rtd_theme --break-system-packages
 
       - name: build-documentation
         run: |

--- a/.github/workflows/github-to-gitlab-push-sync.yml
+++ b/.github/workflows/github-to-gitlab-push-sync.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2024 SeisSol Group
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
 name: codehub-hlrs-sync
 
 on: 

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -130,7 +130,9 @@ int main(int argc, char* argv[]) {
   }
 
 #pragma omp parallel
-  { LIKWID_MARKER_START("SeisSol"); }
+  {
+    LIKWID_MARKER_START("SeisSol");
+  }
 
   EPIK_TRACER("SeisSol");
   SCOREP_USER_REGION("SeisSol", SCOREP_USER_REGION_TYPE_FUNCTION);
@@ -200,7 +202,9 @@ int main(int argc, char* argv[]) {
   }
 
 #pragma omp parallel
-  { LIKWID_MARKER_STOP("SeisSol"); }
+  {
+    LIKWID_MARKER_STOP("SeisSol");
+  }
 
   LIKWID_MARKER_CLOSE;
   // Finalize SeisSol

--- a/src/Parallel/Pin.cpp
+++ b/src/Parallel/Pin.cpp
@@ -201,7 +201,9 @@ CpuMask Pinning::getWorkerUnionMask() {
     CPU_ZERO(&worker);
     sched_getaffinity(0, sizeof(cpu_set_t), &worker);
 #pragma omp critical
-    { CPU_OR(&workerUnion, &workerUnion, &worker); }
+    {
+      CPU_OR(&workerUnion, &workerUnion, &worker);
+    }
   }
 #else
   sched_getaffinity(0, sizeof(cpu_set_t), &workerUnion);

--- a/src/Parallel/SyclInterop.h
+++ b/src/Parallel/SyclInterop.h
@@ -90,7 +90,9 @@ sycl::event syclNativeOperation(sycl::queue& queue, bool blocking, F&& function)
         return;
       }
 #endif
-      { logError() << "Unknown backend" << static_cast<int>(queue.get_device().get_backend()); }
+      {
+        logError() << "Unknown backend" << static_cast<int>(queue.get_device().get_backend());
+      }
     });
 #else
     // we cannot take the fast path; so just submit a host task instead
@@ -109,7 +111,9 @@ sycl::event syclNativeOperation(sycl::queue& queue, bool blocking, F&& function)
         return;
       }
 #endif
-      { logError() << "Unknown backend" << static_cast<int>(queue.get_device().get_backend()); }
+      {
+        logError() << "Unknown backend" << static_cast<int>(queue.get_device().get_backend());
+      }
     });
 #endif
   });


### PR DESCRIPTION
Pip now offers `clang-format==19.1.0`; hence this PR does the upgrade.