### PR TITLE
select PSpaMM for compilation

### DIFF
--- a/Documentation/supermuc.rst
+++ b/Documentation/supermuc.rst
@@ -53,7 +53,7 @@ Install SeisSol with cmake, e.g. with (more options with ccmake)
 
    cd SeisSol
    mkdir build-release && cd build-release
-   cmake -DNUMA_AWARE_PINNING=ON -DASAGI=ON -DCMAKE_BUILD_TYPE=Release -DHOST_ARCH=skx -DPRECISION=double -DORDER=4 ..
+   cmake -DNUMA_AWARE_PINNING=ON -DASAGI=ON -DCMAKE_BUILD_TYPE=Release -DHOST_ARCH=skx -DPRECISION=double -DORDER=4 -DGEMM_TOOLS_LIST=PSpaMM ..
    make -j 48
 
 .. _running_seissol_on_supermuc:


### PR DESCRIPTION
The Supermuc compilation does not work without specifying `-DGEMM_TOOLS_LIST=PSpaMM`. However, the spack environment in the documentation is quite old. If somebody has a newer spack environment that does not throw a libxsmm error during compilation, it would be better to link this environment in the documentation instead.