### PR TITLE
Some very tiny bugfixes

### DIFF
--- a/src/Equations/elastic/Kernels/Interface.h
+++ b/src/Equations/elastic/Kernels/Interface.h
@@ -54,7 +54,7 @@ namespace seissol::kernels {
     LTSTREE_GENERATE_INTERFACE_GETTERED(LocalData, initializer::LTS, cellInformation, localIntegration, neighboringIntegration, dofs, faceDisplacements, boundaryMapping, material)
     LTSTREE_GENERATE_INTERFACE_GETTERED(NeighborData, initializer::LTS, cellInformation, neighboringIntegration, dofs)
 #else
-    LTSTREE_GENERATE_INTERFACE_GETTERED(LocalData, initializer::LTS, cellInformation, localIntegration, neighboringIntegration, dofs, faceDisplacements, faceDisplacementsDevice, plasticity, boundaryMapping, material)
+    LTSTREE_GENERATE_INTERFACE_GETTERED(LocalData, initializer::LTS, cellInformation, localIntegration, neighboringIntegration, dofs, faceDisplacements, faceDisplacementsDevice, plasticity, boundaryMapping, boundaryMappingDevice, material)
     LTSTREE_GENERATE_INTERFACE_GETTERED(NeighborData, initializer::LTS, cellInformation, neighboringIntegration, dofs)
 #endif
   }

--- a/src/Equations/elastic/Kernels/Time.cpp
+++ b/src/Equations/elastic/Kernels/Time.cpp
@@ -398,8 +398,8 @@ void Time::computeBatchedIntegral(double expansionPoint,
    * compute time integral.
    */
   // compute lengths of integration intervals
-  real deltaTLower = integrationStart - expansionPoint;
-  real deltaTUpper = integrationEnd - expansionPoint;
+  const real deltaTLower = integrationStart - expansionPoint;
+  const real deltaTUpper = integrationEnd - expansionPoint;
 
 #ifndef DEVICE_EXPERIMENTAL_EXPLICIT_KERNELS
   // compute lengths of integration intervals
@@ -500,7 +500,6 @@ void Time::computeBatchedTaylorExpansion(real time,
   }
 
   // iterate over time derivatives
-  const real deltaT = time - expansionPoint;
   intKrnl.power(0) = 1.0;
   for(std::size_t derivative = 1; derivative < ConvergenceOrder; ++derivative) {
     intKrnl.power(derivative) = intKrnl.power(derivative - 1) * deltaT / static_cast<real>(derivative);

--- a/src/Initializer/BatchRecorders/LocalIntegrationRecorder.cpp
+++ b/src/Initializer/BatchRecorders/LocalIntegrationRecorder.cpp
@@ -229,8 +229,8 @@ void LocalIntegrationRecorder::recordFreeSurfaceGravityBc() {
 
           aminusTPtrs[face].push_back(data.neighboringIntegration().nAmNm1[face]);
           displacementsPtrs[face].push_back(dataHost.faceDisplacementsDevice()[face]);
-          t[face].push_back(data.boundaryMapping()[face].TData);
-          tInv[face].push_back(data.boundaryMapping()[face].TinvData);
+          t[face].push_back(dataHost.boundaryMappingDevice()[face].TData);
+          tInv[face].push_back(dataHost.boundaryMappingDevice()[face].TinvData);
 
           rhos[face].push_back(data.material().local.rho);
           lambdas[face].push_back(data.material().local.getLambdaBar());
@@ -289,12 +289,13 @@ void LocalIntegrationRecorder::recordDirichletBc() {
           dofsPtrs[face].push_back(static_cast<real*>(data.dofs()));
           idofsPtrs[face].push_back(idofsAddressRegistry[cell]);
 
-          tInv[face].push_back(data.boundaryMapping()[face].TinvData);
+          tInv[face].push_back(dataHost.boundaryMappingDevice()[face].TinvData);
           aminusTPtrs[face].push_back(data.neighboringIntegration().nAmNm1[face]);
 
-          easiBoundaryMapPtrs[face].push_back(data.boundaryMapping()[face].easiBoundaryMap);
+          easiBoundaryMapPtrs[face].push_back(
+              dataHost.boundaryMappingDevice()[face].easiBoundaryMap);
           easiBoundaryConstantPtrs[face].push_back(
-              data.boundaryMapping()[face].easiBoundaryConstant);
+              dataHost.boundaryMappingDevice()[face].easiBoundaryConstant);
         }
       }
     }

--- a/src/Kernels/DynamicRupture.cpp
+++ b/src/Kernels/DynamicRupture.cpp
@@ -212,7 +212,6 @@ void DynamicRupture::batchedSpaceTimeInterpolation(
     }
   };
 
-  device.api->resetCircularStreamCounter();
   for (unsigned timeInterval = 0; timeInterval < ConvergenceOrder; ++timeInterval) {
     ConditionalKey timeIntegrationKey(*KernelNames::DrTime);
     if (table.find(timeIntegrationKey) != table.end()) {


### PR DESCRIPTION
We change:

* remove a remnant of the circular streams/stream ring buffer (those are now allocated dynamically); and may be removed soon-ish from the Device module
* remove a remnant from a merge conflict which prevented a build without experimental kernels
* fix one host-device buffer usage bug
