### PR TITLE
Extend Local Cluster Array

### DIFF
--- a/src/Initializer/TimeStepping/LtsLayout.cpp
+++ b/src/Initializer/TimeStepping/LtsLayout.cpp
@@ -844,6 +844,13 @@ void seissol::initializer::time_stepping::LtsLayout::deriveClusteredCopyInterior
     l_localClusters.insert( m_cellClusterIds[l_cell] );
   }
 
+  // HACK: add ghost cell clusters as well
+  for( int i = 0; i < m_plainNeighboringRanks.size(); ++i ) {
+    for (int j = 0; j < m_numberOfPlainGhostCells[i]; ++j) {
+      l_localClusters.insert( m_plainGhostCellClusterIds[i][j] );
+    }
+  }
+
   // convert set to vector
   m_localClusters = std::vector< unsigned int > ( l_localClusters.begin(), l_localClusters.end() );
 

--- a/src/Initializer/TimeStepping/LtsLayout.cpp
+++ b/src/Initializer/TimeStepping/LtsLayout.cpp
@@ -845,9 +845,18 @@ void seissol::initializer::time_stepping::LtsLayout::deriveClusteredCopyInterior
   }
 
   // HACK: add ghost cell clusters as well
-  for( int i = 0; i < m_plainNeighboringRanks.size(); ++i ) {
-    for (int j = 0; j < m_numberOfPlainGhostCells[i]; ++j) {
+  for( std::size_t i = 0; i < m_plainNeighboringRanks.size(); ++i ) {
+    for (unsigned int j = 0; j < m_numberOfPlainGhostCells[i]; ++j) {
       l_localClusters.insert( m_plainGhostCellClusterIds[i][j] );
+    }
+  }
+
+  // HACK 2: make contiguous
+  if (!l_localClusters.empty()) {
+    const auto minLocal = *l_localClusters.begin();
+    const auto maxLocal = *l_localClusters.rbegin();
+    for (auto i = minLocal; i <= maxLocal; ++i) {
+      l_localClusters.insert(i);
     }
   }
 


### PR DESCRIPTION
Add

* all clusters that are only present in ghost halos
* all cluster gaps, to make everything contiguous afterwards (to make the actor model happy)

to the local cluster id array. So far, it seemingly only contained all copy/interior cell cluster ids (i.e. those which are really computed on the local rank).

Potential relation to #1181 and #839 .
