### PR TITLE
Demote the error when point sources are not found to a warning

### DIFF
--- a/src/SourceTerm/Manager.cpp
+++ b/src/SourceTerm/Manager.cpp
@@ -505,7 +505,7 @@ auto loadSourcesFromNRF(const char* fileName,
   if (rank == 0) {
     const int numSourceOutside = nrf.size() - globalnumSources;
     if (numSourceOutside > 0) {
-      logError() << nrf.size() - globalnumSources << " point sources are outside the domain.";
+      logWarning(rank) << numSourceOutside << " point sources are outside the domain.";
     }
   }
 


### PR DESCRIPTION
Cf. the discussion in #1212 .

(though maybe it would be better to also specify which point sources were not found then)
