### PR TITLE
Remove some legacy code

### DIFF
--- a/Documentation/gpus.rst
+++ b/Documentation/gpus.rst
@@ -125,7 +125,7 @@ the following will force SeisSol to allocate 1.5GB of stack GPU memory for tempo
     export DEVICE_STACK_MEM_SIZE=1.5
     mpirun -n <M x N> ./SeisSol_dsm70_cuda_* ./parameters.par
 
-The following device-specific environment variable are supported right now:
+The following device-specific environment variable is supported right now:
 
 * ``SEISSOL_PREFERRED_MPI_DATA_TRANSFER_MODE``
 

--- a/Documentation/gpus.rst
+++ b/Documentation/gpus.rst
@@ -125,10 +125,9 @@ the following will force SeisSol to allocate 1.5GB of stack GPU memory for tempo
     export DEVICE_STACK_MEM_SIZE=1.5
     mpirun -n <M x N> ./SeisSol_dsm70_cuda_* ./parameters.par
 
-The following device-specific environment variables are supported right now:
+The following device-specific environment variable are supported right now:
 
 * ``SEISSOL_PREFERRED_MPI_DATA_TRANSFER_MODE``
-* ``SEISSOL_SERIAL_NODE_DEVICE_INIT``
 
 Currently, SeisSol allocates MPI buffers using the global memory type.
 Some MPI implementations are not GPU-aware and do not support direct point-to-point
@@ -142,8 +141,3 @@ The default value is ``direct`` which copies the data out of the GPU buffers dir
    :alt: Data Flow Diagram
    :width: 10.0cm
    :align: center
-
-The environment variable ``SEISSOL_SERIAL_NODE_DEVICE_INIT`` exists to mitigate some possible execution bugs
-with regard to AMD GPU drivers. It is disabled by default and scheduled for removal long-term.
-To enable it, set ``SEISSOL_SERIAL_NODE_DEVICE_INIT=1``. To explicitly disable it,
-write ``SEISSOL_SERIAL_NODE_DEVICE_INIT=0``.

--- a/src/Initializer/MemoryManager.cpp
+++ b/src/Initializer/MemoryManager.cpp
@@ -42,29 +42,7 @@ void seissol::initializer::MemoryManager::initialize()
   // initialize global matrices
   GlobalDataInitializerOnHost::init(m_globalDataOnHost, m_memoryAllocator, memory::Standard);
   if constexpr (seissol::isDeviceOn()) {
-    // the serial order for initialization is needed for some (older) driver versions on some GPUs
-    bool serialize = false;
-    const char* envvalue = std::getenv("SEISSOL_SERIAL_NODE_DEVICE_INIT");
-    if (envvalue != nullptr) {
-      if (strcmp(envvalue, "1") == 0) {
-        serialize = true;
-      }
-      else if (strcmp(envvalue, "0") == 0) {
-        serialize = false;
-      }
-      else {
-        logError() << "Invalid value for \"SEISSOL_SERIAL_NODE_DEVICE_INIT\"";
-      }
-    }
-    if (serialize) {
-      logInfo(MPI::mpi.rank()) << "Initializing device global data on a node in serial order.";
-      MPI::mpi.serialOrderExecute([&]() {
-        GlobalDataInitializerOnDevice::init(m_globalDataOnDevice, m_memoryAllocator, memory::DeviceGlobalMemory);
-      }, MPI::mpi.sharedMemComm());
-    }
-    else {
-      GlobalDataInitializerOnDevice::init(m_globalDataOnDevice, m_memoryAllocator, memory::DeviceGlobalMemory);
-    }
+    GlobalDataInitializerOnDevice::init(m_globalDataOnDevice, m_memoryAllocator, memory::DeviceGlobalMemory);
   }
 }
 


### PR DESCRIPTION
Added in #923, it was added to mitigate some bugs on LUMI with old ROCm (early/mid 5) back then. However, those should be fixed by now. Hence, we remove it.
