### PR TITLE
document proxy

### DIFF
--- a/Documentation/behind_firewall.rst
+++ b/Documentation/behind_firewall.rst
@@ -145,4 +145,4 @@ Then pip or git should be reachable. You can e.g. install pip packages with:
 
 In addition, you might need to add the `--no-build-isolation` flag to the pip command.
 
-for more information, see also this :ref:`link <https://doku.lrz.de/faq-installing-your-own-applications-on-supermug-ng-internet-access-from-supermuc-ng-10746066.html>`.
+for more information, see also this `link <https://doku.lrz.de/faq-installing-your-own-applications-on-supermug-ng-internet-access-from-supermuc-ng-10746066.html>`.

--- a/Documentation/behind_firewall.rst
+++ b/Documentation/behind_firewall.rst
@@ -3,6 +3,67 @@
 
   SPDX-License-Identifier: BSD-3-Clause
 
+
+.. _pypi_behind_firewall:
+
+Accessing internet behind a firewall
+------------------------------------
+
+
+Many HPC facilities have rather tight security restrictions, which may include a firewall, preventing any outgoing connections.
+To be able to access git or PyPi behind a firewall, we can create a reverse SSH tunnel for internet access.
+We describe how to proceed in the following.
+
+
+1. On your local machine in ~/.ssh/config add the following `RemoteForward` line:
+
+::
+
+    Host supermucNG
+        ...
+        RemoteForward ddddd localhost:8899
+
+where ddddd is an arbitrary port number with 5 digits.
+ddddd is the port on the remote server that is forwarded to your port 8899 of your local machine.
+(This number should be different from port number used in other RemoteForward entries.)
+
+2. Install proxy.py on your local machine.
+
+::
+
+    pip install --upgrade --user proxy.py
+
+3. Start proxy.py on your local machine. (And keep it running.)
+
+
+::
+
+    ~/.local/bin/proxy --port 8899 &
+
+4. Login to the HPC cluster (e.g. ``ssh supermucNG``). 
+Check that you do not get: `Warning: remote port forwarding failed for listen port ddddd`.
+In this case you would need to change ddddd to a different port.
+Note that the problem might also be you have already an opened connection to the HPC cluster.
+
+Add to your ``~/.bashrc`` file on the HPC cluster:
+
+::
+
+    export http_proxy=http://localhost:ddddd
+    export https_proxy=http://localhost:ddddd
+
+where ddddd is your arbitrary port number.
+
+Then pip or git should be reachable. You can e.g. install pip packages with:
+
+::
+
+    pip install <package name> 
+
+In addition, you might need to add the ``--no-build-isolation`` flag to the pip command.
+
+For more information, see also this `link <https://doku.lrz.de/faq-installing-your-own-applications-on-supermug-ng-internet-access-from-supermuc-ng-10746066.html>`.
+
 .. _git_behind_firewall:
 
 Accessing github behind a firewall (outdated)
@@ -87,62 +148,5 @@ If it works, you will see several lines, for example:
   Resolving deltas: 100% (19382/19382), done.
 
 
-.. _pypi_behind_firewall:
-
-Accessing internet behind a firewall
-------------------------------------
 
 
-Many HPC facilities have rather tight security restrictions, which may include a firewall, preventing any outgoing connections.
-To be able to access git or PyPi behind a firewall, we can create a reverse SSH tunnel for internet access.
-We describe how to proceed in the following.
-
-
-1. On your local machine in ~/.ssh/config add the following `RemoteForward` line:
-
-::
-
-    Host supermucNG
-        ...
-        RemoteForward ddddd localhost:8899
-
-where ddddd is an arbitrary port number with 5 digits.
-ddddd is the port on the remote server that is forwarded to your local machine's port 8899.
-(This number should be different from port number used in other RemoteForward entries.)
-
-2. Install proxy.py on your local machine.
-
-::
-
-    pip install --upgrade --user proxy.py
-
-3. Start proxy.py on your local machine. (And keep it running.)
-
-
-::
-
-    ~/.local/bin/proxy --port 8899 &
-
-4. Login to the HPC cluster (e.g. `ssh supermucNG`). 
-Check that you do not get: `Warning: remote port forwarding failed for listen port ddddd`.
-In this case you would need to change ddddd to a different port.
-Note that the problem might also be you have already an opened connection to the HPC cluster.
-
-Add to your ~/.bashrc file on the HPC cluster:
-
-::
-
-    export http_proxy=http://localhost:DDDDD
-    export https_proxy=http://localhost:DDDDD
-
-where ddddd is your arbitrary port number.
-
-Then pip or git should be reachable. You can e.g. install pip packages with:
-
-::
-
-    pip install <package name> 
-
-In addition, you might need to add the `--no-build-isolation` flag to the pip command.
-
-for more information, see also this `link <https://doku.lrz.de/faq-installing-your-own-applications-on-supermug-ng-internet-access-from-supermuc-ng-10746066.html>`.

--- a/Documentation/behind_firewall.rst
+++ b/Documentation/behind_firewall.rst
@@ -5,8 +5,10 @@
 
 .. _git_behind_firewall:
 
-Accessing github behind a firewall
------------------------------------
+Accessing github behind a firewall (outdated)
+---------------------------------------------
+
+Warning: This procedure works, but a much simpler procedure is available at :ref:`pypi_behind_firewall`.
 
 Some HPC clusters (e.g. SuperMUC-NG) restricts access to outside sources and thus does not allow connections to https servers. 
 Nevertheless, GitHub can be used if remote port forwarding is correctly set.
@@ -87,11 +89,13 @@ If it works, you will see several lines, for example:
 
 .. _pypi_behind_firewall:
 
-Accessing PyPI behind a firewall
---------------------------------
+Accessing internet behind a firewall
+------------------------------------
 
-Many post-processing scripts of SeisSol require Python dependencies.
-We describe how to use pip on a HPC cluster with restricts access to outside sources in the following.
+
+Many HPC facilities have rather tight security restrictions, which may include a firewall, preventing any outgoing connections.
+To be able to access git or PyPi behind a firewall, we can create a reverse SSH tunnel for internet access.
+We describe how to proceed in the following.
 
 
 1. On your local machine in ~/.ssh/config add the following `RemoteForward` line:
@@ -103,6 +107,7 @@ We describe how to use pip on a HPC cluster with restricts access to outside sou
         RemoteForward ddddd localhost:8899
 
 where ddddd is an arbitrary port number with 5 digits.
+ddddd is the port on the remote server that is forwarded to your local machine's port 8899.
 (This number should be different from port number used in other RemoteForward entries.)
 
 2. Install proxy.py on your local machine.
@@ -116,19 +121,28 @@ where ddddd is an arbitrary port number with 5 digits.
 
 ::
 
-    ~/.local/bin/proxy --port 8899
+    ~/.local/bin/proxy --port 8899 &
 
 4. Login to the HPC cluster (e.g. `ssh supermucNG`). 
 Check that you do not get: `Warning: remote port forwarding failed for listen port ddddd`.
 In this case you would need to change ddddd to a different port.
 Note that the problem might also be you have already an opened connection to the HPC cluster.
 
-Once connected to the HPC cluster, pip can be used with
+Add to your ~/.bashrc file on the HPC cluster:
 
 ::
 
-    pip install <package name> --user --proxy http://localhost:ddddd/
+    export http_proxy=http://localhost:DDDDD
+    export https_proxy=http://localhost:DDDDD
 
 where ddddd is your arbitrary port number.
+
+Then pip or git should be reachable. You can e.g. install pip packages with:
+
+::
+
+    pip install <package name> 
+
 In addition, you might need to add the `--no-build-isolation` flag to the pip command.
 
+for more information, see also this :ref:`link <https://doku.lrz.de/faq-installing-your-own-applications-on-supermug-ng-internet-access-from-supermuc-ng-10746066.html>`.

--- a/Documentation/supermuc.rst
+++ b/Documentation/supermuc.rst
@@ -12,7 +12,7 @@ SuperMUC-NG
 Setting up GitHub on SuperMuc-NG
 --------------------------------
 
-see :ref:`git_behind_firewall`.
+see :ref:`pypi_behind_firewall`.
 
 Building SeisSol
 ----------------
@@ -113,7 +113,6 @@ to the number of nodes you want to run on. A rule of thumb for optimal performan
   export SEISSOL_CHECKPOINT_DIRECT=1
   export ASYNC_MODE=THREAD
   export ASYNC_BUFFER_ALIGNMENT=8388608
-  source /etc/profile.d/modules.sh
 
   echo 'num_nodes:' $SLURM_JOB_NUM_NODES 'ntasks:' $SLURM_NTASKS
   ulimit -Ss 2097152

--- a/Documentation/supermuc.rst
+++ b/Documentation/supermuc.rst
@@ -82,6 +82,7 @@ to the number of nodes you want to run on. A rule of thumb for optimal performan
   #SBATCH --mail-user=<your email address>
 
   #Setup of execution environment
+  # note that if you report an issue to LRZ, they will prefer --export=NONE
   #SBATCH --export=ALL
   #SBATCH --account=<project id>
   #SBATCH --no-requeue


### PR DESCRIPTION
I've been trying to install the latest version of tandem on NG, and it was a big mess because e.g. petsc being on gitlab.com, and depending on sowing which is on bitbucket.org and basically I would need to add a ssh key on all these server to be able to install the latest version of petsc on supermuc NG.
I had a discussion with Martin Ohlerich from LRZ, and he suggested it would be much more simple to use a proxy.
I tried and it works.
Therefore I document the procedure (and depreciate the older procedure).

