### PR TITLE
Fix fault receivers in halos (between ghost and copy layers)

### DIFF
--- a/src/DynamicRupture/Output/Builders/PickPointBuilder.h
+++ b/src/DynamicRupture/Output/Builders/PickPointBuilder.h
@@ -64,12 +64,15 @@ class PickPointBuilder : public ReceiverBasedOutputBuilder {
 
     const auto [faultVertices, faultElements, elementToFault] = getElementsAlongFault();
 
+    // TODO: refactor to check for face containment directly, (will remove half of the code in this
+    // file here)
     seissol::initializer::findMeshIds(eigenPoints.data(),
                                       faultVertices,
                                       faultElements,
                                       numReceiverPoints,
                                       contained.data(),
-                                      localIds.data());
+                                      localIds.data(),
+                                      1e-12);
 
     const auto& meshElements = meshReader->getElements();
     const auto& meshVertices = meshReader->getVertices();
@@ -85,15 +88,15 @@ class PickPointBuilder : public ReceiverBasedOutputBuilder {
         assert(faultIndicesIt != elementToFault.end());
         const auto& faultIndices = faultIndicesIt->second;
 
-        const auto firstFaultIdx = faultIndices[0];
+        const auto firstFaultIdx = faultIndices.at(0);
 
         // find the original element which contains a fault face
         // note: this allows to project a receiver to the plus side
         //       even if it was found in the negative one
-        const auto element = meshElements[faultInfos[firstFaultIdx].element];
+        const auto& element = meshElements[faultInfos[firstFaultIdx].element];
 
         const auto closest = findClosestFaultIndex(receiver.global, element, faultIndices);
-        const auto faultItem = faultInfos[closest];
+        const auto& faultItem = faultInfos.at(closest);
 
         receiver.globalTriangle = getGlobalTriangle(faultItem.side, element, meshVertices);
         projectPointToFace(receiver.global, receiver.globalTriangle, faultItem.normal);
@@ -146,24 +149,28 @@ class PickPointBuilder : public ReceiverBasedOutputBuilder {
     // note: an element can have multiple fault faces
     std::unordered_map<size_t, std::vector<size_t>> elementToFault{};
 
+    const auto handleElementFace = [&](std::size_t id, std::size_t faultIdx) {
+      // element copy done on purpose because we are recording
+      // a new vertex array and thus we need to modify vertex indices
+      // inside of each element
+      auto element = meshElements.at(id);
+
+      for (size_t vertexIdx{0}; vertexIdx < NumVertices; ++vertexIdx) {
+        faultVertices.push_back(meshVertices[element.vertices[vertexIdx]]);
+        element.vertices[vertexIdx] = faultVertices.size() - 1;
+      }
+      faultElements.push_back(element);
+      elementToFault[element.localId].push_back(faultIdx);
+    };
+
     for (size_t faultIdx{0}; faultIdx < numFaultElements; ++faultIdx) {
       const auto& faultItem = fault[faultIdx];
 
-      if ((faultItem.element >= 0) && (faultItem.neighborElement >= 0)) {
-        // element copy done on purpose because we are recording
-        // a new vertex array and thus we need to modify vertex indices
-        // inside of each element
-        std::array<Element*, NumSides> elements{&meshElements[faultItem.element],
-                                                &meshElements[faultItem.neighborElement]};
-        for (int sideId = 0; sideId < NumSides; ++sideId) {
-          auto element = (*elements[sideId]);
-
-          for (size_t vertexIdx{0}; vertexIdx < NumVertices; ++vertexIdx) {
-            faultVertices.push_back(meshVertices[element.vertices[vertexIdx]]);
-            element.vertices[vertexIdx] = faultVertices.size() - 1;
-          }
-          faultElements.push_back(element);
-          elementToFault[element.localId].push_back(faultIdx);
+      if (faultItem.element >= 0) {
+        handleElementFace(faultItem.element, faultIdx);
+        // we only care about the negative side, if the positive side is also present locally
+        if (faultItem.neighborElement >= 0) {
+          handleElementFace(faultItem.neighborElement, faultIdx);
         }
       }
     }
@@ -228,14 +235,13 @@ class PickPointBuilder : public ReceiverBasedOutputBuilder {
       for (size_t idx{0}; idx < size; ++idx) {
         const auto isFound = globalContainVector[idx];
         if (!isFound) {
-          logInfo(localRank) << "pickpoint fault output: "
-                             << "receiver (" << idx + 1 << ") is not inside "
-                             << "any element along the rupture surface";
+          logWarning(localRank) << "On-fault receiver " << idx
+                                << " is not inside any element along the rupture surface";
           allReceiversFound = false;
         }
       }
       if (allReceiversFound) {
-        logInfo(localRank) << "all point receivers found along the fault";
+        logInfo(localRank) << "All point receivers found along the fault";
       }
     }
   }

--- a/src/DynamicRupture/Output/Builders/PickPointBuilder.h
+++ b/src/DynamicRupture/Output/Builders/PickPointBuilder.h
@@ -71,8 +71,7 @@ class PickPointBuilder : public ReceiverBasedOutputBuilder {
                                       faultElements,
                                       numReceiverPoints,
                                       contained.data(),
-                                      localIds.data(),
-                                      1e-12);
+                                      localIds.data());
 
     const auto& meshElements = meshReader->getElements();
     const auto& meshVertices = meshReader->getVertices();

--- a/src/DynamicRupture/Output/Builders/PickPointBuilder.h
+++ b/src/DynamicRupture/Output/Builders/PickPointBuilder.h
@@ -231,16 +231,20 @@ class PickPointBuilder : public ReceiverBasedOutputBuilder {
 
     if (localRank == 0) {
       bool allReceiversFound{true};
+      std::size_t missing = 0;
       for (size_t idx{0}; idx < size; ++idx) {
         const auto isFound = globalContainVector[idx];
         if (!isFound) {
           logWarning(localRank) << "On-fault receiver " << idx
                                 << " is not inside any element along the rupture surface";
           allReceiversFound = false;
+          ++missing;
         }
       }
       if (allReceiversFound) {
         logInfo(localRank) << "All point receivers found along the fault";
+      } else {
+        logError() << missing << "on-fault receivers have not been found.";
       }
     }
   }

--- a/src/DynamicRupture/Output/ReceiverBasedOutput.cpp
+++ b/src/DynamicRupture/Output/ReceiverBasedOutput.cpp
@@ -64,7 +64,7 @@ void ReceiverOutput::calcFaultOutput(
   const size_t level = (outputType == seissol::initializer::parameters::OutputType::AtPickpoint)
                            ? outputData->currentCacheLevel
                            : 0;
-  const auto faultInfos = meshReader->getFault();
+  const auto& faultInfos = meshReader->getFault();
 
 #ifdef ACL_DEVICE
   void* stream = device::DeviceInstance::getInstance().api->getDefaultStream();
@@ -101,7 +101,7 @@ void ReceiverOutput::calcFaultOutput(
     local.waveSpeedsPlus = &((local.layer->var(drDescr->waveSpeedsPlus))[local.ltsId]);
     local.waveSpeedsMinus = &((local.layer->var(drDescr->waveSpeedsMinus))[local.ltsId]);
 
-    const auto faultInfo = faultInfos[faceIndex];
+    const auto& faultInfo = faultInfos[faceIndex];
 
 #ifdef ACL_DEVICE
     {

--- a/src/Initializer/PointMapper.cpp
+++ b/src/Initializer/PointMapper.cpp
@@ -139,7 +139,7 @@ void findMeshIds(const Eigen::Vector3d* points,
         for (unsigned dim = 0; dim < 4; ++dim) {
           resultFace += planeEquations[dim][face] * points1[point][dim];
         }
-        notInside += (resultFace > -tolerance) ? 1 : 0;
+        notInside += (resultFace > tolerance) ? 1 : 0;
       }
       if (notInside == 0) {
 #ifdef _OPENMP

--- a/src/Initializer/PointMapper.cpp
+++ b/src/Initializer/PointMapper.cpp
@@ -87,8 +87,10 @@ void findMeshIds(const Eigen::Vector3d* points,
                  const seissol::geometry::MeshReader& mesh,
                  std::size_t numPoints,
                  short* contained,
-                 unsigned* meshIds) {
-  findMeshIds(points, mesh.getVertices(), mesh.getElements(), numPoints, contained, meshIds);
+                 unsigned* meshIds,
+                 double tolerance) {
+  findMeshIds(
+      points, mesh.getVertices(), mesh.getElements(), numPoints, contained, meshIds, tolerance);
 }
 
 void findMeshIds(const Eigen::Vector3d* points,
@@ -96,7 +98,8 @@ void findMeshIds(const Eigen::Vector3d* points,
                  const std::vector<Element>& elements,
                  std::size_t numPoints,
                  short* contained,
-                 unsigned* meshIds) {
+                 unsigned* meshIds,
+                 double tolerance) {
 
   memset(contained, 0, numPoints * sizeof(short));
 
@@ -136,7 +139,7 @@ void findMeshIds(const Eigen::Vector3d* points,
         for (unsigned dim = 0; dim < 4; ++dim) {
           resultFace += planeEquations[dim][face] * points1[point][dim];
         }
-        notInside += (resultFace > 0.0) ? 1 : 0;
+        notInside += (resultFace > -tolerance) ? 1 : 0;
       }
       if (notInside == 0) {
 #ifdef _OPENMP

--- a/src/Initializer/PointMapper.h
+++ b/src/Initializer/PointMapper.h
@@ -53,14 +53,16 @@ void findMeshIds(const Eigen::Vector3d* points,
                  const seissol::geometry::MeshReader& mesh,
                  std::size_t numPoints,
                  short* contained,
-                 unsigned* meshId);
+                 unsigned* meshId,
+                 double tolerance = 0);
 
 void findMeshIds(const Eigen::Vector3d* points,
                  const std::vector<Vertex>& vertices,
                  const std::vector<Element>& elements,
                  std::size_t numPoints,
                  short* contained,
-                 unsigned* meshIds);
+                 unsigned* meshIds,
+                 double tolerance = 0);
 #ifdef USE_MPI
 void cleanDoubles(short* contained, std::size_t numPoints);
 #endif


### PR DESCRIPTION
Fault receivers located between ghost and copy layers were ignored so far; thus we fix that.

(note that the respective point-to-fault-face assignment code can still need a lot of refactoring)
