### PR TITLE
Add the No-Fault Friction Law for the GPU

### DIFF
--- a/src/DynamicRupture/Factory.cpp
+++ b/src/DynamicRupture/Factory.cpp
@@ -56,7 +56,7 @@ DynamicRuptureTuple NoFaultFactory::produce() {
   return {std::make_unique<seissol::initializer::DynamicRupture>(),
           std::make_unique<initializer::NoFaultInitializer>(drParameters, seissolInstance),
           std::make_unique<friction_law::NoFault>(drParameters.get()),
-          std::make_unique<friction_law::NoFault>(drParameters.get()),
+          std::make_unique<friction_law_gpu::NoFault>(drParameters.get()),
           std::make_unique<output::OutputManager>(std::make_unique<output::NoFault>(),
                                                   seissolInstance)};
 }

--- a/src/DynamicRupture/FrictionLaws/BaseFrictionLaw.h
+++ b/src/DynamicRupture/FrictionLaws/BaseFrictionLaw.h
@@ -31,7 +31,7 @@ class BaseFrictionLaw : public FrictionSolver {
     if (layerData.getNumberOfCells() == 0) {
       return;
     }
-    
+
     SCOREP_USER_REGION_DEFINE(myRegionHandle)
     BaseFrictionLaw::copyLtsTreeToLocal(layerData, dynRup, fullUpdateTime);
     static_cast<Derived*>(this)->copyLtsTreeToLocal(layerData, dynRup, fullUpdateTime);

--- a/src/DynamicRupture/FrictionLaws/BaseFrictionLaw.h
+++ b/src/DynamicRupture/FrictionLaws/BaseFrictionLaw.h
@@ -28,6 +28,10 @@ class BaseFrictionLaw : public FrictionSolver {
                 real fullUpdateTime,
                 const double timeWeights[ConvergenceOrder],
                 seissol::parallel::runtime::StreamRuntime& runtime) override {
+    if (layerData.getNumberOfCells() == 0) {
+      return;
+    }
+    
     SCOREP_USER_REGION_DEFINE(myRegionHandle)
     BaseFrictionLaw::copyLtsTreeToLocal(layerData, dynRup, fullUpdateTime);
     static_cast<Derived*>(this)->copyLtsTreeToLocal(layerData, dynRup, fullUpdateTime);

--- a/src/DynamicRupture/FrictionLaws/FrictionLaws.h
+++ b/src/DynamicRupture/FrictionLaws/FrictionLaws.h
@@ -20,6 +20,7 @@
 #include "GpuImpl/AgingLaw.h"
 #include "GpuImpl/FastVelocityWeakeningLaw.h"
 #include "GpuImpl/LinearSlipWeakening.h"
+#include "GpuImpl/NoFault.h"
 #include "GpuImpl/SlipLaw.h"
 #include "GpuImpl/ThermalPressurization/NoTP.h"
 #endif

--- a/src/DynamicRupture/FrictionLaws/GpuImpl/NoFault.h
+++ b/src/DynamicRupture/FrictionLaws/GpuImpl/NoFault.h
@@ -1,0 +1,53 @@
+#ifndef SEISSOL_GPU_NOFAULT_H
+#define SEISSOL_GPU_NOFAULT_H
+
+#include "DynamicRupture/FrictionLaws/GpuImpl/BaseFrictionSolver.h"
+
+namespace seissol::dr::friction_law::gpu {
+
+class NoFault : public BaseFrictionSolver<NoFault> {
+  public:
+  NoFault(seissol::initializer::parameters::DRParameters* drParameters)
+      : BaseFrictionSolver<NoFault>(drParameters) {};
+
+  void updateFrictionAndSlip(unsigned timeIndex) {
+    auto* devTraction1{this->traction1};
+    auto* devTraction2{this->traction2};
+    auto* devFaultStresses{this->faultStresses};
+    auto* devTractionResults{this->tractionResults};
+
+    sycl::nd_range rng{{this->currLayerSize * misc::numPaddedPoints}, {misc::numPaddedPoints}};
+    this->queue.submit([&](sycl::handler& cgh) {
+      cgh.parallel_for(rng, [=](sycl::nd_item<1> item) {
+        const auto ltsFace = item.get_group().get_group_id(0);
+        const auto pointIndex = item.get_local_id(0);
+
+        auto& faultStresses = devFaultStresses[ltsFace];
+        auto& tractionResults = devTractionResults[ltsFace];
+
+        // calculate traction
+        tractionResults.traction1[timeIndex][pointIndex] =
+            faultStresses.traction1[timeIndex][pointIndex];
+        tractionResults.traction2[timeIndex][pointIndex] =
+            faultStresses.traction2[timeIndex][pointIndex];
+        devTraction1[ltsFace][pointIndex] = tractionResults.traction1[timeIndex][pointIndex];
+        devTraction2[ltsFace][pointIndex] = tractionResults.traction2[timeIndex][pointIndex];
+      });
+    });
+  }
+
+  /*
+   * output time when shear stress is equal to the dynamic stress after rupture arrived
+   * currently only for linear slip weakening
+   */
+  void saveDynamicStressOutput() {}
+
+  void preHook(real (*stateVariableBuffer)[misc::numPaddedPoints]) {}
+  void postHook(real (*stateVariableBuffer)[misc::numPaddedPoints]) {}
+
+  protected:
+};
+
+} // namespace seissol::dr::friction_law::gpu
+
+#endif

--- a/src/DynamicRupture/FrictionLaws/GpuImpl/NoFault.h
+++ b/src/DynamicRupture/FrictionLaws/GpuImpl/NoFault.h
@@ -16,7 +16,7 @@ class NoFault : public BaseFrictionSolver<NoFault> {
     auto* devFaultStresses{this->faultStresses};
     auto* devTractionResults{this->tractionResults};
 
-    sycl::nd_range rng{{this->currLayerSize * misc::numPaddedPoints}, {misc::numPaddedPoints}};
+    sycl::nd_range rng{{this->currLayerSize * misc::NumPaddedPoints}, {misc::NumPaddedPoints}};
     this->queue.submit([&](sycl::handler& cgh) {
       cgh.parallel_for(rng, [=](sycl::nd_item<1> item) {
         const auto ltsFace = item.get_group().get_group_id(0);
@@ -42,8 +42,8 @@ class NoFault : public BaseFrictionSolver<NoFault> {
    */
   void saveDynamicStressOutput() {}
 
-  void preHook(real (*stateVariableBuffer)[misc::numPaddedPoints]) {}
-  void postHook(real (*stateVariableBuffer)[misc::numPaddedPoints]) {}
+  void preHook(real (*stateVariableBuffer)[misc::NumPaddedPoints]) {}
+  void postHook(real (*stateVariableBuffer)[misc::NumPaddedPoints]) {}
 
   protected:
 };


### PR DESCRIPTION
Ported from #1122 . Effectively, we only need to copy the traction around (in principle, we could also do that as a memcpy operation, on second thought).

(NOTE: it's different from a "true" DR-disablement—which can also be included in some subsequent PR)