### PR TITLE
Enable CPU CI unit tests for the master branch

### DIFF
--- a/.github/workflows/build-seissol-cpu.yml
+++ b/.github/workflows/build-seissol-cpu.yml
@@ -155,11 +155,11 @@ jobs:
 
   seissol-run-test:
     name: seissol-run-test
-    runs-on: sccs-ci-zen2
+    runs-on: ubuntu-24.04
     container: ${{ matrix.setup.container }}
     continue-on-error: true
     needs: [seissol-build-test]
-    if: ${{ github.repository == 'SeisSol/SeisSol' && false }}
+    if: ${{ github.repository == 'SeisSol/SeisSol' && github.ref_name == 'master' }}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
The CPU CI unit tests currently take a long time, and some tests still fail.

Still, we hereby enable them on the master branch for now.
