### PR TITLE
Unify variable names for receivers and wavefield

### DIFF
--- a/postprocessing/validation/compare-receivers.py
+++ b/postprocessing/validation/compare-receivers.py
@@ -20,12 +20,12 @@ def velocity_norm(receiver):
 
 def stress_norm(receiver):
     return np.sqrt(
-        receiver["xx"] ** 2
-        + receiver["yy"] ** 2
-        + receiver["zz"] ** 2
-        + receiver["xy"] ** 2
-        + receiver["yz"] ** 2
-        + receiver["xz"] ** 2
+        receiver["s_xx"] ** 2
+        + receiver["s_yy"] ** 2
+        + receiver["s_zz"] ** 2
+        + receiver["s_xy"] ** 2
+        + receiver["s_yz"] ** 2
+        + receiver["s_xz"] ** 2
     )
 
 
@@ -138,10 +138,17 @@ def read_receiver(filename):
             l[x_index] = y
         return l
 
-    # Recently, we changed the receiver variables from u,v,w to v1,v2,v3. If the receiver is stored in legacy format, we adapt it
+    # Accomodate variable name changes
+    variables = replace("xx", "s_xx", variables)
+    variables = replace("yy", "s_yy", variables)
+    variables = replace("zz", "s_zz", variables)
+    variables = replace("xy", "s_xy", variables)
+    variables = replace("xz", "s_xz", variables)
+    variables = replace("yz", "s_yz", variables)
     variables = replace("u", "v1", variables)
     variables = replace("v", "v2", variables)
     variables = replace("w", "v3", variables)
+    
     receiver.columns = variables
     return receiver
 

--- a/src/Equations/anisotropic/Model/Datastructures.h
+++ b/src/Equations/anisotropic/Model/Datastructures.h
@@ -60,7 +60,7 @@ struct AnisotropicMaterial : Material {
   static constexpr LocalSolver Solver = LocalSolver::CauchyKovalevski;
   static inline const std::string Text = "anisotropic";
   static inline const std::array<std::string, NumQuantities> Quantities = {
-      "xx", "yy", "zz", "xy", "yz", "xz", "v1", "v2", "v3"};
+      "s_xx", "s_yy", "s_zz", "s_xy", "s_yz", "s_xz", "v1", "v2", "v3"};
 
   double c11;
   double c12;

--- a/src/Equations/elastic/Model/Datastructures.h
+++ b/src/Equations/elastic/Model/Datastructures.h
@@ -60,7 +60,7 @@ struct ElasticMaterial : Material {
   static constexpr LocalSolver Solver = LocalSolver::CauchyKovalevski;
   static inline const std::string Text = "elastic";
   static inline const std::array<std::string, NumQuantities> Quantities = {
-      "xx", "yy", "zz", "xy", "yz", "xz", "v1", "v2", "v3"};
+      "s_xx", "s_yy", "s_zz", "s_xy", "s_yz", "s_xz", "v1", "v2", "v3"};
 
   double lambda;
   double mu;

--- a/src/Equations/poroelastic/Model/Datastructures.h
+++ b/src/Equations/poroelastic/Model/Datastructures.h
@@ -16,8 +16,19 @@ struct PoroElasticMaterial : ElasticMaterial {
   static constexpr MaterialType Type = MaterialType::Poroelastic;
   static constexpr LocalSolver Solver = LocalSolver::SpaceTimePredictorPoroelastic;
   static inline const std::string Text = "poroelastic";
-  static inline const std::array<std::string, NumQuantities> Quantities = {
-      "xx", "yy", "zz", "xy", "yz", "xz", "v1", "v2", "v3", "p", "v1_f", "v2_f", "v3_f"};
+  static inline const std::array<std::string, NumQuantities> Quantities = {"s_xx",
+                                                                           "s_yy",
+                                                                           "s_zz",
+                                                                           "s_xy",
+                                                                           "s_yz",
+                                                                           "s_xz",
+                                                                           "v1",
+                                                                           "v2",
+                                                                           "v3",
+                                                                           "p",
+                                                                           "v1_f",
+                                                                           "v2_f",
+                                                                           "v3_f"};
 
   double bulkSolid;
   double porosity;

--- a/src/Equations/viscoelastic2/Model/Datastructures.h
+++ b/src/Equations/viscoelastic2/Model/Datastructures.h
@@ -64,7 +64,7 @@ struct ViscoElasticMaterialParametrized : public ElasticMaterial {
   static constexpr LocalSolver Solver = LocalSolver::CauchyKovalevskiAnelastic;
   static inline const std::string Text = "viscoelastic-" + std::to_string(MechanismsP);
   static inline const std::array<std::string, NumElasticQuantities> Quantities = {
-      "xx", "yy", "zz", "xy", "yz", "xz", "v1", "v2", "v3"};
+      "s_xx", "s_yy", "s_zz", "s_xy", "s_yz", "s_xz", "v1", "v2", "v3"};
 
   //! Relaxation frequencies
   double omega[zeroLengthArrayHandler(Mechanisms)];

--- a/src/ResultWriter/WaveFieldWriterExecutor.h
+++ b/src/ResultWriter/WaveFieldWriterExecutor.h
@@ -45,6 +45,7 @@
 
 #include <Kernels/Precision.h>
 #include <cassert>
+#include <string>
 #include <vector>
 
 #include "utils/logger.h"
@@ -54,6 +55,9 @@
 #include "async/ExecInfo.h"
 
 #include "Monitoring/Stopwatch.h"
+
+#include "Equations/Datastructures.h"
+#include "Model/Plasticity.h"
 
 namespace seissol::writer {
 
@@ -134,12 +138,17 @@ class WaveFieldWriterExecutor {
     m_numVariables = info.bufferSize(param.bufferIds[OutputFlags]) / sizeof(bool);
     m_outputFlags = static_cast<const bool*>(info.buffer(param.bufferIds[OutputFlags]));
 
-    const char* varNames[20] = {
-        "sigma_xx", "sigma_yy", "sigma_zz", "sigma_xy", "sigma_yz", "sigma_xz", "u",  "v", "w",
-#ifdef USE_POROELASTIC
-        "p",        "u_f",      "v_f",      "w_f",
-#endif
-        "ep_xx",    "ep_yy",    "ep_zz",    "ep_xy",    "ep_yz",    "ep_xz",    "eta"};
+    std::vector<std::string> varNames;
+    std::vector<std::string> varNamesLowRes;
+
+    for (const auto& quantity : seissol::model::MaterialT::Quantities) {
+      varNames.emplace_back(quantity);
+      varNamesLowRes.emplace_back("low_" + quantity);
+    }
+    for (const auto& quantity : seissol::model::PlasticityData::Quantities) {
+      varNames.emplace_back(quantity);
+      varNamesLowRes.emplace_back("low_" + quantity);
+    }
 
     std::vector<const char*> variables;
     for (unsigned int i = 0; i < m_numVariables; i++) {
@@ -149,7 +158,7 @@ class WaveFieldWriterExecutor {
 #else
         assert(i < 16);
 #endif
-        variables.push_back(varNames[i]);
+        variables.push_back(varNames[i].c_str());
       }
     }
 
@@ -192,21 +201,11 @@ class WaveFieldWriterExecutor {
       if (param.bufferIds[LowCells] >= 0) {
         // Pstrain or Integrated quantities enabled
         m_lowOutputFlags = static_cast<const bool*>(info.buffer(param.bufferIds[LowOutputFlags]));
-        // Variables
-        std::vector<const char*> lowVariables;
-        const char* lowVarNames[NumLowvariables] = {"int_sigma_xx",
-                                                    "int_sigma_yy",
-                                                    "int_sigma_zz",
-                                                    "int_sigma_xy",
-                                                    "int_sigma_yz",
-                                                    "int_sigma_xz",
-                                                    "displacement_x",
-                                                    "displacement_y",
-                                                    "displacement_z"};
 
+        std::vector<const char*> lowVariables;
         for (size_t i = 0; i < NumLowvariables; i++) {
           if (m_lowOutputFlags[i]) {
-            lowVariables.push_back(lowVarNames[i]);
+            lowVariables.push_back(varNamesLowRes[i].c_str());
           }
         }
 


### PR DESCRIPTION
A suggestion. It's to source the variable names entirely from the material class. Right now, that would mean that both receivers and wavefield have (displayed here for poroelastic, since it includes elastic):

```
s_xx, s_yy, s_zz, s_xy, s_yz, s_xz, v1, v2, v3, p, v1_f, v2_f, v3_f, # (poro)elastic
ep_xx, ep_yy, ep_zz, ep_xy, ep_yz, ep_xz, eta # plasticity
```

The only significant change would be that `sigma_xx`, `xx` -> `s_xx` and so on.
