### PR TITLE
Fix the Coverage Computation

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,66 @@
+# SPDX-FileCopyrightText: 2024-2025 SeisSol Group
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+name: coverage
+on:
+  - push
+
+jobs:
+  coverage:
+    name: coverage
+    runs-on: ubuntu-24.04
+    steps:
+      - name: apt-get
+        run: |
+          sudo apt-get update
+          sudo apt-get install lcov ninja-build hdf5-tools libeigen3-dev libhdf5-openmpi-dev libmetis-dev libomp-dev libopenmpi-dev libparmetis-dev libyaml-cpp-dev openmpi-bin openmpi-common python3.10 python3-pip
+
+          sudo pip3 install setuptools numpy --break-system-packages
+          sudo mkdir -p /opt/dependencies
+
+      - name: checkout-easi
+        uses: actions/checkout@master
+        with:
+          repository: SeisSol/easi
+
+      - name: build-easi
+        run: |
+          mkdir build && cd build
+          CMAKE_PREFIX_PATH=/opt/dependencies cmake .. -GNinja -DCMAKE_INSTALL_PREFIX=/opt/dependencies -DASAGI=OFF -DLUA=OFF -DEASICUBE=OFF -DIMPALAJIT=OFF
+          ninja install
+      
+      - id: checkout
+        name: checkout-seissol
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - id: build
+        name: build-seissol
+        run: |
+          mkdir build && cd build
+
+          export CC=gcc-13
+          export CXX=g++-13
+          export FC=gfortran-13
+
+          mkdir -p /opt/seissol
+
+          # run w/o netcdf for consistency with the clang-tidy check
+          export CMAKE_PREFIX_PATH=/opt/dependencies
+          cmake .. -GNinja -DCMAKE_INSTALL_PREFIX=/opt/seissol -DGEMM_TOOLS_LIST=none -DNETCDF=OFF -DCOVERAGE=ON -DTESTING=ON -DTESTING_GENERATED=ON -DHOST_ARCH=hsw -DORDER=6 -DCMAKE_BUILD_TYPE=Debug -DEQUATIONS=elastic -DPRECISION=double
+          ninja
+
+      - name: seissol-coverage
+        if: ${{ !cancelled() && steps.build.outcome == 'success' }}
+        run: |
+          cd build
+          ninja seissol-coverage
+      
+      - name: upload-seissol-coverage
+        uses: actions/upload-artifact@v4
+        if: ${{ !cancelled() && steps.build.outcome == 'success' }}
+        with:
+          name: seissol-coverage
+          path: build/seissol-coverage

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,6 +57,13 @@ endif()
 #       derived input: REAL_SIZE_IN_BYTES, ALIGNMENT, VECTORSIZE ARCH_STRING, WITH_GPU, DEVICE_VENDOR
 #
 include(cmake/process_users_input.cmake)
+
+if (TESTING AND COVERAGE AND CMAKE_COMPILER_IS_GNUCXX)
+  message(STATUS "Enable coverage computation.")
+  include(cmake/CodeCoverage.cmake)
+  append_coverage_compiler_flags()
+endif()
+
 set(HARDWARE_DEFINITIONS "ALIGNMENT=${ALIGNMENT}"
                          "VECTORSIZE=${VECTORSIZE}"
                          "REAL_SIZE=${REAL_SIZE_IN_BYTES}"
@@ -552,22 +559,6 @@ endif()
 # put every executable in the root build directory at the end
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
 
-# build SeisSol-bin
-  add_executable(SeisSol-bin src/Main.cpp)
-  set_target_properties(SeisSol-bin PROPERTIES OUTPUT_NAME "SeisSol_${EXE_NAME_PREFIX}")
-
-  if (WITH_GPU)
-    target_link_libraries(SeisSol-bin PUBLIC general-sycl-offloading)
-  endif()
-  target_link_libraries(SeisSol-bin PUBLIC SeisSol-lib)
-
-  install(TARGETS SeisSol-bin RUNTIME)
-# end build SeisSol-bin
-
-# build SeisSol-proxy
-  add_subdirectory(auto-tuning/proxy/src)
-# end build SeisSol-proxy
-
 if (LIKWID)
   find_package(likwid REQUIRED)
   if (BUILD_PROXY)
@@ -583,21 +574,6 @@ endif()
 if (TESTING)
   enable_testing()
   include(cmake/doctest.cmake)
-
-  # Coverage
-  if(COVERAGE AND CMAKE_COMPILER_IS_GNUCXX)
-    include(cmake/CodeCoverage.cmake)
-    append_coverage_compiler_flags()
-    setup_target_for_coverage_lcov(
-            NAME SeisSol-coverage
-            EXECUTABLE SeisSol-serial-test
-            EXCLUDE "/usr/*"
-                    "submodules/*"
-                    "*/tests/*"
-                    "external/*"
-                    "*/yaml-cpp-install/*"
-    )
-  endif()
 
   set(seissol_test_sources
           src/tests/Model/TestModel.cpp
@@ -672,7 +648,37 @@ endif()
 
   # Avoid duplicate definition of FLOP counters
   target_compile_definitions(SeisSol-serial-test PRIVATE YATETO_TESTING_NO_FLOP_COUNTER)
+
+  # Coverage
+  if(COVERAGE AND CMAKE_COMPILER_IS_GNUCXX)
+    setup_target_for_coverage_lcov(
+            NAME seissol-coverage
+            EXECUTABLE SeisSol-serial-test
+            EXCLUDE "/usr/*"
+                    "submodules/*"
+                    "*/tests/*"
+                    "external/*"
+            LCOV_ARGS --ignore-errors inconsistent
+                      --ignore-errors unused
+    )
+  endif()
 endif()
+
+# build SeisSol-bin
+add_executable(SeisSol-bin src/Main.cpp)
+set_target_properties(SeisSol-bin PROPERTIES OUTPUT_NAME "SeisSol_${EXE_NAME_PREFIX}")
+
+if (WITH_GPU)
+  target_link_libraries(SeisSol-bin PUBLIC general-sycl-offloading)
+endif()
+target_link_libraries(SeisSol-bin PUBLIC SeisSol-lib)
+
+install(TARGETS SeisSol-bin RUNTIME)
+# end build SeisSol-bin
+
+# build SeisSol-proxy
+add_subdirectory(auto-tuning/proxy/src)
+# end build SeisSol-proxy
 
 if (WITH_GPU)
   string(TOUPPER "${DEVICE_BACKEND}" BACKEND_UPPER_CASE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -666,6 +666,8 @@ endif()
                     "submodules/*"
                     "*/tests/*"
                     "external/*"
+                    "*/src/generated_code/*"
+                    "/opt/*"
             LCOV_ARGS --ignore-errors inconsistent
                       --ignore-errors unused
     )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -124,6 +124,11 @@ set(GENERATED_FILES_FOR_SEISSOL src/generated_code/subroutine.h
                                 src/generated_code/kernel.h
                                 src/generated_code/kernel.cpp)
 
+if (TESTING AND TESTING_GENERATED)
+  set(GENERATED_FILES_FOR_SEISSOL ${GENERATED_FILES_FOR_SEISSOL}
+                                src/generated_code/test-kernel.cpp)
+endif()
+
 file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/src/generated_code/)
 
 if(PROXY_PYBINDING)
@@ -591,9 +596,12 @@ if (TESTING)
 
 
   if (TESTING_GENERATED)
+    # FIXME: fix by removing the `using namespace` in the test files
+    # and replace by ${CMAKE_CURRENT_BINARY_DIR}/src/generated_code/test-kernel.cpp
+    file(GLOB_RECURSE KERNEL_TESTFILES ${CMAKE_CURRENT_BINARY_DIR}/src/generated_code/**/test-kernel.cpp)
     set(seissol_test_sources
             ${seissol_test_sources}
-            ${CMAKE_CURRENT_BINARY_DIR}/src/generated_code/test-kernel.cpp
+            ${KERNEL_TESTFILES}
             )
   endif()
 

--- a/cmake/CodeCoverage.cmake
+++ b/cmake/CodeCoverage.cmake
@@ -199,7 +199,7 @@ mark_as_advanced(
 
 get_property(GENERATOR_IS_MULTI_CONFIG GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
 if(NOT (CMAKE_BUILD_TYPE STREQUAL "Debug" OR GENERATOR_IS_MULTI_CONFIG))
-    message(WARNING "Code coverage results with an optimised (non-Debug) build may be misleading")
+    message(WARNING "Code coverage results with an optimized (non-Debug) build may be misleading")
 endif() # NOT (CMAKE_BUILD_TYPE STREQUAL "Debug" OR GENERATOR_IS_MULTI_CONFIG)
 
 if(CMAKE_C_COMPILER_ID STREQUAL "GNU" OR CMAKE_Fortran_COMPILER_ID STREQUAL "GNU")
@@ -229,6 +229,11 @@ function(setup_target_for_coverage_lcov)
     set(oneValueArgs BASE_DIRECTORY NAME)
     set(multiValueArgs EXCLUDE EXECUTABLE EXECUTABLE_ARGS DEPENDENCIES LCOV_ARGS GENHTML_ARGS)
     cmake_parse_arguments(Coverage "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+
+    get_property(crosscompiling_emulator
+            TARGET ${Coverage_EXECUTABLE}
+            PROPERTY CROSSCOMPILING_EMULATOR
+            )
 
     if(NOT LCOV_PATH)
         message(FATAL_ERROR "lcov not found! Aborting...")
@@ -273,7 +278,7 @@ function(setup_target_for_coverage_lcov)
             )
     # Run tests
     set(LCOV_EXEC_TESTS_CMD
-            ${Coverage_EXECUTABLE} ${Coverage_EXECUTABLE_ARGS}
+            ${crosscompiling_emulator} ${Coverage_EXECUTABLE} ${Coverage_EXECUTABLE_ARGS}
             )
     # Capturing lcov counters and generating report
     set(LCOV_CAPTURE_CMD
@@ -348,19 +353,17 @@ function(setup_target_for_coverage_lcov)
             WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
             DEPENDS ${Coverage_DEPENDENCIES}
             VERBATIM # Protect arguments to commands
-            COMMENT "Resetting code coverage counters to zero.\nProcessing code coverage counters and generating report."
+            COMMENT "Resetting code coverage counters to zero. Processing code coverage counters and generating report."
             )
 
     # Show where to find the lcov info report
     add_custom_command(TARGET ${Coverage_NAME} POST_BUILD
-            COMMAND ;
-            COMMENT "Lcov code coverage info report saved in ${Coverage_NAME}.info."
+            COMMAND ${CMAKE_COMMAND} -E echo "Lcov code coverage info report saved in ${Coverage_NAME}.info."
             )
 
     # Show info where to find the report
     add_custom_command(TARGET ${Coverage_NAME} POST_BUILD
-            COMMAND ;
-            COMMENT "Open ./${Coverage_NAME}/index.html in your browser to view the coverage report."
+            COMMAND ${CMAKE_COMMAND} -E echo "Open ./${Coverage_NAME}/index.html in your browser to view the coverage report."
             )
 
 endfunction() # setup_target_for_coverage_lcov
@@ -452,8 +455,7 @@ function(setup_target_for_coverage_gcovr_xml)
 
     # Show info where to find the report
     add_custom_command(TARGET ${Coverage_NAME} POST_BUILD
-            COMMAND ;
-            COMMENT "Cobertura code coverage report saved in ${Coverage_NAME}.xml."
+            COMMAND ${CMAKE_COMMAND} -E echo "Cobertura code coverage report saved in ${Coverage_NAME}.xml."
             )
 endfunction() # setup_target_for_coverage_gcovr_xml
 
@@ -554,8 +556,7 @@ function(setup_target_for_coverage_gcovr_html)
 
     # Show info where to find the report
     add_custom_command(TARGET ${Coverage_NAME} POST_BUILD
-            COMMAND ;
-            COMMENT "Open ./${Coverage_NAME}/index.html in your browser to view the coverage report."
+            COMMAND ${CMAKE_COMMAND} -E echo "Open ./${Coverage_NAME}/index.html in your browser to view the coverage report."
             )
 
 endfunction() # setup_target_for_coverage_gcovr_html

--- a/generated-code/generate.py
+++ b/generated-code/generate.py
@@ -252,6 +252,7 @@ def main():
     forward_files("kernel.cpp")
     forward_files("subroutine.cpp")
     forward_files("tensor.cpp")
+    forward_files("test-kernel.cpp")
     forward_files("gpulike_subroutine.cpp")
 
 


### PR DESCRIPTION
* Fix generated kernel test generation
* Make the coverage computation work with test drivers (i.e. testing commands, like needed for NVHPC)
* Fix the coverage computation
* Remove the generated kernels and easi from the coverage calculation (feel free to protest here, if it feels wrong to someone)
* Add the coverage computation to the CI (including a downloadable overview)

(note: the coverage is currently pretty low, since we only consider the unit tests here. The full CI should test through much more parts of the code, via the end-to-end tests—it might be useful to somehow integrate those into the unit tests or the coverage computation somehow.)
