### PR TITLE
Update build-dependencies.rst

### DIFF
--- a/Documentation/build-dependencies.rst
+++ b/Documentation/build-dependencies.rst
@@ -201,7 +201,7 @@ Installing Libxsmm (CPU)
 
 .. code-block:: bash
 
-   git clone --depth=1 --branch 1.17 https://github.com/hfp/libxsmm
+   git clone --depth=1 --branch 1.17 https://github.com/libxsmm/libxsmm
    cd libxsmm
    make generator
    cp bin/libxsmm_gemm_generator $SEISSOL_PREFIX/bin/


### PR DESCRIPTION
https://github.com/hfp/libxsmm does not have version 1.17 in it. We need to use https://github.com/libxsmm/libxsmm