### PR TITLE
Normalize CMake Target Names

### DIFF
--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -51,7 +51,7 @@ jobs:
           git submodule update --init
           mkdir -p build && cd build
           CMAKE_PREFIX_PATH=/opt/dependencies cmake -DGEMM_TOOLS_LIST=none -DNETCDF=OFF -DORDER=6 -DASAGI=OFF -DHDF5=ON -DCMAKE_BUILD_TYPE=Debug -DTESTING=ON -DLOG_LEVEL=warning -DLOG_LEVEL_MASTER=info -DHOST_ARCH=hsw -DPRECISION=double -DEQUATIONS=elastic -DNUMBER_OF_MECHANISMS=0 -DTESTING=ON -DCMAKE_EXPORT_COMPILE_COMMANDS=ON ..
-          make SeisSol-codegen
+          make seissol-codegen
           # clang-tidy can not handle -fprofile-abs-path, so we remove it from the compile commands.
           sed -i 's/-fprofile-abs-path //g' compile_commands.json
           ../.ci/tidy.sh ../ ./ -clang-tidy-binary=$(which clang-tidy-19) -quiet -j $(nproc)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -164,34 +164,34 @@ add_custom_command(
     COMMENT "Code generation for tensor operations..."
        )
 
-add_custom_target(SeisSol-codegen ALL DEPENDS ${GENERATED_FILES_FOR_SEISSOL})
-add_library(SeisSol-common-properties INTERFACE IMPORTED)
+add_custom_target(seissol-codegen ALL DEPENDS ${GENERATED_FILES_FOR_SEISSOL})
+add_library(seissol-common-properties INTERFACE IMPORTED)
 
 include(src/sources.cmake)
 
 # enforce code generation to run before any other target
-add_dependencies(SeisSol-common-properties SeisSol-codegen)
+add_dependencies(seissol-common-properties seissol-codegen)
 
-target_link_libraries(SeisSol-lib PUBLIC SeisSol-common-properties)
-target_link_libraries(SeisSol-kernel-lib PUBLIC SeisSol-common-properties)
-target_link_libraries(SeisSol-common-lib PUBLIC SeisSol-common-properties)
+target_link_libraries(seissol-lib PUBLIC seissol-common-properties)
+target_link_libraries(seissol-kernel-lib PUBLIC seissol-common-properties)
+target_link_libraries(seissol-common-lib PUBLIC seissol-common-properties)
 
-target_link_libraries(SeisSol-common-lib PRIVATE SeisSol-kernel-lib)
-target_link_libraries(SeisSol-lib PRIVATE SeisSol-kernel-lib)
-target_link_libraries(SeisSol-lib PRIVATE SeisSol-common-lib)
+target_link_libraries(seissol-common-lib PRIVATE seissol-kernel-lib)
+target_link_libraries(seissol-lib PRIVATE seissol-kernel-lib)
+target_link_libraries(seissol-lib PRIVATE seissol-common-lib)
 
 if (WITH_GPU)
-  add_dependencies(SeisSol-device-lib SeisSol-codegen)
+  add_dependencies(seissol-device-lib seissol-codegen)
 endif()
 
 if(GemmTools_INCLUDE_DIRS)
-  target_include_directories(SeisSol-common-properties INTERFACE ${GemmTools_INCLUDE_DIRS})
+  target_include_directories(seissol-common-properties INTERFACE ${GemmTools_INCLUDE_DIRS})
 endif()
 if(GemmTools_LIBRARIES)
-  target_link_libraries(SeisSol-common-properties INTERFACE ${GemmTools_LIBRARIES})
+  target_link_libraries(seissol-common-properties INTERFACE ${GemmTools_LIBRARIES})
 endif()
 if(GemmTools_COMPILER_DEFINITIONS)
-  target_compile_definitions(SeisSol-common-properties INTERFACE ${GemmTools_COMPILER_DEFINITIONS})
+  target_compile_definitions(seissol-common-properties INTERFACE ${GemmTools_COMPILER_DEFINITIONS})
 endif()
 
 # Find appropriate compiler flags based on the target computer architecture
@@ -201,18 +201,18 @@ include(cmake/cpu_arch_flags.cmake)
 get_arch_flags(${HOST_ARCH} ${CMAKE_CXX_COMPILER_ID})
 
 # set hardware/compiler specific definitions and flags
-target_compile_definitions(SeisSol-common-properties INTERFACE ${HARDWARE_DEFINITIONS})
-target_compile_options(SeisSol-common-properties INTERFACE ${CPU_ARCH_FLAGS})
+target_compile_definitions(seissol-common-properties INTERFACE ${HARDWARE_DEFINITIONS})
+target_compile_options(seissol-common-properties INTERFACE ${CPU_ARCH_FLAGS})
 
-target_compile_definitions(SeisSol-common-properties INTERFACE LOGLEVEL=${LOG_LEVEL})
-target_compile_definitions(SeisSol-common-properties INTERFACE LOG_LEVEL=${LOG_LEVEL_MASTER}
+target_compile_definitions(seissol-common-properties INTERFACE LOGLEVEL=${LOG_LEVEL})
+target_compile_definitions(seissol-common-properties INTERFACE LOG_LEVEL=${LOG_LEVEL_MASTER}
                                                      LOGLEVEL0=${LOG_LEVEL_MASTER})
 
 
 if (PLASTICITY_METHOD STREQUAL "ip")
-  target_compile_definitions(SeisSol-common-properties INTERFACE USE_PLASTICITY_IP)
+  target_compile_definitions(seissol-common-properties INTERFACE USE_PLASTICITY_IP)
 elseif (PLASTICITY_METHOD STREQUAL "nb")
-  target_compile_definitions(SeisSol-common-properties INTERFACE USE_PLASTICITY_NB)
+  target_compile_definitions(seissol-common-properties INTERFACE USE_PLASTICITY_NB)
 endif()
 
 
@@ -224,37 +224,37 @@ endif()
 include(ExternalProject)
 
 find_package(easi 1.0.0 REQUIRED)
-target_link_libraries(SeisSol-common-properties INTERFACE easi::easi)
+target_link_libraries(seissol-common-properties INTERFACE easi::easi)
 
 if (OPENMP)
   find_package(OpenMP REQUIRED)
-  target_link_libraries(SeisSol-common-properties INTERFACE OpenMP::OpenMP_CXX)
-  target_compile_definitions(SeisSol-common-properties INTERFACE OMP OMPI_SKIP_MPICXX)
+  target_link_libraries(seissol-common-properties INTERFACE OpenMP::OpenMP_CXX)
+  target_compile_definitions(seissol-common-properties INTERFACE OMP OMPI_SKIP_MPICXX)
 endif()
 
 if (MPI)
   find_package(MPI REQUIRED)
 
-  target_include_directories(SeisSol-common-properties SYSTEM INTERFACE ${MPI_CXX_INCLUDE_PATH})
-  target_link_libraries(SeisSol-common-properties INTERFACE MPI::MPI_C)
+  target_include_directories(seissol-common-properties SYSTEM INTERFACE ${MPI_CXX_INCLUDE_PATH})
+  target_link_libraries(seissol-common-properties INTERFACE MPI::MPI_C)
 
-  target_compile_definitions(SeisSol-common-properties INTERFACE USE_MPI PARALLEL)
+  target_compile_definitions(seissol-common-properties INTERFACE USE_MPI PARALLEL)
 endif()
 
 if (NUMA_AWARE_PINNING)
-  target_compile_definitions(SeisSol-common-properties INTERFACE USE_NUMA_AWARE_PINNING)
+  target_compile_definitions(seissol-common-properties INTERFACE USE_NUMA_AWARE_PINNING)
   find_package(NUMA REQUIRED)
 
-  target_include_directories(SeisSol-common-properties SYSTEM INTERFACE ${NUMA_INCLUDE_DIR})
-  target_link_libraries(SeisSol-common-properties INTERFACE ${NUMA_LIBRARY})
+  target_include_directories(seissol-common-properties SYSTEM INTERFACE ${NUMA_INCLUDE_DIR})
+  target_link_libraries(seissol-common-properties INTERFACE ${NUMA_LIBRARY})
 endif()
 
 #set(HDF5_PREFER_PARALLEL True)
 if (NETCDF)
   find_package(NetCDF REQUIRED)
-  target_include_directories(SeisSol-common-properties INTERFACE ${NetCDF_INCLUDE_DIRS})
-  target_link_libraries(SeisSol-common-properties INTERFACE ${NetCDF_LIBRARY})
-  target_compile_definitions(SeisSol-common-properties INTERFACE USE_NETCDF)
+  target_include_directories(seissol-common-properties INTERFACE ${NetCDF_INCLUDE_DIRS})
+  target_link_libraries(seissol-common-properties INTERFACE ${NetCDF_LIBRARY})
+  target_compile_definitions(seissol-common-properties INTERFACE USE_NETCDF)
 endif()
 
 if (HDF5)
@@ -262,9 +262,9 @@ if (HDF5)
     set(HDF5_PREFER_PARALLEL True)
   endif()
   find_package(HDF5 REQUIRED COMPONENTS C HL)
-  target_include_directories(SeisSol-common-properties INTERFACE ${HDF5_INCLUDE_DIRS})
-  target_link_libraries(SeisSol-common-properties INTERFACE ${HDF5_C_HL_LIBRARIES} ${HDF5_C_LIBRARIES})
-  target_compile_definitions(SeisSol-common-properties INTERFACE USE_HDF)
+  target_include_directories(seissol-common-properties INTERFACE ${HDF5_INCLUDE_DIRS})
+  target_link_libraries(seissol-common-properties INTERFACE ${HDF5_C_HL_LIBRARIES} ${HDF5_C_LIBRARIES})
+  target_compile_definitions(seissol-common-properties INTERFACE USE_HDF)
   if (NOT HDF5_IS_PARALLEL)
     message(WARNING "The found parallel Hdf5 installation is not parallel. Compile errors will occur.")
   endif()
@@ -277,19 +277,19 @@ if ("parmetis" IN_LIST GRAPH_PARTITIONING_LIBS)
       message(WARNING "Found METIS compiled with IDXTYPEWIDTH = 32. It is strongly recommend to compile METIS with IDXTYPEWIDTH = 64, because otherwise the partitioning of large meshes might fail.")
   endif()
   find_package(ParMETIS REQUIRED)
-  target_include_directories(SeisSol-common-properties INTERFACE ${PARMETIS_INCLUDE_DIRS})
-  target_link_libraries(SeisSol-common-properties INTERFACE ${PARMETIS_LIBRARIES})
-  target_compile_definitions(SeisSol-common-properties INTERFACE USE_METIS USE_PARMETIS)
+  target_include_directories(seissol-common-properties INTERFACE ${PARMETIS_INCLUDE_DIRS})
+  target_link_libraries(seissol-common-properties INTERFACE ${PARMETIS_LIBRARIES})
+  target_compile_definitions(seissol-common-properties INTERFACE USE_METIS USE_PARMETIS)
 endif()
 if ("parhip" IN_LIST GRAPH_PARTITIONING_LIBS)
     find_package(ParHIP REQUIRED)
-    target_link_libraries(SeisSol-common-properties INTERFACE ParHIP::ParHIP)
-    target_compile_definitions(SeisSol-common-properties INTERFACE USE_PARHIP)
+    target_link_libraries(seissol-common-properties INTERFACE ParHIP::ParHIP)
+    target_compile_definitions(seissol-common-properties INTERFACE USE_PARHIP)
 endif()
 if ("ptscotch" IN_LIST GRAPH_PARTITIONING_LIBS)
     find_package(SCOTCH REQUIRED)
-    target_link_libraries(SeisSol-common-properties INTERFACE SCOTCH::ptscotch SCOTCH::ptscotcherr)
-    target_compile_definitions(SeisSol-common-properties INTERFACE USE_PTSCOTCH)
+    target_link_libraries(seissol-common-properties INTERFACE SCOTCH::ptscotch SCOTCH::ptscotcherr)
+    target_compile_definitions(seissol-common-properties INTERFACE USE_PTSCOTCH)
 endif()
 if (NOT GRAPH_PARTITIONING_LIBS)
     message(WARNING "Compiling without graph partitioning library; expect poor performance in multi-rank runs.")
@@ -299,17 +299,17 @@ find_package(PkgConfig REQUIRED)
 if (ASAGI)
   # todo warn if netcdf is off
   pkg_check_modules(ASAGI REQUIRED IMPORTED_TARGET asagi) # asagi_nompi?
-  target_compile_definitions(SeisSol-common-properties INTERFACE USE_ASAGI)
-  target_link_libraries(SeisSol-common-properties INTERFACE ${ASAGI_LDFLAGS})
-  target_include_directories(SeisSol-common-properties INTERFACE ${ASAGI_INCLUDE_DIRS})
-  target_compile_options(SeisSol-common-properties INTERFACE ${ASAGI_CFLAGS} ${ASAGI_CFLAGS_OTHER})
+  target_compile_definitions(seissol-common-properties INTERFACE USE_ASAGI)
+  target_link_libraries(seissol-common-properties INTERFACE ${ASAGI_LDFLAGS})
+  target_include_directories(seissol-common-properties INTERFACE ${ASAGI_INCLUDE_DIRS})
+  target_compile_options(seissol-common-properties INTERFACE ${ASAGI_CFLAGS} ${ASAGI_CFLAGS_OTHER})
 endif()
 
 if (MEMKIND)
   find_package(Memkind REQUIRED)
-  target_include_directories(SeisSol-common-properties INTERFACE ${MEMKIND_INCLUDE_DIR})
-  target_link_libraries(SeisSol-common-properties INTERFACE ${MEMKIND_LIBRARIES})
-  target_compile_definitions(SeisSol-common-properties INTERFACE USE_MEMKIND)
+  target_include_directories(seissol-common-properties INTERFACE ${MEMKIND_INCLUDE_DIR})
+  target_link_libraries(seissol-common-properties INTERFACE ${MEMKIND_LIBRARIES})
+  target_compile_definitions(seissol-common-properties INTERFACE USE_MEMKIND)
 endif()
 
 if(${EQUATIONS} STREQUAL "poroelastic")
@@ -320,8 +320,8 @@ if(${EQUATIONS} STREQUAL "poroelastic")
     include(FortranCInterface)
     FortranCInterface_HEADER(FC.h MACRO_NAMESPACE "FC_")
     find_package(LAPACK REQUIRED)
-    target_include_directories(SeisSol-common-properties INTERFACE ${CMAKE_CURRENT_BINARY_DIR})
-    target_link_libraries(SeisSol-common-properties INTERFACE ${LAPACK_LIBRARIES})
+    target_include_directories(seissol-common-properties INTERFACE ${CMAKE_CURRENT_BINARY_DIR})
+    target_link_libraries(seissol-common-properties INTERFACE ${LAPACK_LIBRARIES})
   else()
     message(FATAL_ERROR "SeisSol needs a Fortran compiler.")
   endif()
@@ -329,15 +329,15 @@ endif()
 
 
 if (INTEGRATE_QUANTITIES)
-  target_compile_definitions(SeisSol-common-properties INTERFACE INTEGRATE_QUANTITIES)
+  target_compile_definitions(seissol-common-properties INTERFACE INTEGRATE_QUANTITIES)
 endif()
 
 if (DEVICE_EXPERIMENTAL_EXPLICIT_KERNELS)
-  target_compile_definitions(SeisSol-common-properties INTERFACE DEVICE_EXPERIMENTAL_EXPLICIT_KERNELS)
+  target_compile_definitions(seissol-common-properties INTERFACE DEVICE_EXPERIMENTAL_EXPLICIT_KERNELS)
 endif()
 
 if (ADDRESS_SANITIZER_DEBUG)
-  target_link_libraries(SeisSol-common-properties INTERFACE debug
+  target_link_libraries(seissol-common-properties INTERFACE debug
           -fno-omit-frame-pointer -fsanitize=address -fsanitize-recover=address -static-libasan
   )
 endif()
@@ -346,28 +346,28 @@ endif()
 # system headers because they emit lot's of warnings
 # from clang. Most of them are issues with respect
 # to overriden virtual methods
-target_include_directories(SeisSol-common-properties SYSTEM INTERFACE
+target_include_directories(seissol-common-properties SYSTEM INTERFACE
   ${CMAKE_CURRENT_SOURCE_DIR}/submodules/async
 )
 
 find_package(Eigen3 3.4 REQUIRED)
-target_link_libraries(SeisSol-common-properties INTERFACE Eigen3::Eigen)
+target_link_libraries(seissol-common-properties INTERFACE Eigen3::Eigen)
 
 find_package(yaml-cpp REQUIRED)
 
 if ("${yaml-cpp_VERSION}" VERSION_GREATER_EQUAL "0.8")
-  target_link_libraries(SeisSol-common-properties INTERFACE yaml-cpp::yaml-cpp)
+  target_link_libraries(seissol-common-properties INTERFACE yaml-cpp::yaml-cpp)
 else()
   # fallback code for old versions
   if (YAML_CPP_INCLUDE_DIR AND EXISTS "${YAML_CPP_INCLUDE_DIR}")
-    target_include_directories(SeisSol-common-properties INTERFACE ${YAML_CPP_INCLUDE_DIR})
+    target_include_directories(seissol-common-properties INTERFACE ${YAML_CPP_INCLUDE_DIR})
   endif()
   if (YAML_CPP_LIBRARIES)
     # use the YAML_CPP_LIBRARIES, if available (though it may just say `yaml-cpp`)
-    target_link_libraries(SeisSol-common-properties INTERFACE ${YAML_CPP_LIBRARIES})
+    target_link_libraries(seissol-common-properties INTERFACE ${YAML_CPP_LIBRARIES})
   else()
     # fallback
-    target_link_libraries(SeisSol-common-properties INTERFACE yaml-cpp)
+    target_link_libraries(seissol-common-properties INTERFACE yaml-cpp)
   endif()
 endif()
 
@@ -378,27 +378,27 @@ endif()
 # use eigen in GPU kernels. Therefore, it is better to change
 # the default behaviour (which assumes CUDA support) and
 # set `EIGEN_NO_CUDA`
-target_compile_definitions(SeisSol-common-properties INTERFACE EIGEN_NO_CUDA)
+target_compile_definitions(seissol-common-properties INTERFACE EIGEN_NO_CUDA)
 
 if (EIGEN3_INCLUDE_DIR)
-  target_include_directories(SeisSol-common-properties INTERFACE ${EIGEN3_INCLUDE_DIR})
+  target_include_directories(seissol-common-properties INTERFACE ${EIGEN3_INCLUDE_DIR})
 endif()
 
-target_include_directories(SeisSol-common-properties INTERFACE
+target_include_directories(seissol-common-properties INTERFACE
     ${CMAKE_CURRENT_SOURCE_DIR}/src
     ${CMAKE_CURRENT_SOURCE_DIR}/submodules
     ${CMAKE_CURRENT_SOURCE_DIR}/submodules/yateto/include
     ${CMAKE_CURRENT_BINARY_DIR}/src/
 )
 
-target_compile_definitions(SeisSol-common-properties INTERFACE
+target_compile_definitions(seissol-common-properties INTERFACE
     CONVERGENCE_ORDER=${ORDER}
     NUMBER_OF_RELAXATION_MECHANISMS=${NUMBER_OF_MECHANISMS}
     ${DR_QUAD_RULE}
 )
 
 if (PREMULTIPLY_FLUX)
-  target_compile_definitions(SeisSol-common-properties INTERFACE USE_PREMULTIPLY_FLUX)
+  target_compile_definitions(seissol-common-properties INTERFACE USE_PREMULTIPLY_FLUX)
 endif()
 
 # adjust prefix name of executables
@@ -409,37 +409,37 @@ else()
 endif()
 
 if (SHARED)
-  set_target_properties(SeisSol-lib PROPERTIES OUTPUT_NAME "SeisSol_lib_${EXE_NAME_PREFIX}")
-  install(TARGETS SeisSol-lib LIBRARY)
+  set_target_properties(seissol-lib PROPERTIES OUTPUT_NAME "SeisSol_lib_${EXE_NAME_PREFIX}")
+  install(TARGETS seissol-lib LIBRARY)
 endif()
 
 if (WITH_GPU)
   if (DEVICE_BACKEND STREQUAL "cuda")
-    target_compile_definitions(SeisSol-common-properties INTERFACE SEISSOL_KERNELS_CUDA)
+    target_compile_definitions(seissol-common-properties INTERFACE SEISSOL_KERNELS_CUDA)
   endif()
   if (DEVICE_BACKEND STREQUAL "hip")
-    target_compile_definitions(SeisSol-common-properties INTERFACE SEISSOL_KERNELS_HIP)
+    target_compile_definitions(seissol-common-properties INTERFACE SEISSOL_KERNELS_HIP)
   endif()
   if (DEVICE_BACKEND STREQUAL "hipsycl" OR DEVICE_BACKEND STREQUAL "oneapi")
-    target_compile_definitions(SeisSol-common-properties INTERFACE SEISSOL_KERNELS_SYCL)
+    target_compile_definitions(seissol-common-properties INTERFACE SEISSOL_KERNELS_SYCL)
   endif()
 
   # set SeisSol GPU definitions
-  target_compile_definitions(SeisSol-common-properties INTERFACE ACL_DEVICE)
+  target_compile_definitions(seissol-common-properties INTERFACE ACL_DEVICE)
 
   # add device submodule
   add_subdirectory(submodules/Device)
-  target_include_directories(SeisSol-common-properties INTERFACE submodules/Device)
-  target_link_libraries(SeisSol-common-properties INTERFACE device)
+  target_include_directories(seissol-common-properties INTERFACE submodules/Device)
+  target_link_libraries(seissol-common-properties INTERFACE device)
 
   # add SeisSol GPU part
-  target_link_libraries(SeisSol-common-properties INTERFACE SeisSol-device-lib)
+  target_link_libraries(seissol-common-properties INTERFACE seissol-device-lib)
 
   add_library(general-sycl-offloading SHARED
       ${SYCL_DEPENDENT_SRC_FILES}
       ${SYCL_ONLY_SRC_FILES})
-  target_link_libraries(general-sycl-offloading PRIVATE SeisSol-common-properties)
-  target_link_libraries(general-sycl-offloading PRIVATE SeisSol-common-lib)
+  target_link_libraries(general-sycl-offloading PRIVATE seissol-common-properties)
+  target_link_libraries(general-sycl-offloading PRIVATE seissol-common-lib)
 
   set(SYCL_CC "acpp" CACHE STRING "The SYCL Compiler used for general SYCL offloading")
   set(SYCL_CC_OPTIONS acpp hipsycl dpcpp)
@@ -491,27 +491,27 @@ if (WITH_GPU)
     find_package(DpcppFlags REQUIRED)
     message(STATUS "Using DPC++ for general SYCL offloading")
     target_link_libraries(general-sycl-offloading PRIVATE dpcpp::device_flags)
-    target_link_libraries(SeisSol-common-properties INTERFACE dpcpp::interface)
+    target_link_libraries(seissol-common-properties INTERFACE dpcpp::interface)
   endif()
 
-  add_dependencies(general-sycl-offloading SeisSol-codegen)
+  add_dependencies(general-sycl-offloading seissol-codegen)
 
   set_target_properties(general-sycl-offloading PROPERTIES OUTPUT_NAME "SeisSol_offloading_${EXE_NAME_PREFIX}")
-  set_target_properties(SeisSol-device-lib PROPERTIES OUTPUT_NAME "SeisSol_gpucodegen_${EXE_NAME_PREFIX}")
+  set_target_properties(seissol-device-lib PROPERTIES OUTPUT_NAME "SeisSol_gpucodegen_${EXE_NAME_PREFIX}")
   set_target_properties(device PROPERTIES OUTPUT_NAME "device_${CMAKE_BUILD_TYPE}_${DEVICE_ARCH_STR}_${DEVICE_BACKEND}")
 
   # set up GPU install targets
   install(TARGETS general-sycl-offloading LIBRARY)
-  install(TARGETS SeisSol-device-lib LIBRARY)
+  install(TARGETS seissol-device-lib LIBRARY)
   install(TARGETS device LIBRARY)
 else()
-  # add DR source files to SeisSol-lib if we are compiling without any GPU support
-  target_sources(SeisSol-common-lib PRIVATE ${SYCL_DEPENDENT_SRC_FILES})
+  # add DR source files to seissol-lib if we are compiling without any GPU support
+  target_sources(seissol-common-lib PRIVATE ${SYCL_DEPENDENT_SRC_FILES})
 endif()
 
 # C++ compiler settings
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
-  target_compile_options(SeisSol-lib INTERFACE -pedantic $<$<OR:$<COMPILE_LANGUAGE:CXX>,$<COMPILE_LANGUAGE:C>>:-Wall -Wextra -Wno-unused-parameter -Wno-unknown-pragmas>)
+  target_compile_options(seissol-lib INTERFACE -pedantic $<$<OR:$<COMPILE_LANGUAGE:CXX>,$<COMPILE_LANGUAGE:C>>:-Wall -Wextra -Wno-unused-parameter -Wno-unknown-pragmas>)
 
   # using GCC
 elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Intel")
@@ -520,7 +520,7 @@ elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Intel")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17")
 
   # Activate interprocedual optimization.
-  #set_property(TARGET SeisSol-lib PROPERTY INTERPROCEDURAL_OPTIMIZATION TRUE) 
+  #set_property(TARGET seissol-lib PROPERTY INTERPROCEDURAL_OPTIMIZATION TRUE) 
 elseif (CMAKE_CXX_COMPILER_ID MATCHES "Clang|IntelLLVM")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -pedantic -Wno-unused-parameter")
 
@@ -540,7 +540,7 @@ elseif(CMAKE_CXX_COMPILER_ID MATCHES "NVHPC|PGI")
 endif()
 
 find_package(FILESYSTEM REQUIRED)
-target_link_libraries(SeisSol-common-properties INTERFACE std::filesystem)
+target_link_libraries(seissol-common-properties INTERFACE std::filesystem)
 
 # Generated code does only work without red-zone.
 if (HAS_REDZONE)
@@ -552,21 +552,21 @@ endif()
 # put every executable in the root build directory at the end
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
 
-# build SeisSol-bin
-  add_executable(SeisSol-bin src/Main.cpp)
-  set_target_properties(SeisSol-bin PROPERTIES OUTPUT_NAME "SeisSol_${EXE_NAME_PREFIX}")
+# build seissol-bin
+  add_executable(seissol-bin src/Main.cpp)
+  set_target_properties(seissol-bin PROPERTIES OUTPUT_NAME "SeisSol_${EXE_NAME_PREFIX}")
 
   if (WITH_GPU)
-    target_link_libraries(SeisSol-bin PUBLIC general-sycl-offloading)
+    target_link_libraries(seissol-bin PUBLIC general-sycl-offloading)
   endif()
-  target_link_libraries(SeisSol-bin PUBLIC SeisSol-lib)
+  target_link_libraries(seissol-bin PUBLIC seissol-lib)
 
-  install(TARGETS SeisSol-bin RUNTIME)
-# end build SeisSol-bin
+  install(TARGETS seissol-bin RUNTIME)
+# end build seissol-bin
 
-# build SeisSol-proxy
+# build seissol-proxy
   add_subdirectory(auto-tuning/proxy/src)
-# end build SeisSol-proxy
+# end build seissol-proxy
 
 if (LIKWID)
   find_package(likwid REQUIRED)
@@ -575,9 +575,9 @@ if (LIKWID)
     target_include_directories(seissol-proxy-lib PUBLIC ${LIKWID_INCLUDE_DIR})
     target_link_libraries(seissol-proxy-lib PUBLIC likwid::likwid)
   endif()
-  target_compile_definitions(SeisSol-lib PUBLIC LIKWID_PERFMON)
-  target_include_directories(SeisSol-lib PUBLIC ${LIKWID_INCLUDE_DIR})
-  target_link_libraries(SeisSol-lib PUBLIC likwid::likwid)
+  target_compile_definitions(seissol-lib PUBLIC LIKWID_PERFMON)
+  target_include_directories(seissol-lib PUBLIC ${LIKWID_INCLUDE_DIR})
+  target_link_libraries(seissol-lib PUBLIC likwid::likwid)
 endif()
 
 if (TESTING)
@@ -589,8 +589,8 @@ if (TESTING)
     include(cmake/CodeCoverage.cmake)
     append_coverage_compiler_flags()
     setup_target_for_coverage_lcov(
-            NAME SeisSol-coverage
-            EXECUTABLE SeisSol-serial-test
+            NAME seissol-coverage
+            EXECUTABLE seissol-serial-test
             EXCLUDE "/usr/*"
                     "submodules/*"
                     "*/tests/*"
@@ -657,21 +657,21 @@ if (TESTING)
     set(seissol_test_sources ${seissol_test_sources} ${CMAKE_CURRENT_SOURCE_DIR}/src/tests/Reader/ReaderTest.cpp)
   endif()
 
-  add_executable(SeisSol-serial-test
+  add_executable(seissol-serial-test
             ${seissol_test_sources}
             src/tests/TestMain.cpp)
-  target_link_libraries(SeisSol-serial-test PRIVATE SeisSol-lib)
+  target_link_libraries(seissol-serial-test PRIVATE seissol-lib)
 if(WITH_GPU)
-  target_link_libraries(SeisSol-serial-test PRIVATE general-sycl-offloading)
+  target_link_libraries(seissol-serial-test PRIVATE general-sycl-offloading)
 endif()
-  target_include_directories(SeisSol-serial-test PUBLIC external/)
+  target_include_directories(seissol-serial-test PUBLIC external/)
 
   separate_arguments(TESTING_COMMAND_LIST NATIVE_COMMAND ${TESTING_COMMAND})
-  set_property(TARGET SeisSol-serial-test PROPERTY CROSSCOMPILING_EMULATOR ${TESTING_COMMAND_LIST})
-  doctest_discover_tests(SeisSol-serial-test)
+  set_property(TARGET seissol-serial-test PROPERTY CROSSCOMPILING_EMULATOR ${TESTING_COMMAND_LIST})
+  doctest_discover_tests(seissol-serial-test)
 
   # Avoid duplicate definition of FLOP counters
-  target_compile_definitions(SeisSol-serial-test PRIVATE YATETO_TESTING_NO_FLOP_COUNTER)
+  target_compile_definitions(seissol-serial-test PRIVATE YATETO_TESTING_NO_FLOP_COUNTER)
 endif()
 
 if (WITH_GPU)

--- a/auto-tuning/proxy/src/CMakeLists.txt
+++ b/auto-tuning/proxy/src/CMakeLists.txt
@@ -21,7 +21,7 @@ if (WITH_GPU)
 endif()
 
 # C/C++ proxy interface
-add_executable(SeisSol-proxy Main.cpp)
-target_link_libraries(SeisSol-proxy PUBLIC seissol-proxy-lib)
-set_target_properties(SeisSol-proxy PROPERTIES OUTPUT_NAME "SeisSol_proxy_${EXE_NAME_PREFIX}")
-install(TARGETS SeisSol-proxy RUNTIME)
+add_executable(seissol-proxy Main.cpp)
+target_link_libraries(seissol-proxy PUBLIC seissol-proxy-lib)
+set_target_properties(seissol-proxy PROPERTIES OUTPUT_NAME "SeisSol_proxy_${EXE_NAME_PREFIX}")
+install(TARGETS seissol-proxy RUNTIME)

--- a/auto-tuning/proxy/src/Proxy/CMakeLists.txt
+++ b/auto-tuning/proxy/src/Proxy/CMakeLists.txt
@@ -12,4 +12,4 @@ add_library(seissol-proxy-lib
     Tools.cpp
 )
 
-target_link_libraries(seissol-proxy-lib PUBLIC SeisSol-lib)
+target_link_libraries(seissol-proxy-lib PUBLIC seissol-lib)

--- a/src/IO/CMakeLists.txt
+++ b/src/IO/CMakeLists.txt
@@ -27,4 +27,4 @@ add_library(seissol-io STATIC
     Manager.cpp
 )
 
-target_link_libraries(seissol-io PUBLIC SeisSol-common-properties)
+target_link_libraries(seissol-io PUBLIC seissol-common-properties)

--- a/src/cuda.cmake
+++ b/src/cuda.cmake
@@ -5,39 +5,39 @@ set(DEVICE_SRC ${DEVICE_SRC}
         ${CMAKE_CURRENT_SOURCE_DIR}/src/Kernels/DeviceAux/cuda/PlasticityAux.cu
         ${CMAKE_CURRENT_SOURCE_DIR}/src/Equations/elastic/Kernels/DeviceAux/cuda/KernelsAux.cu)
 
-add_library(SeisSol-device-lib SHARED ${DEVICE_SRC})
+add_library(seissol-device-lib SHARED ${DEVICE_SRC})
 
-set_target_properties(SeisSol-device-lib PROPERTIES POSITION_INDEPENDENT_CODE ON)
+set_target_properties(seissol-device-lib PROPERTIES POSITION_INDEPENDENT_CODE ON)
 set_source_files_properties(${DEVICE_SRC} PROPERTIES LANGUAGE CUDA)
 
-target_include_directories(SeisSol-device-lib PUBLIC ${SEISSOL_DEVICE_INCLUDE})
-target_compile_features(SeisSol-device-lib PRIVATE cxx_std_17)
-target_compile_features(SeisSol-device-lib PRIVATE cuda_std_17)
-target_compile_options(SeisSol-device-lib PRIVATE ${EXTRA_CXX_FLAGS})
-target_compile_definitions(SeisSol-device-lib PRIVATE ${HARDWARE_DEFINITIONS}
+target_include_directories(seissol-device-lib PUBLIC ${SEISSOL_DEVICE_INCLUDE})
+target_compile_features(seissol-device-lib PRIVATE cxx_std_17)
+target_compile_features(seissol-device-lib PRIVATE cuda_std_17)
+target_compile_options(seissol-device-lib PRIVATE ${EXTRA_CXX_FLAGS})
+target_compile_definitions(seissol-device-lib PRIVATE ${HARDWARE_DEFINITIONS}
         CONVERGENCE_ORDER=${ORDER}
         NUMBER_OF_QUANTITIES=${NUMBER_OF_QUANTITIES}
         NUMBER_OF_RELAXATION_MECHANISMS=${NUMBER_OF_MECHANISMS}
         ${DR_QUAD_RULE})
 
 if (DEVICE_EXPERIMENTAL_EXPLICIT_KERNELS)
-target_compile_definitions(SeisSol-device-lib PRIVATE DEVICE_EXPERIMENTAL_EXPLICIT_KERNELS)
+target_compile_definitions(seissol-device-lib PRIVATE DEVICE_EXPERIMENTAL_EXPLICIT_KERNELS)
 endif()
 
 string(REPLACE "sm_" "" CUDA_DEVICE_ARCH "${DEVICE_ARCH}")
-set_target_properties(SeisSol-device-lib PROPERTIES CUDA_ARCHITECTURES "${CUDA_DEVICE_ARCH}")
+set_target_properties(seissol-device-lib PROPERTIES CUDA_ARCHITECTURES "${CUDA_DEVICE_ARCH}")
 
-target_compile_definitions(SeisSol-device-lib PRIVATE $<$<COMPILE_LANGUAGE:CUDA>:
+target_compile_definitions(seissol-device-lib PRIVATE $<$<COMPILE_LANGUAGE:CUDA>:
         -DREAL_SIZE=${REAL_SIZE_IN_BYTES}
         >)
 
-target_compile_options(SeisSol-device-lib PRIVATE $<$<COMPILE_LANGUAGE:CUDA>:
+target_compile_options(seissol-device-lib PRIVATE $<$<COMPILE_LANGUAGE:CUDA>:
         -Xptxas -v;
         -std=c++17;
         --expt-relaxed-constexpr;
         >)
 if (EXTRA_CXX_FLAGS)
-    target_compile_options(SeisSol-device-lib PRIVATE $<$<COMPILE_LANGUAGE:CUDA>:
+    target_compile_options(seissol-device-lib PRIVATE $<$<COMPILE_LANGUAGE:CUDA>:
             --compiler-options ${EXTRA_CXX_FLAGS}
             >)
 endif()

--- a/src/hip.cmake
+++ b/src/hip.cmake
@@ -52,24 +52,24 @@ set(DEVICE_SRC ${DEVICE_SRC}
 set_source_files_properties(${DEVICE_SRC} PROPERTIES HIP_SOURCE_PROPERTY_FORMAT 1)
 
 hip_reset_flags()
-hip_add_library(SeisSol-device-lib SHARED ${DEVICE_SRC}
+hip_add_library(seissol-device-lib SHARED ${DEVICE_SRC}
         HIPCC_OPTIONS ${SEISSOL_HIPCC}
         NVCC_OPTIONS ${SEISSOL_NVCC})
 
-target_include_directories(SeisSol-device-lib PUBLIC ${SEISSOL_DEVICE_INCLUDE})
-set_property(TARGET SeisSol-device-lib PROPERTY HIP_ARCHITECTURES OFF)
-target_compile_definitions(SeisSol-device-lib PRIVATE ${HARDWARE_DEFINITIONS}
+target_include_directories(seissol-device-lib PUBLIC ${SEISSOL_DEVICE_INCLUDE})
+set_property(TARGET seissol-device-lib PROPERTY HIP_ARCHITECTURES OFF)
+target_compile_definitions(seissol-device-lib PRIVATE ${HARDWARE_DEFINITIONS}
         CONVERGENCE_ORDER=${ORDER}
         NUMBER_OF_QUANTITIES=${NUMBER_OF_QUANTITIES}
         NUMBER_OF_RELAXATION_MECHANISMS=${NUMBER_OF_MECHANISMS}
         ${DR_QUAD_RULE})
 if (DEVICE_EXPERIMENTAL_EXPLICIT_KERNELS)
-target_compile_definitions(SeisSol-device-lib PRIVATE DEVICE_EXPERIMENTAL_EXPLICIT_KERNELS)
+target_compile_definitions(seissol-device-lib PRIVATE DEVICE_EXPERIMENTAL_EXPLICIT_KERNELS)
 endif()
 
 if (IS_NVCC_PLATFORM)
-    set_target_properties(SeisSol-device-lib PROPERTIES LINKER_LANGUAGE HIP)
-    target_link_options(SeisSol-device-lib PRIVATE -arch=${DEVICE_ARCH})
+    set_target_properties(seissol-device-lib PROPERTIES LINKER_LANGUAGE HIP)
+    target_link_options(seissol-device-lib PRIVATE -arch=${DEVICE_ARCH})
 else()
-    target_link_libraries(SeisSol-device-lib PUBLIC ${HIP_PATH}/lib/libamdhip64.so)
+    target_link_libraries(seissol-device-lib PUBLIC ${HIP_PATH}/lib/libamdhip64.so)
 endif()

--- a/src/sources.cmake
+++ b/src/sources.cmake
@@ -1,5 +1,5 @@
 # Source code
-add_library(SeisSol-kernel-lib
+add_library(seissol-kernel-lib
 
 # do YATeTo first, since kernel.cpp usually takes really long
 
@@ -11,7 +11,7 @@ ${CMAKE_CURRENT_BINARY_DIR}/src/generated_code/subroutine.cpp
 ${CMAKE_CURRENT_BINARY_DIR}/src/generated_code/init.cpp
 )
 
-add_library(SeisSol-common-lib
+add_library(seissol-common-lib
 
 src/Initializer/CellLocalMatrices.cpp
 src/Initializer/GlobalData.cpp
@@ -76,17 +76,17 @@ src/Solver/Simulator.cpp
 src/ResultWriter/AnalysisWriter.cpp
 )
 
-# target_link_options(SeisSol-common-lib PUBLIC SeisSol-kernel-lib)
-target_compile_options(SeisSol-kernel-lib PRIVATE -fPIC)
-target_compile_options(SeisSol-common-lib PRIVATE -fPIC)
+# target_link_options(seissol-common-lib PUBLIC seissol-kernel-lib)
+target_compile_options(seissol-kernel-lib PRIVATE -fPIC)
+target_compile_options(seissol-common-lib PRIVATE -fPIC)
 
 if (SHARED)
-add_library(SeisSol-lib SHARED)
+add_library(seissol-lib SHARED)
 else()
-add_library(SeisSol-lib STATIC)
+add_library(seissol-lib STATIC)
 endif()
 
-target_sources(SeisSol-lib PRIVATE
+target_sources(seissol-lib PRIVATE
 src/ResultWriter/EnergyOutput.cpp
 src/ResultWriter/FreeSurfaceWriter.cpp
 src/ResultWriter/FreeSurfaceWriterExecutor.cpp
@@ -161,11 +161,11 @@ set(SYCL_ONLY_SRC_FILES
   ${CMAKE_CURRENT_SOURCE_DIR}/src/DynamicRupture/FrictionLaws/GpuImpl/FrictionSolverDetails.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/src/Kernels/PointSourceClusterOnDevice.cpp)
 
-target_compile_options(SeisSol-common-properties INTERFACE ${EXTRA_CXX_FLAGS})
-target_include_directories(SeisSol-common-properties INTERFACE ${CMAKE_CURRENT_BINARY_DIR}/src/generated_code)
+target_compile_options(seissol-common-properties INTERFACE ${EXTRA_CXX_FLAGS})
+target_include_directories(seissol-common-properties INTERFACE ${CMAKE_CURRENT_BINARY_DIR}/src/generated_code)
 
 if (HDF5 AND MPI)
-  target_sources(SeisSol-lib PRIVATE
+  target_sources(seissol-lib PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/src/Geometry/PartitioningLib.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/Geometry/PUMLReader.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/Initializer/TimeStepping/LtsWeights/LtsWeights.cpp
@@ -174,8 +174,8 @@ if (HDF5 AND MPI)
 endif()
 
 if (NETCDF)
-  target_sources(SeisSol-common-lib PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src/SourceTerm/NRFReader.cpp)
-  target_sources(SeisSol-lib PRIVATE
+  target_sources(seissol-common-lib PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src/SourceTerm/NRFReader.cpp)
+  target_sources(seissol-lib PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/src/Geometry/NetcdfReader.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/Geometry/CubeGenerator.cpp
     )
@@ -184,72 +184,72 @@ endif()
 
 # Eqations have to be set at compile time currently.
 if ("${EQUATIONS}" STREQUAL "elastic")
-  target_sources(SeisSol-common-lib PRIVATE
+  target_sources(seissol-common-lib PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/src/Equations/elastic/Kernels/DirichletBoundary.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/Equations/elastic/Kernels/Local.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/Equations/elastic/Kernels/Neighbor.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/Equations/elastic/Kernels/Time.cpp
     )
-  target_include_directories(SeisSol-common-properties INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/src/Equations/elastic)
-  target_compile_definitions(SeisSol-common-properties INTERFACE USE_ELASTIC)
+  target_include_directories(seissol-common-properties INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/src/Equations/elastic)
+  target_compile_definitions(seissol-common-properties INTERFACE USE_ELASTIC)
 
 elseif ("${EQUATIONS}" STREQUAL "acoustic")
-  target_sources(SeisSol-common-lib PRIVATE
+  target_sources(seissol-common-lib PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/src/Equations/acoustic/Kernels/DirichletBoundary.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/Equations/acoustic/Kernels/Local.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/Equations/acoustic/Kernels/Neighbor.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/Equations/acoustic/Kernels/Time.cpp
     )
-  target_include_directories(SeisSol-common-properties INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/src/Equations/acoustic)
-  target_compile_definitions(SeisSol-common-properties INTERFACE USE_ACOUSTIC)
+  target_include_directories(seissol-common-properties INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/src/Equations/acoustic)
+  target_compile_definitions(seissol-common-properties INTERFACE USE_ACOUSTIC)
 
 elseif ("${EQUATIONS}" STREQUAL "viscoelastic")
-  target_sources(SeisSol-common-lib PRIVATE
+  target_sources(seissol-common-lib PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/src/Equations/viscoelastic/Kernels/DirichletBoundary.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/Equations/viscoelastic/Kernels/Local.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/Equations/viscoelastic/Kernels/Neighbor.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/Equations/viscoelastic/Kernels/Time.cpp
     )
-  target_include_directories(SeisSol-common-properties INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/src/Equations/viscoelastic)
-  target_compile_definitions(SeisSol-common-properties INTERFACE USE_VISCOELASTIC)
+  target_include_directories(seissol-common-properties INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/src/Equations/viscoelastic)
+  target_compile_definitions(seissol-common-properties INTERFACE USE_VISCOELASTIC)
 
 elseif ("${EQUATIONS}" STREQUAL "viscoelastic2")
-  target_sources(SeisSol-common-lib PRIVATE
+  target_sources(seissol-common-lib PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/src/Equations/viscoelastic2/Kernels/Neighbor.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/Equations/viscoelastic2/Kernels/Local.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/Equations/viscoelastic2/Kernels/Time.cpp
   )
-  target_include_directories(SeisSol-common-properties INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/src/Equations/viscoelastic2)
-  target_compile_definitions(SeisSol-common-properties INTERFACE USE_VISCOELASTIC2)
+  target_include_directories(seissol-common-properties INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/src/Equations/viscoelastic2)
+  target_compile_definitions(seissol-common-properties INTERFACE USE_VISCOELASTIC2)
 
 elseif ("${EQUATIONS}" STREQUAL "anisotropic")
-  target_sources(SeisSol-common-lib PRIVATE
+  target_sources(seissol-common-lib PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/src/Equations/anisotropic/Kernels/DirichletBoundary.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/Equations/anisotropic/Kernels/Neighbor.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/Equations/anisotropic/Kernels/Local.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/Equations/anisotropic/Kernels/Time.cpp
   )
-  target_include_directories(SeisSol-common-properties INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/src/Equations/anisotropic)
-  target_compile_definitions(SeisSol-common-properties INTERFACE USE_ANISOTROPIC)
+  target_include_directories(seissol-common-properties INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/src/Equations/anisotropic)
+  target_compile_definitions(seissol-common-properties INTERFACE USE_ANISOTROPIC)
 
 elseif ("${EQUATIONS}" STREQUAL "poroelastic")
-  target_sources(SeisSol-common-lib PRIVATE
+  target_sources(seissol-common-lib PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/src/Equations/poroelastic/Kernels/Neighbor.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/Equations/poroelastic/Kernels/Local.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/Equations/poroelastic/Kernels/Time.cpp
   )
-  target_include_directories(SeisSol-common-properties INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/src/Equations/poroelastic)
-  target_compile_definitions(SeisSol-common-properties INTERFACE USE_STP)
-  target_compile_definitions(SeisSol-common-properties INTERFACE USE_POROELASTIC)
+  target_include_directories(seissol-common-properties INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/src/Equations/poroelastic)
+  target_compile_definitions(seissol-common-properties INTERFACE USE_STP)
+  target_compile_definitions(seissol-common-properties INTERFACE USE_POROELASTIC)
 endif()
 
-target_include_directories(SeisSol-common-properties INTERFACE
+target_include_directories(seissol-common-properties INTERFACE
         ${CMAKE_CURRENT_SOURCE_DIR}/src/Initializer/BatchRecorders)
 
 
 # GPU code
 if (WITH_GPU)
-  target_sources(SeisSol-lib PRIVATE
+  target_sources(seissol-lib PRIVATE
           ${CMAKE_CURRENT_SOURCE_DIR}/src/Initializer/BatchRecorders/LocalIntegrationRecorder.cpp
           ${CMAKE_CURRENT_SOURCE_DIR}/src/Initializer/BatchRecorders/NeighIntegrationRecorder.cpp
           ${CMAKE_CURRENT_SOURCE_DIR}/src/Initializer/BatchRecorders/PlasticityRecorder.cpp
@@ -262,7 +262,7 @@ if (WITH_GPU)
                              ${CMAKE_BINARY_DIR}/src
                              ${CMAKE_CURRENT_SOURCE_DIR}/src)
 
-  # include cmake files will define SeisSol-device-lib target
+  # include cmake files will define seissol-device-lib target
   if ("${DEVICE_BACKEND}" STREQUAL "cuda")
     include(${CMAKE_SOURCE_DIR}/src/cuda.cmake)
   elseif ("${DEVICE_BACKEND}" STREQUAL "hip")
@@ -271,27 +271,27 @@ if (WITH_GPU)
     include(${CMAKE_SOURCE_DIR}/src/sycl.cmake)
   endif()
 
-  target_compile_options(SeisSol-device-lib PRIVATE -fPIC)
+  target_compile_options(seissol-device-lib PRIVATE -fPIC)
   if ("${EQUATIONS}" STREQUAL "elastic")
-    target_compile_definitions(SeisSol-device-lib PRIVATE USE_ELASTIC)
+    target_compile_definitions(seissol-device-lib PRIVATE USE_ELASTIC)
   elseif ("${EQUATIONS}" STREQUAL "acoustic")
-    target_compile_definitions(SeisSol-device-lib PRIVATE USE_ACOUSTIC)
+    target_compile_definitions(seissol-device-lib PRIVATE USE_ACOUSTIC)
   elseif ("${EQUATIONS}" STREQUAL "viscoelastic")
-    target_compile_definitions(SeisSol-device-lib PRIVATE USE_VISCOELASTIC)
+    target_compile_definitions(seissol-device-lib PRIVATE USE_VISCOELASTIC)
   elseif ("${EQUATIONS}" STREQUAL "viscoelastic2")
-    target_compile_definitions(SeisSol-device-lib PRIVATE USE_VISCOELASTIC2)
+    target_compile_definitions(seissol-device-lib PRIVATE USE_VISCOELASTIC2)
   elseif ("${EQUATIONS}" STREQUAL "anisotropic")
-    target_compile_definitions(SeisSol-device-lib PRIVATE USE_ANISOTROPIC)
+    target_compile_definitions(seissol-device-lib PRIVATE USE_ANISOTROPIC)
   elseif ("${EQUATIONS}" STREQUAL "poroelastic")
-    target_compile_definitions(SeisSol-device-lib PRIVATE USE_STP)
-    target_compile_definitions(SeisSol-device-lib PRIVATE USE_POROELASTIC)
+    target_compile_definitions(seissol-device-lib PRIVATE USE_STP)
+    target_compile_definitions(seissol-device-lib PRIVATE USE_POROELASTIC)
   endif()
-  target_include_directories(SeisSol-lib PRIVATE ${DEVICE_INCLUDE_DIRS})
+  target_include_directories(seissol-lib PRIVATE ${DEVICE_INCLUDE_DIRS})
 
   if ("${EQUATIONS}" STREQUAL "elastic")
-    target_compile_definitions(SeisSol-device-lib PRIVATE USE_ELASTIC)
+    target_compile_definitions(seissol-device-lib PRIVATE USE_ELASTIC)
   endif()
 endif()
 
 add_subdirectory(src/IO)
-target_link_libraries(SeisSol-lib PUBLIC seissol-io)
+target_link_libraries(seissol-lib PUBLIC seissol-io)

--- a/src/sycl.cmake
+++ b/src/sycl.cmake
@@ -5,14 +5,14 @@ if ("${DEVICE_BACKEND}" STREQUAL "hipsycl")
           ${CMAKE_CURRENT_SOURCE_DIR}/src/Kernels/DeviceAux/sycl/PlasticityAux.cpp
           ${CMAKE_CURRENT_SOURCE_DIR}/src/Equations/elastic/Kernels/DeviceAux/sycl/KernelsAux.cpp)
 
-  add_library(SeisSol-device-lib SHARED ${DEVICE_SRC})
+  add_library(seissol-device-lib SHARED ${DEVICE_SRC})
 
   find_package(Boost REQUIRED COMPONENTS context fiber)
   if (DEVICE_ARCH MATCHES "sm_*")
     find_package(CUDA REQUIRED)
     set(HIPSYCL_TARGETS "cuda:${DEVICE_ARCH}")
-    target_include_directories(SeisSol-device-lib PRIVATE ${CUDA_TOOLKIT_ROOT_DIR})
-    target_link_libraries(SeisSol-device-lib PRIVATE -lcuda ${CUDA_LIBRARIES})
+    target_include_directories(seissol-device-lib PRIVATE ${CUDA_TOOLKIT_ROOT_DIR})
+    target_link_libraries(seissol-device-lib PRIVATE -lcuda ${CUDA_LIBRARIES})
   elseif(DEVICE_ARCH MATCHES "gfx*")
     set(HIP_COMPILER hcc)
     find_package(HIP REQUIRED)
@@ -21,15 +21,15 @@ if ("${DEVICE_BACKEND}" STREQUAL "hipsycl")
     set(HIPSYCL_TARGETS "${DEVICE_BACKEND}:${DEVICE_ARCH}")
   endif()
 
-  target_include_directories(SeisSol-device-lib PUBLIC ${SEISSOL_DEVICE_INCLUDE})
-  target_compile_definitions(SeisSol-device-lib PRIVATE DEVICE_HIPSYCL_LANG REAL_SIZE=${REAL_SIZE_IN_BYTES})
-  target_link_libraries(SeisSol-device-lib PUBLIC ${Boost_LIBRARIES})
+  target_include_directories(seissol-device-lib PUBLIC ${SEISSOL_DEVICE_INCLUDE})
+  target_compile_definitions(seissol-device-lib PRIVATE DEVICE_HIPSYCL_LANG REAL_SIZE=${REAL_SIZE_IN_BYTES})
+  target_link_libraries(seissol-device-lib PUBLIC ${Boost_LIBRARIES})
 
   find_package(OpenMP REQUIRED)
-  target_compile_options(SeisSol-device-lib PRIVATE ${EXTRA_CXX_FLAGS} "-fPIC" ${OpenMP_CXX_FLAGS})
+  target_compile_options(seissol-device-lib PRIVATE ${EXTRA_CXX_FLAGS} "-fPIC" ${OpenMP_CXX_FLAGS})
 
   find_package(hipSYCL CONFIG REQUIRED)
-  add_sycl_to_target(TARGET SeisSol-device-lib SOURCES ${DEVICE_SRC})
+  add_sycl_to_target(TARGET seissol-device-lib SOURCES ${DEVICE_SRC})
 
 elseif("${DEVICE_BACKEND}" STREQUAL "oneapi")
   set(DEVICE_SRC ${DEVICE_SRC}
@@ -37,23 +37,23 @@ elseif("${DEVICE_BACKEND}" STREQUAL "oneapi")
                  ${CMAKE_CURRENT_SOURCE_DIR}/src/Kernels/DeviceAux/sycl/PlasticityAux.cpp
                  ${CMAKE_CURRENT_SOURCE_DIR}/src/Equations/elastic/Kernels/DeviceAux/sycl/KernelsAux.cpp)
 
-  add_library(SeisSol-device-lib SHARED ${DEVICE_SRC})
+  add_library(seissol-device-lib SHARED ${DEVICE_SRC})
 
-  target_include_directories(SeisSol-device-lib PUBLIC ${SEISSOL_DEVICE_INCLUDE})
+  target_include_directories(seissol-device-lib PUBLIC ${SEISSOL_DEVICE_INCLUDE})
 
-  target_compile_options(SeisSol-device-lib PRIVATE ${EXTRA_CXX_FLAGS} "-O3")
-  target_compile_definitions(SeisSol-device-lib PRIVATE DEVICE_ONEAPI_LANG REAL_SIZE=${REAL_SIZE_IN_BYTES} __DPCPP_COMPILER)
+  target_compile_options(seissol-device-lib PRIVATE ${EXTRA_CXX_FLAGS} "-O3")
+  target_compile_definitions(seissol-device-lib PRIVATE DEVICE_ONEAPI_LANG REAL_SIZE=${REAL_SIZE_IN_BYTES} __DPCPP_COMPILER)
 
   find_package(DpcppFlags REQUIRED)
-  target_link_libraries(SeisSol-device-lib PRIVATE dpcpp::device_flags)
+  target_link_libraries(seissol-device-lib PRIVATE dpcpp::device_flags)
 endif()
 
-target_compile_definitions(SeisSol-device-lib PRIVATE ${HARDWARE_DEFINITIONS}
+target_compile_definitions(seissol-device-lib PRIVATE ${HARDWARE_DEFINITIONS}
         CONVERGENCE_ORDER=${ORDER}
         NUMBER_OF_QUANTITIES=${NUMBER_OF_QUANTITIES}
         NUMBER_OF_RELAXATION_MECHANISMS=${NUMBER_OF_MECHANISMS}
         ${DR_QUAD_RULE})
 
 if (DEVICE_EXPERIMENTAL_EXPLICIT_KERNELS)
-target_compile_definitions(SeisSol-device-lib PRIVATE DEVICE_EXPERIMENTAL_EXPLICIT_KERNELS)
+target_compile_definitions(seissol-device-lib PRIVATE DEVICE_EXPERIMENTAL_EXPLICIT_KERNELS)
 endif()


### PR DESCRIPTION
...to: kebab case (all lowercase). B/c it's easier to type. (also, some parts like `seissol-io` are already in that style)

[note: the exported target names don't change—those are set explicitly; however, we can of course do that as well]