### PR TITLE
Set a positive pickdt default

### DIFF
--- a/src/Initializer/Parameters/OutputParameters.cpp
+++ b/src/Initializer/Parameters/OutputParameters.cpp
@@ -139,6 +139,8 @@ ReceiverOutputParameters readReceiverParameters(ParameterReader* baseReader) {
   const auto samplingInterval = reader->readWithDefault("pickdt", 0.005);
   const auto fileName = reader->readWithDefault("rfilename", std::string(""));
 
+  warnIntervalAndDisable(enabled, samplingInterval, "receiveroutput", "pickdt");
+
   const auto collectiveio = reader->readWithDefault("receivercollectiveio", false);
 
   return ReceiverOutputParameters{

--- a/src/Initializer/Parameters/OutputParameters.cpp
+++ b/src/Initializer/Parameters/OutputParameters.cpp
@@ -136,7 +136,7 @@ ReceiverOutputParameters readReceiverParameters(ParameterReader* baseReader) {
 
   const auto computeRotation = reader->readWithDefault("receivercomputerotation", false);
   const auto computeStrain = reader->readWithDefault("receivercomputestrain", false);
-  const auto samplingInterval = reader->readWithDefault("pickdt", 0.0);
+  const auto samplingInterval = reader->readWithDefault("pickdt", 0.005);
   const auto fileName = reader->readWithDefault("rfilename", std::string(""));
 
   const auto collectiveio = reader->readWithDefault("receivercollectiveio", false);


### PR DESCRIPTION
Set `pickdt=0.005` if not given (as in the doc parameter file); previously, it had been `0`, causing length error bugs when reserving receiver space.

Furthermore, we now block non-negative `pickdt` values—and interpret them as disabling the receiver recording.