### PR TITLE
Fix Builds at the Non-Existence of Chainforge

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,7 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
   endif()
 endif()
 
-if(CMAKE_CXX_COMPILER_ID MATCHES "Intel")
+if(CMAKE_CXX_COMPILER_ID STREQUAL "Intel")
   message(WARNING "The Intel Compiler Classic (ICC) is deprecated; consider switching to the Intel oneAPI C++ Compiler (ICX) instead.")
 endif()
 

--- a/generated-code/generate.py
+++ b/generated-code/generate.py
@@ -105,11 +105,11 @@ def main():
 
     cost_estimators = BoundingBoxCostEstimator
     if "gpu" in targets:
-        try:
-            chainforge_spec = importlib.util.find_spec("chainforge")
+        chainforge_spec = importlib.util.find_spec("chainforge")
+        if chainforge_spec is not None:
             chainforge_spec.loader.load_module()
             cost_estimators = FusedGemmsBoundingBoxCostEstimator
-        except ModuleNotFoundError:
+        else:
             print("WARNING: ChainForge was not found. Falling back to GemmForge.")
 
     subfolders = []
@@ -117,10 +117,9 @@ def main():
     equationsSpec = importlib.util.find_spec(
         f"kernels.equations.{cmdLineArgs.equations}"
     )
-    try:
-        equations = equationsSpec.loader.load_module()
-    except ModuleNotFoundError:
+    if equationsSpec is None:
         raise RuntimeError("Could not find kernels for " + cmdLineArgs.equations)
+    equations = equationsSpec.loader.load_module()
 
     equation_class = equations.EQUATION_CLASS
 


### PR DESCRIPTION
* fix builds when chainforge is not available
* do not mark ICX as deprecated (like ICC)
