### PR TITLE
Display the NZ-HW-FLOP ratio (as percentage)

### DIFF
--- a/src/Monitoring/FlopCounter.cpp
+++ b/src/Monitoring/FlopCounter.cpp
@@ -140,16 +140,17 @@ void FlopCounter::printPerformanceSummary(double wallTime) const {
   logInfo(rank) << "Total     pspamm HW-FLOP: "
                 << UnitFlop.formatPrefix(totalFlops[Pspamm]).c_str();
 #endif
+  const auto totalHardwareFlops =
+      totalFlops[WPHardwareFlops] + totalFlops[DRHardwareFlops] + totalFlops[PLHardwareFlops];
+  const auto totalNonZeroFlops =
+      totalFlops[WPNonZeroFlops] + totalFlops[DRNonZeroFlops] + totalFlops[PLNonZeroFlops];
+
+  const auto percentageUsefulFlops = totalNonZeroFlops / totalHardwareFlops * 100;
+
   logInfo(rank) << "Total calculated HW-FLOP: "
-                << UnitFlop
-                       .formatPrefix(totalFlops[WPHardwareFlops] + totalFlops[DRHardwareFlops] +
-                                     totalFlops[PLHardwareFlops])
-                       .c_str();
-  logInfo(rank) << "Total calculated NZ-FLOP: "
-                << UnitFlop
-                       .formatPrefix(totalFlops[WPNonZeroFlops] + totalFlops[DRNonZeroFlops] +
-                                     totalFlops[PLNonZeroFlops])
-                       .c_str();
+                << UnitFlop.formatPrefix(totalHardwareFlops).c_str();
+  logInfo(rank) << "Total calculated NZ-FLOP: " << UnitFlop.formatPrefix(totalNonZeroFlops).c_str();
+  logInfo(rank) << "NZ part of HW-FLOP:" << percentageUsefulFlops << "%";
   logInfo(rank) << "Total calculated HW-FLOP/s: "
                 << UnitFlopPerS
                        .formatPrefix((totalFlops[WPHardwareFlops] + totalFlops[DRHardwareFlops] +


### PR DESCRIPTION
The NZ-HW-FLOP ratio is a good measure to see how much "useful" work is getting done. Hence, we display it at the end of the simulation.

Not super happy with the name "NZ part of HW-FLOP" yet—if you have better suggestions, I'd be happy to hear them. :)