### PR TITLE
Merge the DR Kernels

### DIFF
--- a/src/DynamicRupture/FrictionLaws/BaseFrictionLaw.h
+++ b/src/DynamicRupture/FrictionLaws/BaseFrictionLaw.h
@@ -48,7 +48,7 @@ class BaseFrictionLaw : public FrictionSolver {
 #pragma omp parallel for schedule(static)
 #endif
     for (unsigned ltsFace = 0; ltsFace < layerData.getNumberOfCells(); ++ltsFace) {
-      alignas(Alignment) FaultStresses faultStresses{};
+      alignas(Alignment) FaultStresses<Executor::Host> faultStresses{};
       SCOREP_USER_REGION_BEGIN(
           myRegionHandle, "computeDynamicRupturePrecomputeStress", SCOREP_USER_REGION_TYPE_COMMON)
       LIKWID_MARKER_START("computeDynamicRupturePrecomputeStress");
@@ -75,7 +75,7 @@ class BaseFrictionLaw : public FrictionSolver {
                                "computeDynamicRuptureUpdateFrictionAndSlip",
                                SCOREP_USER_REGION_TYPE_COMMON)
       LIKWID_MARKER_START("computeDynamicRuptureUpdateFrictionAndSlip");
-      TractionResults tractionResults = {};
+      TractionResults<Executor::Host> tractionResults = {};
 
       // loop over sub time steps (i.e. quadrature points in time)
       for (std::size_t timeIndex = 0; timeIndex < ConvergenceOrder; timeIndex++) {

--- a/src/DynamicRupture/FrictionLaws/FrictionSolverCommon.h
+++ b/src/DynamicRupture/FrictionLaws/FrictionSolverCommon.h
@@ -8,6 +8,7 @@
 #ifndef SEISSOL_SRC_DYNAMICRUPTURE_FRICTIONLAWS_FRICTIONSOLVERCOMMON_H_
 #define SEISSOL_SRC_DYNAMICRUPTURE_FRICTIONLAWS_FRICTIONSOLVERCOMMON_H_
 
+#include <Common/Executor.h>
 #include <limits>
 #include <type_traits>
 
@@ -54,13 +55,51 @@ struct QInterpolated {
   using Range = std::conditional_t<Type == RangeType::CPU, CpuRange, GpuRange>;
 };
 
+template <RangeType Type>
+struct RangeExecutor;
+
+template <>
+struct RangeExecutor<RangeType::CPU> {
+  static constexpr Executor Exec = Executor::Host;
+};
+
+template <>
+struct RangeExecutor<RangeType::GPU> {
+  static constexpr Executor Exec = Executor::Device;
+};
+
+template <Executor Executor>
+struct VariableIndexing;
+
+template <>
+struct VariableIndexing<Executor::Host> {
+  static constexpr real&
+      index(real (&data)[ConvergenceOrder][misc::NumPaddedPoints], int o, int i) {
+    return data[o][i];
+  }
+
+  static constexpr real
+      index(const real (&data)[ConvergenceOrder][misc::NumPaddedPoints], int o, int i) {
+    return data[o][i];
+  }
+};
+
+template <>
+struct VariableIndexing<Executor::Device> {
+  static constexpr real& index(real (&data)[ConvergenceOrder], int o, int i) { return data[o]; }
+
+  static constexpr real index(const real (&data)[ConvergenceOrder], int o, int i) {
+    return data[o];
+  }
+};
+
 /**
  * Asserts whether all relevant arrays are properly aligned
  */
 inline void checkAlignmentPreCompute(
     const real qIPlus[ConvergenceOrder][dr::misc::NumQuantities][dr::misc::NumPaddedPoints],
     const real qIMinus[ConvergenceOrder][dr::misc::NumQuantities][dr::misc::NumPaddedPoints],
-    const FaultStresses& faultStresses) {
+    const FaultStresses<Executor::Host>& faultStresses) {
   using namespace dr::misc::quantity_indices;
   for (unsigned o = 0; o < ConvergenceOrder; ++o) {
     assert(reinterpret_cast<uintptr_t>(qIPlus[o][U]) % Alignment == 0);
@@ -100,7 +139,7 @@ inline void checkAlignmentPreCompute(
  */
 template <RangeType Type = RangeType::CPU>
 inline void precomputeStressFromQInterpolated(
-    FaultStresses& faultStresses,
+    FaultStresses<RangeExecutor<Type>::Exec>& faultStresses,
     const ImpedancesAndEta& impAndEta,
     const ImpedanceMatrices& impedanceMatrices,
     const real qInterpolatedPlus[ConvergenceOrder][tensor::QInterpolated::size()],
@@ -136,15 +175,15 @@ inline void precomputeStressFromQInterpolated(
 #endif
     for (auto index = Range::Start; index < Range::End; index += Range::Step) {
       auto i{startLoopIndex + index};
-      faultStresses.normalStress[o][i] =
+      VariableIndexing<RangeExecutor<Type>::Exec>::index(faultStresses.normalStress, o, i) =
           etaP * (qIMinus[o][U][i] - qIPlus[o][U][i] + qIPlus[o][N][i] * invZp +
                   qIMinus[o][N][i] * invZpNeig);
 
-      faultStresses.traction1[o][i] =
+      VariableIndexing<RangeExecutor<Type>::Exec>::index(faultStresses.traction1, o, i) =
           etaS * (qIMinus[o][V][i] - qIPlus[o][V][i] + qIPlus[o][T1][i] * invZs +
                   qIMinus[o][T1][i] * invZsNeig);
 
-      faultStresses.traction2[o][i] =
+      VariableIndexing<RangeExecutor<Type>::Exec>::index(faultStresses.traction2, o, i) =
           etaS * (qIMinus[o][W][i] - qIPlus[o][W][i] + qIPlus[o][T2][i] * invZs +
                   qIMinus[o][T2][i] * invZsNeig);
     }
@@ -186,8 +225,8 @@ inline void checkAlignmentPostCompute(
     const real qIMinus[ConvergenceOrder][dr::misc::NumQuantities][dr::misc::NumPaddedPoints],
     const real imposedStateP[ConvergenceOrder][dr::misc::NumPaddedPoints],
     const real imposedStateM[ConvergenceOrder][dr::misc::NumPaddedPoints],
-    const FaultStresses& faultStresses,
-    const TractionResults& tractionResults) {
+    const FaultStresses<Executor::Host>& faultStresses,
+    const TractionResults<Executor::Host>& tractionResults) {
   using namespace dr::misc::quantity_indices;
 
   assert(reinterpret_cast<uintptr_t>(imposedStateP[U]) % Alignment == 0);
@@ -241,8 +280,8 @@ inline void checkAlignmentPostCompute(
  */
 template <RangeType Type = RangeType::CPU>
 inline void postcomputeImposedStateFromNewStress(
-    const FaultStresses& faultStresses,
-    const TractionResults& tractionResults,
+    const FaultStresses<RangeExecutor<Type>::Exec>& faultStresses,
+    const TractionResults<RangeExecutor<Type>::Exec>& tractionResults,
     const ImpedancesAndEta& impAndEta,
     const ImpedanceMatrices& impedanceMatrices,
     real imposedStatePlus[tensor::QInterpolated::size()],
@@ -292,9 +331,12 @@ inline void postcomputeImposedStateFromNewStress(
          index += NumPointsRange::Step) {
       auto i{startIndex + index};
 
-      const auto normalStress = faultStresses.normalStress[o][i];
-      const auto traction1 = tractionResults.traction1[o][i];
-      const auto traction2 = tractionResults.traction2[o][i];
+      const auto normalStress =
+          VariableIndexing<RangeExecutor<Type>::Exec>::index(faultStresses.normalStress, o, i);
+      const auto traction1 =
+          VariableIndexing<RangeExecutor<Type>::Exec>::index(tractionResults.traction1, o, i);
+      const auto traction2 =
+          VariableIndexing<RangeExecutor<Type>::Exec>::index(tractionResults.traction2, o, i);
 
       imposedStateM[N][i] += weight * normalStress;
       imposedStateM[T1][i] += weight * traction1;

--- a/src/DynamicRupture/FrictionLaws/GpuImpl/AgingLaw.h
+++ b/src/DynamicRupture/FrictionLaws/GpuImpl/AgingLaw.h
@@ -18,27 +18,19 @@ class AgingLaw : public SlowVelocityWeakeningLaw<AgingLaw<TPMethod>, TPMethod> {
   using SlowVelocityWeakeningLaw<AgingLaw<TPMethod>, TPMethod>::SlowVelocityWeakeningLaw;
   using SlowVelocityWeakeningLaw<AgingLaw<TPMethod>, TPMethod>::copyLtsTreeToLocal;
 
-  void updateStateVariable(double timeIncrement) {
-    auto* devSl0{this->sl0};
-    auto* devStateVarReference{this->initialVariables.stateVarReference};
-    auto* devLocalSlipRate{this->initialVariables.localSlipRate};
-    auto* devStateVariableBuffer{this->stateVariableBuffer};
+  static void updateStateVariable(FrictionLawContext& ctx, double timeIncrement) {
+    auto* devSl0{ctx.data->sl0};
+    auto& devStateVarReference{ctx.initialVariables.stateVarReference};
+    auto& devLocalSlipRate{ctx.initialVariables.localSlipRate};
+    auto& devStateVariableBuffer{ctx.stateVariableBuffer};
 
-    sycl::nd_range rng{{this->currLayerSize * misc::NumPaddedPoints}, {misc::NumPaddedPoints}};
-    this->queue.submit([&](sycl::handler& cgh) {
-      cgh.parallel_for(rng, [=](sycl::nd_item<1> item) {
-        const auto ltsFace = item.get_group().get_group_id(0);
-        const auto pointIndex = item.get_local_id(0);
+    const double localSl0 = devSl0[ctx.ltsFace][ctx.pointIndex];
+    const double localSlipRate = devLocalSlipRate;
+    const double exp1 = sycl::exp(-localSlipRate * (timeIncrement / localSl0));
 
-        const double localSl0 = devSl0[ltsFace][pointIndex];
-        const double localSlipRate = devLocalSlipRate[ltsFace][pointIndex];
-        const double exp1 = sycl::exp(-localSlipRate * (timeIncrement / localSl0));
-
-        const double stateVarReference = devStateVarReference[ltsFace][pointIndex];
-        devStateVariableBuffer[ltsFace][pointIndex] =
-            static_cast<real>(stateVarReference * exp1 + localSl0 / localSlipRate * (1.0 - exp1));
-      });
-    });
+    const double stateVarReference = devStateVarReference;
+    devStateVariableBuffer =
+        static_cast<real>(stateVarReference * exp1 + localSl0 / localSlipRate * (1.0 - exp1));
   }
 };
 

--- a/src/DynamicRupture/FrictionLaws/GpuImpl/BaseFrictionSolver.h
+++ b/src/DynamicRupture/FrictionLaws/GpuImpl/BaseFrictionSolver.h
@@ -11,16 +11,42 @@
 #include "DynamicRupture/FrictionLaws/FrictionSolverCommon.h"
 #include "DynamicRupture/FrictionLaws/GpuImpl/FrictionSolverDetails.h"
 #include "Numerical/SyclFunctions.h"
+#include <Common/Constants.h>
+#include <DynamicRupture/FrictionLaws/GpuImpl/FrictionSolverInterface.h>
 #include <algorithm>
 
 namespace seissol::dr::friction_law::gpu {
+
+struct InitialVariables {
+  real absoluteShearTraction;
+  real localSlipRate;
+  real normalStress;
+  real stateVarReference;
+};
+
+struct FrictionLawContext {
+  int ltsFace;
+  int pointIndex;
+  FrictionLawData* data;
+
+  FaultStresses<Executor::Device> faultStresses{};
+  TractionResults<Executor::Device> tractionResults{};
+  real stateVariableBuffer;
+  real strengthBuffer;
+  double* devTimeWeights{nullptr};
+  real* devSpaceWeights{nullptr};
+  real* resampleMatrix{nullptr};
+  real* deltaStateVar;
+  InitialVariables initialVariables;
+  sycl::nd_item<1>* item;
+};
 
 template <typename Derived>
 class BaseFrictionSolver : public FrictionSolverDetails {
   public:
   explicit BaseFrictionSolver<Derived>(seissol::initializer::parameters::DRParameters* drParameters)
       : FrictionSolverDetails(drParameters) {}
-  ~BaseFrictionSolver<Derived>() = default;
+  ~BaseFrictionSolver<Derived>() override = default;
 
   void evaluate(seissol::initializer::Layer& layerData,
                 const seissol::initializer::DynamicRupture* const dynRup,
@@ -30,53 +56,70 @@ class BaseFrictionSolver : public FrictionSolverDetails {
 
     runtime.syncToSycl(&this->queue);
 
-    FrictionSolver::copyLtsTreeToLocal(layerData, dynRup, fullUpdateTime);
-    this->copySpecificLtsDataTreeToLocal(layerData, dynRup, fullUpdateTime);
-    this->currLayerSize = layerData.getNumberOfCells();
+    // TODO: avoid copying the data all the time
+    // TODO: allocate FrictionLawData as constant data
 
-    size_t requiredNumBytes = ConvergenceOrder * sizeof(double);
-    auto timeWeightsCopy = this->queue.memcpy(devTimeWeights, &timeWeights[0], requiredNumBytes);
+    FrictionSolverInterface::copyLtsTreeToLocal(&dataHost, layerData, dynRup, fullUpdateTime);
+    Derived::copySpecificLtsDataTreeToLocal(&dataHost, layerData, dynRup, fullUpdateTime);
+    this->currLayerSize = layerData.getNumberOfCells();
+    dataHost.drParameters = *this->drParameters;
+
+    std::memcpy(dataHost.deltaT, deltaT, sizeof(decltype(deltaT)));
+    dataHost.sumDt = sumDt;
+
+    this->queue.memcpy(data, &dataHost, sizeof(FrictionLawData));
+
+    this->queue.memcpy(devTimeWeights, timeWeights, sizeof(double[ConvergenceOrder]));
 
     {
       constexpr common::RangeType gpuRangeType{common::RangeType::GPU};
 
-      auto* devImpAndEta{this->impAndEta};
-      auto* devImpedanceMatrices{this->impedanceMatrices};
-      auto* devQInterpolatedPlus{this->qInterpolatedPlus};
-      auto* devQInterpolatedMinus{this->qInterpolatedMinus};
-      auto* devFaultStresses{this->faultStresses};
+      auto* data{this->data};
+      auto* devTimeWeights{this->devTimeWeights};
+      auto* devSpaceWeights{this->devSpaceWeights};
+      auto* resampleMatrix{this->resampleMatrix};
 
       sycl::nd_range rng{{this->currLayerSize * misc::NumPaddedPoints}, {misc::NumPaddedPoints}};
       this->queue.submit([&](sycl::handler& cgh) {
+        // NOLINTNEXTLINE
+        sycl::accessor<real, 1, sycl::access::mode::read_write, sycl::access::target::local>
+            deltaStateVar(misc::NumPaddedPoints, cgh);
+
         cgh.parallel_for(rng, [=](sycl::nd_item<1> item) {
+          FrictionLawContext ctx{};
+          ctx.data = data;
+          ctx.devTimeWeights = devTimeWeights;
+          ctx.devSpaceWeights = devSpaceWeights;
+          ctx.resampleMatrix = resampleMatrix;
+          ctx.deltaStateVar = &deltaStateVar[0];
+          ctx.item = &item;
+
+          auto* devImpAndEta{data->impAndEta};
+          auto* devImpedanceMatrices{data->impedanceMatrices};
+          auto* devQInterpolatedPlus{data->qInterpolatedPlus};
+          auto* devQInterpolatedMinus{data->qInterpolatedMinus};
+
           const auto ltsFace = item.get_group().get_group_id(0);
           const auto pointIndex = item.get_local_id(0);
 
-          common::precomputeStressFromQInterpolated<gpuRangeType>(devFaultStresses[ltsFace],
+          ctx.ltsFace = ltsFace;
+          ctx.pointIndex = pointIndex;
+
+          common::precomputeStressFromQInterpolated<gpuRangeType>(ctx.faultStresses,
                                                                   devImpAndEta[ltsFace],
                                                                   devImpedanceMatrices[ltsFace],
                                                                   devQInterpolatedPlus[ltsFace],
                                                                   devQInterpolatedMinus[ltsFace],
                                                                   pointIndex);
-        });
-      });
 
-      static_cast<Derived*>(this)->preHook(stateVariableBuffer);
-      for (unsigned timeIndex = 0; timeIndex < ConvergenceOrder; ++timeIndex) {
-        const real t0{this->drParameters->t0};
-        const real dt = deltaT[timeIndex];
-        auto* devInitialStressInFaultCS{this->initialStressInFaultCS};
-        const auto* devNucleationStressInFaultCS{this->nucleationStressInFaultCS};
-        auto* devInitialPressure{this->initialPressure};
-        const auto* devNucleationPressure{this->nucleationPressure};
-
-        this->queue.submit([&](sycl::handler& cgh) {
-          if (timeIndex == 0) {
-            cgh.depends_on(timeWeightsCopy);
-          }
-          cgh.parallel_for(rng, [=](sycl::nd_item<1> item) {
-            auto ltsFace = item.get_group().get_group_id(0);
-            auto pointIndex = item.get_local_id(0);
+          Derived::preHook(ctx);
+          for (unsigned timeIndex = 0; timeIndex < ConvergenceOrder; ++timeIndex) {
+            const real t0{data->drParameters.t0};
+            const real dt = data->deltaT[timeIndex];
+            auto* devInitialStressInFaultCS{data->initialStressInFaultCS};
+            const auto* devNucleationStressInFaultCS{data->nucleationStressInFaultCS};
+            auto* devInitialPressure{data->initialPressure};
+            const auto* devNucleationPressure{data->nucleationPressure};
 
             using StdMath = seissol::functions::SyclStdFunctions;
             common::adjustInitialStress<gpuRangeType, StdMath>(
@@ -88,55 +131,39 @@ class BaseFrictionSolver : public FrictionSolverDetails {
                 t0,
                 dt,
                 pointIndex);
-          });
-        });
 
-        static_cast<Derived*>(this)->updateFrictionAndSlip(timeIndex);
-      }
-      static_cast<Derived*>(this)->postHook(stateVariableBuffer);
+            Derived::updateFrictionAndSlip(ctx, timeIndex);
+          }
+          Derived::postHook(ctx);
 
-      auto* devRuptureTimePending{this->ruptureTimePending};
-      auto* devSlipRateMagnitude{this->slipRateMagnitude};
-      auto* devRuptureTime{this->ruptureTime};
+          auto* devRuptureTimePending{data->ruptureTimePending};
+          auto* devSlipRateMagnitude{data->slipRateMagnitude};
+          auto* devRuptureTime{data->ruptureTime};
 
-      this->queue.submit([&](sycl::handler& cgh) {
-        cgh.parallel_for(rng, [=](sycl::nd_item<1> item) {
-          auto ltsFace = item.get_group().get_group_id(0);
-          auto pointIndex = item.get_local_id(0);
           common::saveRuptureFrontOutput<gpuRangeType>(devRuptureTimePending[ltsFace],
                                                        devRuptureTime[ltsFace],
                                                        devSlipRateMagnitude[ltsFace],
                                                        fullUpdateTime,
                                                        pointIndex);
-        });
-      });
 
-      static_cast<Derived*>(this)->saveDynamicStressOutput();
+          Derived::saveDynamicStressOutput(ctx);
 
-      auto* devPeakSlipRate{this->peakSlipRate};
-      auto* devImposedStatePlus{this->imposedStatePlus};
-      auto* devImposedStateMinus{this->imposedStateMinus};
-      auto* devTractionResults{this->tractionResults};
-      auto* devTimeWeights{this->devTimeWeights};
-      auto* devSpaceWeights{this->devSpaceWeights};
-      auto* devEnergyData{this->energyData};
-      auto* devGodunovData{this->godunovData};
-      auto devSumDt{this->sumDt};
+          auto* devPeakSlipRate{data->peakSlipRate};
+          auto* devImposedStatePlus{data->imposedStatePlus};
+          auto* devImposedStateMinus{data->imposedStateMinus};
+          auto* devEnergyData{data->energyData};
+          auto* devGodunovData{data->godunovData};
+          auto devSumDt{data->sumDt};
 
-      auto isFrictionEnergyRequired{this->drParameters->isFrictionEnergyRequired};
-      auto isCheckAbortCriteraEnabled{this->drParameters->isCheckAbortCriteraEnabled};
-      auto devTerminatorSlipRateThreshold{this->drParameters->terminatorSlipRateThreshold};
-
-      this->queue.submit([&](sycl::handler& cgh) {
-        cgh.parallel_for(rng, [=](sycl::nd_item<1> item) {
-          auto ltsFace = item.get_group().get_group_id(0);
-          auto pointIndex = item.get_local_id(0);
+          auto isFrictionEnergyRequired{data->drParameters.isFrictionEnergyRequired};
+          auto isCheckAbortCriteraEnabled{data->drParameters.isCheckAbortCriteraEnabled};
+          auto devTerminatorSlipRateThreshold{data->drParameters.terminatorSlipRateThreshold};
 
           common::savePeakSlipRateOutput<gpuRangeType>(
               devSlipRateMagnitude[ltsFace], devPeakSlipRate[ltsFace], pointIndex);
 
-          common::postcomputeImposedStateFromNewStress<gpuRangeType>(devFaultStresses[ltsFace],
-                                                                     devTractionResults[ltsFace],
+          common::postcomputeImposedStateFromNewStress<gpuRangeType>(ctx.faultStresses,
+                                                                     ctx.tractionResults,
                                                                      devImpAndEta[ltsFace],
                                                                      devImpedanceMatrices[ltsFace],
                                                                      devImposedStatePlus[ltsFace],

--- a/src/DynamicRupture/FrictionLaws/GpuImpl/BaseFrictionSolver.h
+++ b/src/DynamicRupture/FrictionLaws/GpuImpl/BaseFrictionSolver.h
@@ -158,7 +158,8 @@ class BaseFrictionSolver : public FrictionSolverDetails {
           auto isFrictionEnergyRequired{data->drParameters.isFrictionEnergyRequired};
           auto isCheckAbortCriteraEnabled{data->drParameters.isCheckAbortCriteraEnabled};
           auto devTerminatorSlipRateThreshold{data->drParameters.terminatorSlipRateThreshold};
-          auto energiesFromAcrossFaultVelocities{data->drParameters.energiesFromAcrossFaultVelocities};
+          auto energiesFromAcrossFaultVelocities{
+              data->drParameters.energiesFromAcrossFaultVelocities};
 
           common::savePeakSlipRateOutput<gpuRangeType>(
               devSlipRateMagnitude[ltsFace], devPeakSlipRate[ltsFace], pointIndex);

--- a/src/DynamicRupture/FrictionLaws/GpuImpl/FastVelocityWeakeningLaw.h
+++ b/src/DynamicRupture/FrictionLaws/GpuImpl/FastVelocityWeakeningLaw.h
@@ -9,6 +9,8 @@
 #define SEISSOL_SRC_DYNAMICRUPTURE_FRICTIONLAWS_GPUIMPL_FASTVELOCITYWEAKENINGLAW_H_
 
 #include "DynamicRupture/FrictionLaws/GpuImpl/RateAndState.h"
+#include <DynamicRupture/FrictionLaws/GpuImpl/BaseFrictionSolver.h>
+#include <DynamicRupture/FrictionLaws/GpuImpl/FrictionSolverInterface.h>
 
 namespace seissol::dr::friction_law::gpu {
 
@@ -18,140 +20,92 @@ class FastVelocityWeakeningLaw
   public:
   using RateAndStateBase<FastVelocityWeakeningLaw, TPMethod>::RateAndStateBase;
 
-  void copyLtsTreeToLocal(seissol::initializer::Layer& layerData,
-                          const seissol::initializer::DynamicRupture* const dynRup,
-                          real fullUpdateTime) {}
+  static void copyLtsTreeToLocal(FrictionLawData* data,
+                                 seissol::initializer::Layer& layerData,
+                                 const seissol::initializer::DynamicRupture* const dynRup,
+                                 real fullUpdateTime) {}
 
-  void copySpecificLtsDataTreeToLocal(seissol::initializer::Layer& layerData,
-                                      const seissol::initializer::DynamicRupture* const dynRup,
-                                      real fullUpdateTime) override {
+  static void
+      copySpecificLtsDataTreeToLocal(FrictionLawData* data,
+                                     seissol::initializer::Layer& layerData,
+                                     const seissol::initializer::DynamicRupture* const dynRup,
+                                     real fullUpdateTime) {
     using SelfInitializerType = seissol::initializer::LTSRateAndStateFastVelocityWeakening;
-    auto* concreteLts = dynamic_cast<const SelfInitializerType*>(dynRup);
-    this->srW = layerData.var(concreteLts->rsSrW, seissol::initializer::AllocationPlace::Device);
-
-    using ParentType = RateAndStateBase<FastVelocityWeakeningLaw<TPMethod>, TPMethod>;
-    ParentType::copySpecificLtsDataTreeToLocal(layerData, dynRup, fullUpdateTime);
+    const auto* concreteLts = dynamic_cast<const SelfInitializerType*>(dynRup);
+    data->srW = layerData.var(concreteLts->rsSrW, seissol::initializer::AllocationPlace::Device);
   }
 
-  struct Details {
-    decltype(FastVelocityWeakeningLaw::a) a;
-    decltype(FastVelocityWeakeningLaw::sl0) sl0;
-    decltype(FastVelocityWeakeningLaw::srW) srW;
-    decltype(seissol::initializer::parameters::DRParameters::rsSr0) rsSr0;
-    decltype(seissol::initializer::parameters::DRParameters::rsF0) rsF0;
-    decltype(seissol::initializer::parameters::DRParameters::rsB) rsB;
-  };
+  static void updateStateVariable(FrictionLawContext& ctx, double timeIncrement) {
+    auto& devStateVarReference{ctx.initialVariables.stateVarReference};
+    auto& devLocalSlipRate{ctx.initialVariables.localSlipRate};
+    auto& devStateVariableBuffer{ctx.stateVariableBuffer};
+    const double muW{ctx.data->drParameters.muW};
 
-  Details getCurrentLtsLayerDetails() {
-    Details details{};
-    details.a = this->a;
-    details.sl0 = this->sl0;
-    details.srW = this->srW;
-    details.rsSr0 = this->drParameters->rsSr0;
-    details.rsF0 = this->drParameters->rsF0;
-    details.rsB = this->drParameters->rsB;
-    return details;
+    const double localSl0 = ctx.data->sl0[ctx.ltsFace][ctx.pointIndex];
+    const double localA = ctx.data->a[ctx.ltsFace][ctx.pointIndex];
+    const double localSrW = ctx.data->srW[ctx.ltsFace][ctx.pointIndex];
+    const double localSlipRate = devLocalSlipRate;
+
+    const double lowVelocityFriction =
+        ctx.data->drParameters.rsF0 - (ctx.data->drParameters.rsB - localA) *
+                                          sycl::log(localSlipRate / ctx.data->drParameters.rsSr0);
+
+    const double steadyStateFrictionCoefficient =
+        muW + (lowVelocityFriction - muW) /
+                  sycl::pow(1.0 + sycl::pown(localSlipRate / localSrW, 8), 1.0 / 8.0);
+
+    const double steadyStateStateVariable =
+        localA * sycl::log(ctx.data->drParameters.rsSr0 / localSlipRate * 2 *
+                           sycl::sinh(steadyStateFrictionCoefficient / localA));
+
+    const double preexp1 = -localSlipRate * (timeIncrement / localSl0);
+    const double exp1 = sycl::exp(preexp1);
+    const double exp1m = -sycl::expm1(preexp1);
+    const double localStateVariable =
+        steadyStateStateVariable * exp1m + exp1 * devStateVarReference;
+
+    devStateVariableBuffer = localStateVariable;
   }
 
-  void updateStateVariable(double timeIncrement) {
-    auto* devStateVarReference{this->initialVariables.stateVarReference};
-    auto* devLocalSlipRate{this->initialVariables.localSlipRate};
-    auto* devStateVariableBuffer{this->stateVariableBuffer};
-    const double muW{this->drParameters->muW};
-    auto details = this->getCurrentLtsLayerDetails();
-
-    sycl::nd_range rng{{this->currLayerSize * misc::NumPaddedPoints}, {misc::NumPaddedPoints}};
-    this->queue.submit([&](sycl::handler& cgh) {
-      cgh.parallel_for(rng, [=](sycl::nd_item<1> item) {
-        const auto ltsFace = item.get_group().get_group_id(0);
-        const auto pointIndex = item.get_local_id(0);
-
-        const double localSl0 = details.sl0[ltsFace][pointIndex];
-        const double localA = details.a[ltsFace][pointIndex];
-        const double localSrW = details.srW[ltsFace][pointIndex];
-        const double localSlipRate = devLocalSlipRate[ltsFace][pointIndex];
-
-        const double lowVelocityFriction =
-            details.rsF0 - (details.rsB - localA) * sycl::log(localSlipRate / details.rsSr0);
-
-        const double steadyStateFrictionCoefficient =
-            muW + (lowVelocityFriction - muW) /
-                      sycl::pow(1.0 + sycl::pown(localSlipRate / localSrW, 8), 1.0 / 8.0);
-
-        const double steadyStateStateVariable =
-            localA * sycl::log(details.rsSr0 / localSlipRate * 2 *
-                               sycl::sinh(steadyStateFrictionCoefficient / localA));
-
-        const double preexp1 = -localSlipRate * (timeIncrement / localSl0);
-        const double exp1 = sycl::exp(preexp1);
-        const double exp1m = -sycl::expm1(preexp1);
-        const double localStateVariable =
-            steadyStateStateVariable * exp1m + exp1 * devStateVarReference[ltsFace][pointIndex];
-
-        devStateVariableBuffer[ltsFace][pointIndex] = localStateVariable;
-      });
-    });
-  }
-
-  static double updateMu(double localSlipRateMagnitude,
-                         double localStateVariable,
-                         Details details,
-                         size_t ltsFace,
-                         size_t pointIndex) {
-    const double localA = details.a[ltsFace][pointIndex];
-    const double x =
-        0.5 / details.rsSr0 * sycl::exp(localStateVariable / localA) * localSlipRateMagnitude;
+  static double
+      updateMu(FrictionLawContext& ctx, double localSlipRateMagnitude, double localStateVariable) {
+    const double localA = ctx.data->a[ctx.ltsFace][ctx.pointIndex];
+    const double x = 0.5 / ctx.data->drParameters.rsSr0 * sycl::exp(localStateVariable / localA) *
+                     localSlipRateMagnitude;
     return localA * sycl::asinh(x);
   }
 
-  static double updateMuDerivative(double localSlipRateMagnitude,
-                                   double localStateVariable,
-                                   Details details,
-                                   size_t ltsFace,
-                                   size_t pointIndex) {
-    const double localA = details.a[ltsFace][pointIndex];
-    const double c = 0.5 / details.rsSr0 * sycl::exp(localStateVariable / localA);
+  static double updateMuDerivative(FrictionLawContext& ctx,
+                                   double localSlipRateMagnitude,
+                                   double localStateVariable) {
+    const double localA = ctx.data->a[ctx.ltsFace][ctx.pointIndex];
+    const double c = 0.5 / ctx.data->drParameters.rsSr0 * sycl::exp(localStateVariable / localA);
     return localA * c / sycl::sqrt(sycl::pown(localSlipRateMagnitude * c, 2) + 1.0);
   }
 
-  void resampleStateVar(real (*devStateVariableBuffer)[misc::NumPaddedPoints]) {
-    auto* devStateVariable{this->stateVariable};
-    auto* resampleMatrix{this->resampleMatrix};
+  static void resampleStateVar(FrictionLawContext& ctx) {
+    auto* devStateVariable{ctx.data->stateVariable};
+    auto* resampleMatrix{ctx.resampleMatrix};
 
     constexpr auto Dim0 = misc::dimSize<init::resample, 0>();
     constexpr auto Dim1 = misc::dimSize<init::resample, 1>();
     static_assert(Dim0 == misc::NumPaddedPoints);
     static_assert(Dim0 >= Dim1);
 
-    sycl::nd_range rng{{this->currLayerSize * misc::NumPaddedPoints}, {misc::NumPaddedPoints}};
-    this->queue.submit([&](sycl::handler& cgh) {
-      // NOLINTNEXTLINE
-      sycl::accessor<real, 1, sycl::access::mode::read_write, sycl::access::target::local>
-          deltaStateVar(misc::NumPaddedPoints, cgh);
+    const auto localStateVariable = devStateVariable[ctx.ltsFace][ctx.pointIndex];
+    ctx.deltaStateVar[ctx.pointIndex] = ctx.stateVariableBuffer - localStateVariable;
+    ctx.item->barrier(sycl::access::fence_space::local_space);
 
-      cgh.parallel_for(rng, [=](sycl::nd_item<1> item) {
-        const auto ltsFace = item.get_group().get_group_id(0);
-        const auto pointIndex = item.get_local_id(0);
+    real resampledDeltaStateVar{0.0};
+    for (size_t i{0}; i < Dim1; ++i) {
+      resampledDeltaStateVar +=
+          ctx.resampleMatrix[ctx.pointIndex + i * Dim0] * ctx.deltaStateVar[i];
+    }
 
-        const auto localStateVariable = devStateVariable[ltsFace][pointIndex];
-        deltaStateVar[pointIndex] =
-            devStateVariableBuffer[ltsFace][pointIndex] - localStateVariable;
-        item.barrier(sycl::access::fence_space::local_space);
-
-        real resampledDeltaStateVar{0.0};
-        for (size_t i{0}; i < Dim1; ++i) {
-          resampledDeltaStateVar += resampleMatrix[pointIndex + i * Dim0] * deltaStateVar[i];
-        }
-
-        devStateVariable[ltsFace][pointIndex] = localStateVariable + resampledDeltaStateVar;
-      });
-    });
+    devStateVariable[ctx.ltsFace][ctx.pointIndex] = localStateVariable + resampledDeltaStateVar;
   }
 
-  void executeIfNotConverged() {}
-
-  protected:
-  real (*srW)[misc::NumPaddedPoints];
+  static void executeIfNotConverged() {}
 };
 } // namespace seissol::dr::friction_law::gpu
 

--- a/src/DynamicRupture/FrictionLaws/GpuImpl/FrictionSolverDetails.h
+++ b/src/DynamicRupture/FrictionLaws/GpuImpl/FrictionSolverDetails.h
@@ -27,21 +27,14 @@ class FrictionSolverDetails : public FrictionSolverInterface {
   void allocateAuxiliaryMemory() override;
   void copyStaticDataToDevice() override;
 
-  virtual void
-      copySpecificLtsDataTreeToLocal(seissol::initializer::Layer& layerData,
-                                     const seissol::initializer::DynamicRupture* const dynRup,
-                                     real fullUpdateTime) = 0;
-
   protected:
   size_t currLayerSize{};
 
-  FaultStresses* faultStresses{nullptr};
-  TractionResults* tractionResults{nullptr};
-  real (*stateVariableBuffer)[misc::NumPaddedPoints]{nullptr};
-  real (*strengthBuffer)[misc::NumPaddedPoints]{nullptr};
   real* resampleMatrix{nullptr};
   double* devTimeWeights{nullptr};
   real* devSpaceWeights{nullptr};
+
+  FrictionLawData* data{nullptr};
 
   sycl::device device;
   sycl::queue queue;

--- a/src/DynamicRupture/FrictionLaws/GpuImpl/FrictionSolverInterface.h
+++ b/src/DynamicRupture/FrictionLaws/GpuImpl/FrictionSolverInterface.h
@@ -10,15 +10,72 @@
 
 #include "DynamicRupture/FrictionLaws/FrictionSolver.h"
 #include "Initializer/Parameters/DRParameters.h"
+#include <Initializer/Tree/Layer.h>
 
 // A sycl-independent interface is required for interacting with the wp solver
 // which, in its turn, is not supposed to know anything about SYCL
 namespace seissol::dr::friction_law::gpu {
+struct FrictionLawData {
+  real deltaT[ConvergenceOrder] = {};
+  real sumDt{};
+
+  seissol::initializer::parameters::DRParameters drParameters;
+
+  ImpedancesAndEta* impAndEta{};
+  ImpedanceMatrices* impedanceMatrices{};
+  real mFullUpdateTime{};
+  // CS = coordinate system
+  real (*initialStressInFaultCS)[misc::NumPaddedPoints][6]{};
+  real (*nucleationStressInFaultCS)[misc::NumPaddedPoints][6]{};
+  real (*cohesion)[misc::NumPaddedPoints]{};
+  real (*mu)[misc::NumPaddedPoints]{};
+  real (*accumulatedSlipMagnitude)[misc::NumPaddedPoints]{};
+  real (*slip1)[misc::NumPaddedPoints]{};
+  real (*slip2)[misc::NumPaddedPoints]{};
+  real (*slipRateMagnitude)[misc::NumPaddedPoints]{};
+  real (*slipRate1)[misc::NumPaddedPoints]{};
+  real (*slipRate2)[misc::NumPaddedPoints]{};
+  real (*ruptureTime)[misc::NumPaddedPoints]{};
+  bool (*ruptureTimePending)[misc::NumPaddedPoints]{};
+  real (*peakSlipRate)[misc::NumPaddedPoints]{};
+  real (*traction1)[misc::NumPaddedPoints]{};
+  real (*traction2)[misc::NumPaddedPoints]{};
+  real (*imposedStatePlus)[tensor::QInterpolated::size()]{};
+  real (*imposedStateMinus)[tensor::QInterpolated::size()]{};
+  real spaceWeights[misc::NumPaddedPoints]{};
+  DREnergyOutput* energyData{};
+  DRGodunovData* godunovData{};
+  real (*initialPressure)[misc::NumPaddedPoints]{};
+  real (*nucleationPressure)[misc::NumPaddedPoints]{};
+
+  // be careful only for some FLs initialized:
+  real (*dynStressTime)[misc::NumPaddedPoints]{};
+  bool (*dynStressTimePending)[misc::NumPaddedPoints]{};
+
+  real (*qInterpolatedPlus)[ConvergenceOrder][tensor::QInterpolated::size()]{};
+  real (*qInterpolatedMinus)[ConvergenceOrder][tensor::QInterpolated::size()]{};
+
+  // LSW
+  real (*dC)[misc::NumPaddedPoints];
+  real (*muS)[misc::NumPaddedPoints];
+  real (*muD)[misc::NumPaddedPoints];
+  real (*forcedRuptureTime)[misc::NumPaddedPoints];
+  real (*regularisedStrength)[misc::NumPaddedPoints];
+
+  // R+S
+  real (*a)[misc::NumPaddedPoints];
+  real (*sl0)[misc::NumPaddedPoints];
+  real (*stateVariable)[misc::NumPaddedPoints];
+
+  // R+S FVW
+  real (*srW)[misc::NumPaddedPoints];
+};
+
 class FrictionSolverInterface : public seissol::dr::friction_law::FrictionSolver {
   public:
   explicit FrictionSolverInterface(seissol::initializer::parameters::DRParameters* drParameters)
       : seissol::dr::friction_law::FrictionSolver(drParameters) {}
-  ~FrictionSolverInterface() override {};
+  ~FrictionSolverInterface() override = default;
 
   virtual void initSyclQueue() = 0;
   void setMaxClusterSize(size_t size) { maxClusterSize = size; }
@@ -29,8 +86,44 @@ class FrictionSolverInterface : public seissol::dr::friction_law::FrictionSolver
     return seissol::initializer::AllocationPlace::Device;
   }
 
+  static void copyLtsTreeToLocal(FrictionLawData* data,
+                                 seissol::initializer::Layer& layerData,
+                                 const seissol::initializer::DynamicRupture* dynRup,
+                                 real fullUpdateTime) {
+    const seissol::initializer::AllocationPlace place =
+        seissol::initializer::AllocationPlace::Device;
+    data->impAndEta = layerData.var(dynRup->impAndEta, place);
+    data->impedanceMatrices = layerData.var(dynRup->impedanceMatrices, place);
+    data->initialStressInFaultCS = layerData.var(dynRup->initialStressInFaultCS, place);
+    data->nucleationStressInFaultCS = layerData.var(dynRup->nucleationStressInFaultCS, place);
+    data->mu = layerData.var(dynRup->mu, place);
+    data->accumulatedSlipMagnitude = layerData.var(dynRup->accumulatedSlipMagnitude, place);
+    data->slip1 = layerData.var(dynRup->slip1, place);
+    data->slip2 = layerData.var(dynRup->slip2, place);
+    data->slipRateMagnitude = layerData.var(dynRup->slipRateMagnitude, place);
+    data->slipRate1 = layerData.var(dynRup->slipRate1, place);
+    data->slipRate2 = layerData.var(dynRup->slipRate2, place);
+    data->ruptureTime = layerData.var(dynRup->ruptureTime, place);
+    data->ruptureTimePending = layerData.var(dynRup->ruptureTimePending, place);
+    data->peakSlipRate = layerData.var(dynRup->peakSlipRate, place);
+    data->traction1 = layerData.var(dynRup->traction1, place);
+    data->traction2 = layerData.var(dynRup->traction2, place);
+    data->imposedStatePlus = layerData.var(dynRup->imposedStatePlus, place);
+    data->imposedStateMinus = layerData.var(dynRup->imposedStateMinus, place);
+    data->energyData = layerData.var(dynRup->drEnergyOutput, place);
+    data->godunovData = layerData.var(dynRup->godunovData, place);
+    data->mFullUpdateTime = fullUpdateTime;
+    data->dynStressTime = layerData.var(dynRup->dynStressTime, place);
+    data->dynStressTimePending = layerData.var(dynRup->dynStressTimePending, place);
+    data->qInterpolatedPlus = layerData.var(dynRup->qInterpolatedPlus, place);
+    data->qInterpolatedMinus = layerData.var(dynRup->qInterpolatedMinus, place);
+    data->initialPressure = layerData.var(dynRup->initialPressure, place);
+    data->nucleationPressure = layerData.var(dynRup->nucleationPressure, place);
+  }
+
   protected:
   size_t maxClusterSize{};
+  FrictionLawData dataHost;
 };
 } // namespace seissol::dr::friction_law::gpu
 

--- a/src/DynamicRupture/FrictionLaws/GpuImpl/NoFault.h
+++ b/src/DynamicRupture/FrictionLaws/GpuImpl/NoFault.h
@@ -9,52 +9,42 @@
 #define SEISSOL_SRC_DYNAMICRUPTURE_FRICTIONLAWS_GPUIMPL_NOFAULT_H_
 
 #include "DynamicRupture/FrictionLaws/GpuImpl/BaseFrictionSolver.h"
+#include <DynamicRupture/FrictionLaws/GpuImpl/FrictionSolverInterface.h>
 
 namespace seissol::dr::friction_law::gpu {
 
 class NoFault : public BaseFrictionSolver<NoFault> {
   public:
   NoFault(seissol::initializer::parameters::DRParameters* drParameters)
-      : BaseFrictionSolver<NoFault>(drParameters) {};
+      : BaseFrictionSolver<NoFault>(drParameters) {}
 
-  void copySpecificLtsDataTreeToLocal(seissol::initializer::Layer& layerData,
-                                      const seissol::initializer::DynamicRupture* const dynRup,
-                                      real fullUpdateTime) override {}
+  static void
+      copySpecificLtsDataTreeToLocal(FrictionLawData* data,
+                                     seissol::initializer::Layer& layerData,
+                                     const seissol::initializer::DynamicRupture* const dynRup,
+                                     real fullUpdateTime) {}
 
-  void updateFrictionAndSlip(unsigned timeIndex) {
-    auto* devTraction1{this->traction1};
-    auto* devTraction2{this->traction2};
-    auto* devFaultStresses{this->faultStresses};
-    auto* devTractionResults{this->tractionResults};
+  static void updateFrictionAndSlip(FrictionLawContext& ctx, unsigned timeIndex) {
+    auto* devTraction1{ctx.data->traction1};
+    auto* devTraction2{ctx.data->traction2};
+    auto& faultStresses{ctx.faultStresses};
+    auto& tractionResults{ctx.tractionResults};
 
-    sycl::nd_range rng{{this->currLayerSize * misc::NumPaddedPoints}, {misc::NumPaddedPoints}};
-    this->queue.submit([&](sycl::handler& cgh) {
-      cgh.parallel_for(rng, [=](sycl::nd_item<1> item) {
-        const auto ltsFace = item.get_group().get_group_id(0);
-        const auto pointIndex = item.get_local_id(0);
-
-        auto& faultStresses = devFaultStresses[ltsFace];
-        auto& tractionResults = devTractionResults[ltsFace];
-
-        // calculate traction
-        tractionResults.traction1[timeIndex][pointIndex] =
-            faultStresses.traction1[timeIndex][pointIndex];
-        tractionResults.traction2[timeIndex][pointIndex] =
-            faultStresses.traction2[timeIndex][pointIndex];
-        devTraction1[ltsFace][pointIndex] = tractionResults.traction1[timeIndex][pointIndex];
-        devTraction2[ltsFace][pointIndex] = tractionResults.traction2[timeIndex][pointIndex];
-      });
-    });
+    // calculate traction
+    tractionResults.traction1[timeIndex] = faultStresses.traction1[timeIndex];
+    tractionResults.traction2[timeIndex] = faultStresses.traction2[timeIndex];
+    devTraction1[ctx.ltsFace][ctx.pointIndex] = tractionResults.traction1[timeIndex];
+    devTraction2[ctx.ltsFace][ctx.pointIndex] = tractionResults.traction2[timeIndex];
   }
 
   /*
    * output time when shear stress is equal to the dynamic stress after rupture arrived
    * currently only for linear slip weakening
    */
-  void saveDynamicStressOutput() {}
+  static void saveDynamicStressOutput(FrictionLawContext& ctx) {}
 
-  void preHook(real (*stateVariableBuffer)[misc::NumPaddedPoints]) {}
-  void postHook(real (*stateVariableBuffer)[misc::NumPaddedPoints]) {}
+  static void preHook(FrictionLawContext& ctx) {}
+  static void postHook(FrictionLawContext& ctx) {}
 
   protected:
 };

--- a/src/DynamicRupture/FrictionLaws/GpuImpl/RateAndState.h
+++ b/src/DynamicRupture/FrictionLaws/GpuImpl/RateAndState.h
@@ -136,6 +136,7 @@ class RateAndStateBase : public BaseFrictionSolver<RateAndStateBase<Derived, TPM
                                                                          localSlipRateMagnitude,
                                                                          localImpAndEta.invEtaS,
                                                                          settings);
+      ctx.item->barrier(sycl::access::fence_space::local_space);
 
       devLocalSlipRate = 0.5 * (localSlipRateMagnitude + std::fabs(slipRateTest));
       devSlipRateMagnitude[ctx.ltsFace][ctx.pointIndex] = std::fabs(slipRateTest);

--- a/src/DynamicRupture/FrictionLaws/GpuImpl/RateAndState.h
+++ b/src/DynamicRupture/FrictionLaws/GpuImpl/RateAndState.h
@@ -10,6 +10,7 @@
 
 #include "DynamicRupture/FrictionLaws/GpuImpl/BaseFrictionSolver.h"
 #include "DynamicRupture/FrictionLaws/RateAndStateCommon.h"
+#include <DynamicRupture/FrictionLaws/GpuImpl/FrictionSolverInterface.h>
 
 namespace seissol::dr::friction_law::gpu {
 /**
@@ -23,357 +24,249 @@ class RateAndStateBase : public BaseFrictionSolver<RateAndStateBase<Derived, TPM
       : BaseFrictionSolver<RateAndStateBase<Derived, TPMethod>>::BaseFrictionSolver(drParameters),
         tpMethod(TPMethod(drParameters)) {}
 
-  ~RateAndStateBase() {
-    if (this->maxClusterSize == 0)
-      return;
-
-    sycl::free(initialVariables.absoluteShearTraction, this->queue);
-    sycl::free(initialVariables.localSlipRate, this->queue);
-    sycl::free(initialVariables.normalStress, this->queue);
-    sycl::free(initialVariables.stateVarReference, this->queue);
-    sycl::free(hasConverged, this->queue);
-    this->queue.wait_and_throw();
-  }
+  ~RateAndStateBase() = default;
 
   void allocateAuxiliaryMemory() override {
     FrictionSolverDetails::allocateAuxiliaryMemory();
-    if (this->maxClusterSize == 0)
+    if (this->maxClusterSize == 0) {
       return;
-
-    {
-      using gpPointType = real(*)[misc::NumPaddedPoints];
-      const size_t requiredNumBytes = misc::NumPaddedPoints * this->maxClusterSize * sizeof(real);
-      initialVariables.absoluteShearTraction =
-          static_cast<gpPointType>(sycl::malloc_device(requiredNumBytes, this->queue));
-      initialVariables.localSlipRate =
-          static_cast<gpPointType>(sycl::malloc_device(requiredNumBytes, this->queue));
-      initialVariables.normalStress =
-          static_cast<gpPointType>(sycl::malloc_device(requiredNumBytes, this->queue));
-      initialVariables.stateVarReference =
-          static_cast<gpPointType>(sycl::malloc_device(requiredNumBytes, this->queue));
-    }
-    {
-      const size_t requiredNumBytes = misc::NumPaddedPoints * this->maxClusterSize * sizeof(bool);
-      hasConverged = static_cast<bool*>(sycl::malloc_device(requiredNumBytes, this->queue));
     }
   }
 
-  void copySpecificLtsDataTreeToLocal(seissol::initializer::Layer& layerData,
-                                      const seissol::initializer::DynamicRupture* const dynRup,
-                                      real fullUpdateTime) override {
-    auto* concreteLts = dynamic_cast<const seissol::initializer::LTSRateAndState*>(dynRup);
-    this->a = layerData.var(concreteLts->rsA, seissol::initializer::AllocationPlace::Device);
-    this->sl0 = layerData.var(concreteLts->rsSl0, seissol::initializer::AllocationPlace::Device);
-    this->stateVariable =
+  static void
+      copySpecificLtsDataTreeToLocal(FrictionLawData* data,
+                                     seissol::initializer::Layer& layerData,
+                                     const seissol::initializer::DynamicRupture* const dynRup,
+                                     real fullUpdateTime) {
+    const auto* concreteLts = dynamic_cast<const seissol::initializer::LTSRateAndState*>(dynRup);
+    data->a = layerData.var(concreteLts->rsA, seissol::initializer::AllocationPlace::Device);
+    data->sl0 = layerData.var(concreteLts->rsSl0, seissol::initializer::AllocationPlace::Device);
+    data->stateVariable =
         layerData.var(concreteLts->stateVariable, seissol::initializer::AllocationPlace::Device);
-    this->tpMethod.copyLtsTreeToLocal(layerData, dynRup, fullUpdateTime);
+    Derived::copySpecificLtsDataTreeToLocal(data, layerData, dynRup, fullUpdateTime);
+    TPMethod::copyLtsTreeToLocal(data, layerData, dynRup, fullUpdateTime);
   }
 
-  void updateFrictionAndSlip(unsigned timeIndex) {
+  static void updateFrictionAndSlip(FrictionLawContext& ctx, unsigned timeIndex) {
     // compute initial slip rate and reference values
-    static_cast<Derived*>(this)->calcInitialVariables(timeIndex);
+    Derived::calcInitialVariables(ctx, timeIndex);
 
-    this->updateStateVariableIterative(timeIndex);
-    static_cast<Derived*>(this)->executeIfNotConverged();
+    updateStateVariableIterative(ctx, timeIndex);
+    Derived::executeIfNotConverged();
 
-    tpMethod.calcFluidPressure(this->initialVariables.normalStress,
-                               this->mu,
-                               this->initialVariables.localSlipRate,
-                               this->deltaT[timeIndex],
-                               true);
-    updateNormalStress(timeIndex);
-    this->calcSlipRateAndTraction(timeIndex);
+    TPMethod::calcFluidPressure(ctx, true);
+    updateNormalStress(ctx, timeIndex);
+    calcSlipRateAndTraction(ctx, timeIndex);
   }
 
-  void preHook(real (*stateVariableBuffer)[misc::NumPaddedPoints]) {
+  static void preHook(FrictionLawContext& ctx) {
     // copy state variable from last time step
-
-    auto* devLocalStateVariable{this->stateVariable};
-    sycl::nd_range rng{{this->currLayerSize * misc::NumPaddedPoints}, {misc::NumPaddedPoints}};
-    this->queue.submit([&](sycl::handler& cgh) {
-      cgh.parallel_for(rng, [=](sycl::nd_item<1> item) {
-        const auto ltsFace = item.get_group().get_group_id(0);
-        const auto pointIndex = item.get_local_id(0);
-        stateVariableBuffer[ltsFace][pointIndex] = devLocalStateVariable[ltsFace][pointIndex];
-      });
-    });
+    ctx.stateVariableBuffer = ctx.data->stateVariable[ctx.ltsFace][ctx.pointIndex];
   }
 
-  void postHook(real (*stateVariableBuffer)[misc::NumPaddedPoints]) {
-    static_cast<Derived*>(this)->resampleStateVar(stateVariableBuffer);
-  }
-
-  void copyLtsTreeToLocal(seissol::initializer::Layer& layerData,
-                          const seissol::initializer::DynamicRupture* const dynRup,
-                          real fullUpdateTime) {
-    auto* concreteLts = dynamic_cast<const seissol::initializer::LTSRateAndState*>(dynRup);
-    a = layerData.var(concreteLts->rsA, seissol::initializer::AllocationPlace::Device);
-    sl0 = layerData.var(concreteLts->rsSl0, seissol::initializer::AllocationPlace::Device);
-    stateVariable =
-        layerData.var(concreteLts->stateVariable, seissol::initializer::AllocationPlace::Device);
-    static_cast<Derived*>(this)->copyLtsTreeToLocal(layerData, dynRup, fullUpdateTime);
-    tpMethod.copyLtsTreeToLocal(layerData, dynRup, fullUpdateTime);
-  }
-
-  /**
-   * Contains all the variables, which are to be computed initially in each timestep.
-   */
-  struct InitialVariables {
-    real (*absoluteShearTraction)[misc::NumPaddedPoints]{nullptr};
-    real (*localSlipRate)[misc::NumPaddedPoints]{nullptr};
-    real (*normalStress)[misc::NumPaddedPoints]{nullptr};
-    real (*stateVarReference)[misc::NumPaddedPoints]{nullptr};
-  } initialVariables;
+  static void postHook(FrictionLawContext& ctx) { Derived::resampleStateVar(ctx); }
 
   /*
    * Compute shear stress magnitude, localSlipRate, effective normal stress, reference state
    * variable. Also sets slipRateMagnitude member to reference value.
    */
-  void calcInitialVariables(unsigned int timeIndex) {
-    auto* devStateVariableBuffer{this->stateVariableBuffer};
-    auto* devFaultStresses{this->faultStresses};
-    auto* devSlipRateMagnitude{this->slipRateMagnitude};
-    auto* devSlipRate1{this->slipRate1};
-    auto* devSlipRate2{this->slipRate2};
-    auto* devInitialStressInFaultCS{this->initialStressInFaultCS};
+  static void calcInitialVariables(FrictionLawContext& ctx, unsigned int timeIndex) {
+    auto& devStateVariableBuffer{ctx.stateVariableBuffer};
+    auto& devFaultStresses{ctx.faultStresses};
+    auto* devSlipRateMagnitude{ctx.data->slipRateMagnitude};
+    auto* devSlipRate1{ctx.data->slipRate1};
+    auto* devSlipRate2{ctx.data->slipRate2};
+    auto* devInitialStressInFaultCS{ctx.data->initialStressInFaultCS};
 
-    auto* devAbsoluteShearTraction{this->initialVariables.absoluteShearTraction};
-    auto* devLocalSlipRate{this->initialVariables.localSlipRate};
-    auto* devStateVarReference{this->initialVariables.stateVarReference};
+    auto& devAbsoluteShearTraction{ctx.initialVariables.absoluteShearTraction};
+    auto& devLocalSlipRate{ctx.initialVariables.localSlipRate};
+    auto& devStateVarReference{ctx.initialVariables.stateVarReference};
 
-    updateNormalStress(timeIndex);
+    updateNormalStress(ctx, timeIndex);
 
-    sycl::nd_range rng{{this->currLayerSize * misc::NumPaddedPoints}, {misc::NumPaddedPoints}};
-    this->queue.submit([&](sycl::handler& cgh) {
-      cgh.parallel_for(rng, [=](sycl::nd_item<1> item) {
-        const auto ltsFace = item.get_group().get_group_id(0);
-        const auto pointIndex = item.get_local_id(0);
-        auto& faultStresses = devFaultStresses[ltsFace];
+    auto& faultStresses = devFaultStresses;
 
-        devStateVarReference[ltsFace][pointIndex] = devStateVariableBuffer[ltsFace][pointIndex];
+    devStateVarReference = devStateVariableBuffer;
 
-        const real totalTraction1 = devInitialStressInFaultCS[ltsFace][pointIndex][3] +
-                                    faultStresses.traction1[timeIndex][pointIndex];
+    const real totalTraction1 = devInitialStressInFaultCS[ctx.ltsFace][ctx.pointIndex][3] +
+                                faultStresses.traction1[timeIndex];
 
-        const real totalTraction2 = devInitialStressInFaultCS[ltsFace][pointIndex][5] +
-                                    faultStresses.traction2[timeIndex][pointIndex];
+    const real totalTraction2 = devInitialStressInFaultCS[ctx.ltsFace][ctx.pointIndex][5] +
+                                faultStresses.traction2[timeIndex];
 
-        devAbsoluteShearTraction[ltsFace][pointIndex] =
-            misc::magnitude(totalTraction1, totalTraction2);
-        auto localSlipRateMagnitude =
-            misc::magnitude(devSlipRate1[ltsFace][pointIndex], devSlipRate2[ltsFace][pointIndex]);
+    devAbsoluteShearTraction = misc::magnitude(totalTraction1, totalTraction2);
+    auto localSlipRateMagnitude = misc::magnitude(devSlipRate1[ctx.ltsFace][ctx.pointIndex],
+                                                  devSlipRate2[ctx.ltsFace][ctx.pointIndex]);
 
-        localSlipRateMagnitude = std::max(rs::almostZero(), localSlipRateMagnitude);
-        devSlipRateMagnitude[ltsFace][pointIndex] = localSlipRateMagnitude;
-        devLocalSlipRate[ltsFace][pointIndex] = localSlipRateMagnitude;
-      });
-    });
+    localSlipRateMagnitude = std::max(rs::almostZero(), localSlipRateMagnitude);
+    devSlipRateMagnitude[ctx.ltsFace][ctx.pointIndex] = localSlipRateMagnitude;
+    devLocalSlipRate = localSlipRateMagnitude;
   }
 
-  void updateStateVariableIterative(unsigned timeIndex) {
-    auto* devHasConverged{this->hasConverged};
-    auto* devLocalSlipRate{this->initialVariables.localSlipRate};
-    auto* devStateVariableBuffer{this->stateVariableBuffer};
-    auto* devNormalStress{this->initialVariables.normalStress};
-    auto* devAbsoluteShearStress{this->initialVariables.absoluteShearTraction};
-    auto* devMu{this->mu};
+  static void updateStateVariableIterative(FrictionLawContext& ctx, unsigned timeIndex) {
+    auto& devLocalSlipRate{ctx.initialVariables.localSlipRate};
+    auto& devStateVariableBuffer{ctx.stateVariableBuffer};
+    auto& devNormalStress{ctx.initialVariables.normalStress};
+    auto& devAbsoluteShearStress{ctx.initialVariables.absoluteShearTraction};
+    auto* devMu{ctx.data->mu};
 
-    auto* devSlipRateMagnitude{this->slipRateMagnitude};
-    auto* devImpAndEta{this->impAndEta};
-    auto solverSettings{this->settings};
+    auto* devSlipRateMagnitude{ctx.data->slipRateMagnitude};
+    auto* devImpAndEta{ctx.data->impAndEta};
+    rs::Settings settings{};
 
-    auto details = static_cast<Derived*>(this)->getCurrentLtsLayerDetails();
-    sycl::nd_range rng{{this->currLayerSize * misc::NumPaddedPoints}, {misc::NumPaddedPoints}};
-    for (unsigned j = 0; j < this->settings.numberStateVariableUpdates; j++) {
+    for (unsigned j = 0; j < settings.numberStateVariableUpdates; j++) {
 
-      const auto dt{this->deltaT[timeIndex]};
-      static_cast<Derived*>(this)->updateStateVariable(dt);
-      this->tpMethod.calcFluidPressure(devNormalStress, devMu, devLocalSlipRate, dt, false);
-      updateNormalStress(timeIndex);
+      const auto dt{ctx.data->deltaT[timeIndex]};
+      Derived::updateStateVariable(ctx, dt);
+      TPMethod::calcFluidPressure(ctx, false);
+      updateNormalStress(ctx, timeIndex);
 
-      this->queue.submit([&](sycl::handler& cgh) {
-        cgh.parallel_for(rng, [=](sycl::nd_item<1> item) {
-          const auto ltsFace = item.get_group().get_group_id(0);
-          const auto pointIndex = item.get_local_id(0);
+      const auto localStateVariable = devStateVariableBuffer;
+      const auto normalStress = devNormalStress;
+      const auto absoluteShearStress = devAbsoluteShearStress;
+      const auto localSlipRateMagnitude = devSlipRateMagnitude[ctx.ltsFace][ctx.pointIndex];
+      const auto localImpAndEta = devImpAndEta[ctx.ltsFace];
 
-          const auto localStateVariable = devStateVariableBuffer[ltsFace][pointIndex];
-          const auto normalStress = devNormalStress[ltsFace][pointIndex];
-          const auto absoluteShearStress = devAbsoluteShearStress[ltsFace][pointIndex];
-          const auto localSlipRateMagnitude = devSlipRateMagnitude[ltsFace][pointIndex];
-          const auto localImpAndEta = devImpAndEta[ltsFace];
+      real slipRateTest{};
+      bool hasConvergedLocal = RateAndStateBase::invertSlipRateIterative(ctx,
+                                                                         slipRateTest,
+                                                                         localStateVariable,
+                                                                         normalStress,
+                                                                         absoluteShearStress,
+                                                                         localSlipRateMagnitude,
+                                                                         localImpAndEta.invEtaS,
+                                                                         settings);
 
-          real slipRateTest{};
-          bool hasConvergedLocal = RateAndStateBase::invertSlipRateIterative(slipRateTest,
-                                                                             localStateVariable,
-                                                                             normalStress,
-                                                                             absoluteShearStress,
-                                                                             localSlipRateMagnitude,
-                                                                             localImpAndEta.invEtaS,
-                                                                             details,
-                                                                             solverSettings,
-                                                                             item);
+      devLocalSlipRate = 0.5 * (localSlipRateMagnitude + std::fabs(slipRateTest));
+      devSlipRateMagnitude[ctx.ltsFace][ctx.pointIndex] = std::fabs(slipRateTest);
 
-          if (pointIndex == 0)
-            devHasConverged[ltsFace] = hasConvergedLocal;
-
-          devLocalSlipRate[ltsFace][pointIndex] =
-              0.5 * (localSlipRateMagnitude + std::fabs(slipRateTest));
-          devSlipRateMagnitude[ltsFace][pointIndex] = std::fabs(slipRateTest);
-
-          devMu[ltsFace][pointIndex] = Derived::updateMu(
-              localSlipRateMagnitude, localStateVariable, details, ltsFace, pointIndex);
-        });
-      });
+      devMu[ctx.ltsFace][ctx.pointIndex] =
+          Derived::updateMu(ctx, localSlipRateMagnitude, localStateVariable);
     }
   }
 
-  void calcSlipRateAndTraction(unsigned timeIndex) {
-    auto* devStateVarReference{this->initialVariables.stateVarReference};
-    auto* devLocalSlipRate{this->initialVariables.localSlipRate};
-    auto* devStateVariableBuffer{this->stateVariableBuffer}; // localStateVariable
-    auto* devNormalStress{this->initialVariables.normalStress};
-    auto* devAbsoluteTraction{this->initialVariables.absoluteShearTraction};
-    auto* devFaultStresses{this->faultStresses};
-    auto* devTractionResults{this->tractionResults};
+  static void calcSlipRateAndTraction(FrictionLawContext& ctx, unsigned timeIndex) {
+    auto& devStateVarReference{ctx.initialVariables.stateVarReference};
+    auto& devLocalSlipRate{ctx.initialVariables.localSlipRate};
+    auto& devStateVariableBuffer{ctx.stateVariableBuffer}; // localStateVariable
+    auto& devNormalStress{ctx.initialVariables.normalStress};
+    auto& devAbsoluteTraction{ctx.initialVariables.absoluteShearTraction};
+    auto& devFaultStresses{ctx.faultStresses};
+    auto& devTractionResults{ctx.tractionResults};
 
-    auto* devMu{this->mu};
-    auto* devSlipRateMagnitude{this->slipRateMagnitude};
-    auto* devInitialStressInFaultCS{this->initialStressInFaultCS};
-    auto* devTraction1{this->traction1};
-    auto* devTraction2{this->traction2};
-    auto* devSlipRate1{this->slipRate1};
-    auto* devSlipRate2{this->slipRate2};
-    auto* devSlip1{this->slip1};
-    auto* devSlip2{this->slip2};
-    auto* devImpAndEta{this->impAndEta};
-    auto* devAccumulatedSlipMagnitude{this->accumulatedSlipMagnitude};
-    auto deltaTime{this->deltaT[timeIndex]};
+    auto* devMu{ctx.data->mu};
+    auto* devSlipRateMagnitude{ctx.data->slipRateMagnitude};
+    auto* devInitialStressInFaultCS{ctx.data->initialStressInFaultCS};
+    auto* devTraction1{ctx.data->traction1};
+    auto* devTraction2{ctx.data->traction2};
+    auto* devSlipRate1{ctx.data->slipRate1};
+    auto* devSlipRate2{ctx.data->slipRate2};
+    auto* devSlip1{ctx.data->slip1};
+    auto* devSlip2{ctx.data->slip2};
+    auto* devImpAndEta{ctx.data->impAndEta};
+    auto* devAccumulatedSlipMagnitude{ctx.data->accumulatedSlipMagnitude};
+    auto deltaTime{ctx.data->deltaT[timeIndex]};
 
-    auto details = static_cast<Derived*>(this)->getCurrentLtsLayerDetails();
+    Derived::updateStateVariable(ctx, ctx.data->deltaT[timeIndex]);
 
-    static_cast<Derived*>(this)->updateStateVariable(this->deltaT[timeIndex]);
+    const auto localStateVariable = devStateVariableBuffer;
+    const auto slipRateMagnitude = devSlipRateMagnitude[ctx.ltsFace][ctx.pointIndex];
+    devMu[ctx.ltsFace][ctx.pointIndex] =
+        Derived::updateMu(ctx, slipRateMagnitude, localStateVariable);
+    const real strength = -devMu[ctx.ltsFace][ctx.pointIndex] * devNormalStress;
 
-    sycl::nd_range rng{{this->currLayerSize * misc::NumPaddedPoints}, {misc::NumPaddedPoints}};
-    this->queue.submit([&](sycl::handler& cgh) {
-      cgh.parallel_for(rng, [=](sycl::nd_item<1> item) {
-        const auto ltsFace = item.get_group().get_group_id(0);
-        const auto pointIndex = item.get_local_id(0);
+    const auto* initialStressInFaultCS = devInitialStressInFaultCS[ctx.ltsFace][ctx.pointIndex];
+    const auto savedTraction1 = devFaultStresses.traction1[timeIndex];
+    const auto savedTraction2 = devFaultStresses.traction2[timeIndex];
 
-        const auto localStateVariable = devStateVariableBuffer[ltsFace][pointIndex];
-        const auto slipRateMagnitude = devSlipRateMagnitude[ltsFace][pointIndex];
-        devMu[ltsFace][pointIndex] =
-            Derived::updateMu(slipRateMagnitude, localStateVariable, details, ltsFace, pointIndex);
-        const real strength = -devMu[ltsFace][pointIndex] * devNormalStress[ltsFace][pointIndex];
+    // calculate absolute value of stress in Y and Z direction
+    const real totalTraction1 = initialStressInFaultCS[3] + savedTraction1;
+    const real totalTraction2 = initialStressInFaultCS[5] + savedTraction2;
 
-        const auto initialStressInFaultCS = devInitialStressInFaultCS[ltsFace][pointIndex];
-        const auto savedTraction1 = devFaultStresses[ltsFace].traction1[timeIndex][pointIndex];
-        const auto savedTraction2 = devFaultStresses[ltsFace].traction2[timeIndex][pointIndex];
+    // update stress change
+    const auto traction1 =
+        (totalTraction1 / devAbsoluteTraction) * strength - initialStressInFaultCS[3];
+    const auto traction2 =
+        (totalTraction2 / devAbsoluteTraction) * strength - initialStressInFaultCS[5];
 
-        // calculate absolute value of stress in Y and Z direction
-        devFaultStresses[ltsFace].traction2[timeIndex][pointIndex];
-        const real totalTraction1 = initialStressInFaultCS[3] + savedTraction1;
-        const real totalTraction2 = initialStressInFaultCS[5] + savedTraction2;
+    // Compute slip
+    devAccumulatedSlipMagnitude[ctx.ltsFace][ctx.pointIndex] += slipRateMagnitude * deltaTime;
 
-        // update stress change
-        const auto traction1 =
-            (totalTraction1 / devAbsoluteTraction[ltsFace][pointIndex]) * strength -
-            initialStressInFaultCS[3];
-        const auto traction2 =
-            (totalTraction2 / devAbsoluteTraction[ltsFace][pointIndex]) * strength -
-            initialStressInFaultCS[5];
+    // Update slip rate
+    const auto invEtaS = devImpAndEta[ctx.ltsFace].invEtaS;
+    auto slipRate1 = -invEtaS * (traction1 - savedTraction1);
+    auto slipRate2 = -invEtaS * (traction2 - savedTraction2);
 
-        // Compute slip
-        devAccumulatedSlipMagnitude[ltsFace][pointIndex] += slipRateMagnitude * deltaTime;
+    const real locSlipRateMagnitude = misc::magnitude(slipRate1, slipRate2);
 
-        // Update slip rate
-        const auto invEtaS = devImpAndEta[ltsFace].invEtaS;
-        auto slipRate1 = -invEtaS * (traction1 - savedTraction1);
-        auto slipRate2 = -invEtaS * (traction2 - savedTraction2);
+    if (locSlipRateMagnitude != 0.0) {
+      slipRate1 *= slipRateMagnitude / locSlipRateMagnitude;
+      slipRate2 *= slipRateMagnitude / locSlipRateMagnitude;
+    }
 
-        const real locSlipRateMagnitude = misc::magnitude(slipRate1, slipRate2);
+    // Save traction for flux computation
+    devTraction1[ctx.ltsFace][ctx.pointIndex] = traction1;
+    devTraction2[ctx.ltsFace][ctx.pointIndex] = traction2;
 
-        if (locSlipRateMagnitude != 0.0) {
-          slipRate1 *= slipRateMagnitude / locSlipRateMagnitude;
-          slipRate2 *= slipRateMagnitude / locSlipRateMagnitude;
-        }
+    // update directional slip
+    devSlip1[ctx.ltsFace][ctx.pointIndex] += slipRate1 * deltaTime;
+    devSlip2[ctx.ltsFace][ctx.pointIndex] += slipRate2 * deltaTime;
 
-        // Save traction for flux computation
-        devTraction1[ltsFace][pointIndex] = traction1;
-        devTraction2[ltsFace][pointIndex] = traction2;
+    // update traction
+    devTractionResults.traction1[timeIndex] = traction1;
+    devTractionResults.traction2[timeIndex] = traction2;
 
-        // update directional slip
-        devSlip1[ltsFace][pointIndex] += slipRate1 * deltaTime;
-        devSlip2[ltsFace][pointIndex] += slipRate2 * deltaTime;
-
-        // update traction
-        devTractionResults[ltsFace].traction1[timeIndex][pointIndex] = traction1;
-        devTractionResults[ltsFace].traction2[timeIndex][pointIndex] = traction2;
-
-        // update slip rate
-        devSlipRate1[ltsFace][pointIndex] = slipRate1;
-        devSlipRate2[ltsFace][pointIndex] = slipRate2;
-      });
-    });
+    // update slip rate
+    devSlipRate1[ctx.ltsFace][ctx.pointIndex] = slipRate1;
+    devSlipRate2[ctx.ltsFace][ctx.pointIndex] = slipRate2;
   }
 
-  void saveDynamicStressOutput() {
-    auto fullUpdateTime{this->mFullUpdateTime};
-    auto muW{this->drParameters->muW};
-    auto rsF0{this->drParameters->rsF0};
+  static void saveDynamicStressOutput(FrictionLawContext& ctx) {
+    auto fullUpdateTime{ctx.data->mFullUpdateTime};
+    auto muW{ctx.data->drParameters.muW};
+    auto rsF0{ctx.data->drParameters.rsF0};
 
-    auto* devDynStressTime{this->dynStressTime};
-    auto* devDynStressTimePending{this->dynStressTimePending};
-    auto* devRuptureTime{this->ruptureTime};
-    auto* devMu{this->mu};
+    auto* devDynStressTime{ctx.data->dynStressTime};
+    auto* devDynStressTimePending{ctx.data->dynStressTimePending};
+    auto* devRuptureTime{ctx.data->ruptureTime};
+    auto* devMu{ctx.data->mu};
 
-    sycl::nd_range rng{{this->currLayerSize * misc::NumPaddedPoints}, {misc::NumPaddedPoints}};
-    this->queue.submit([&](sycl::handler& cgh) {
-      cgh.parallel_for(rng, [=](sycl::nd_item<1> item) {
-        const auto ltsFace = item.get_group().get_group_id(0);
-        const auto pointIndex = item.get_local_id(0);
-
-        const auto localRuptureTime = devRuptureTime[ltsFace][pointIndex];
-        if (localRuptureTime > 0.0 && localRuptureTime <= fullUpdateTime &&
-            devDynStressTimePending[ltsFace][pointIndex] &&
-            devMu[ltsFace][pointIndex] <= (muW + 0.05 * (rsF0 - muW))) {
-          devDynStressTime[ltsFace][pointIndex] = fullUpdateTime;
-          devDynStressTimePending[ltsFace][pointIndex] = false;
-        }
-      });
-    });
+    const auto localRuptureTime = devRuptureTime[ctx.ltsFace][ctx.pointIndex];
+    if (localRuptureTime > 0.0 && localRuptureTime <= fullUpdateTime &&
+        devDynStressTimePending[ctx.ltsFace][ctx.pointIndex] &&
+        devMu[ctx.ltsFace][ctx.pointIndex] <= (muW + 0.05 * (rsF0 - muW))) {
+      devDynStressTime[ctx.ltsFace][ctx.pointIndex] = fullUpdateTime;
+      devDynStressTimePending[ctx.ltsFace][ctx.pointIndex] = false;
+    }
   }
 
-  template <typename DetailsType>
-  static bool invertSlipRateIterative(real& slipRateTest,
+  static bool invertSlipRateIterative(FrictionLawContext& ctx,
+                                      real& slipRateTest,
                                       real localStateVariable,
                                       real normalStress,
                                       real absoluteShearStress,
                                       real slipRateMagnitude,
                                       real invEtaS,
-                                      DetailsType details,
-                                      rs::Settings solverSettings,
-                                      sycl::nd_item<1> item) {
-
-    const auto ltsFace = item.get_group().get_group_id(0);
-    const auto pointIndex = item.get_local_id(0);
+                                      rs::Settings solverSettings) {
 
     // Note that we need double precision here, since single precision led to NaNs.
-    double muF{0.0}, dMuF{0.0}, g{0.0}, dG{0.0};
+    double muF{0.0};
+    double dMuF{0.0};
+    double g{0.0};
+    double dG{0.0};
     slipRateTest = slipRateMagnitude;
 
     for (unsigned i = 0; i < solverSettings.maxNumberSlipRateUpdates; i++) {
-      muF = Derived::updateMu(slipRateTest, localStateVariable, details, ltsFace, pointIndex);
-      dMuF = Derived::updateMuDerivative(
-          slipRateTest, localStateVariable, details, ltsFace, pointIndex);
+      muF = Derived::updateMu(ctx, slipRateTest, localStateVariable);
+      dMuF = Derived::updateMuDerivative(ctx, slipRateTest, localStateVariable);
 
       g = -invEtaS * (sycl::fabs(normalStress) * muF - absoluteShearStress) - slipRateTest;
 
-      auto group = item.get_group();
-      const bool converged =
-          sycl::all_of_group(group, std::fabs(g) < solverSettings.newtonTolerance);
+      const bool converged = std::fabs(g) < solverSettings.newtonTolerance;
 
-      if (converged)
+      if (converged) {
         return true;
+      }
 
       dG = -invEtaS * (std::fabs(normalStress) * dMuF) - 1.0;
       slipRateTest =
@@ -382,27 +275,17 @@ class RateAndStateBase : public BaseFrictionSolver<RateAndStateBase<Derived, TPM
     return false;
   }
 
-  void updateNormalStress(size_t timeIndex) {
-    auto* devFaultStresses{this->faultStresses};
-    auto* devInitialStressInFaultCS{this->initialStressInFaultCS};
-    auto* devNormalStress{this->initialVariables.normalStress};
+  static void updateNormalStress(FrictionLawContext& ctx, size_t timeIndex) {
+    auto& devFaultStresses{ctx.faultStresses};
+    auto* devInitialStressInFaultCS{ctx.data->initialStressInFaultCS};
+    auto& devNormalStress{ctx.initialVariables.normalStress};
 
-    auto tpCurrentLayerDetails = tpMethod.getCurrentLayerDetails();
+    auto& faultStresses = devFaultStresses;
 
-    sycl::nd_range rng{{this->currLayerSize * misc::NumPaddedPoints}, {misc::NumPaddedPoints}};
-    this->queue.submit([&](sycl::handler& cgh) {
-      cgh.parallel_for(rng, [=](sycl::nd_item<1> item) {
-        const auto ltsFace = item.get_group().get_group_id(0);
-        const auto pointIndex = item.get_local_id(0);
-        auto& faultStresses = devFaultStresses[ltsFace];
-
-        devNormalStress[ltsFace][pointIndex] =
-            std::min(static_cast<real>(0.0),
-                     faultStresses.normalStress[timeIndex][pointIndex] +
-                         devInitialStressInFaultCS[ltsFace][pointIndex][0] -
-                         TPMethod::getFluidPressure(tpCurrentLayerDetails, ltsFace, pointIndex));
-      });
-    });
+    devNormalStress = std::min(static_cast<real>(0.0),
+                               faultStresses.normalStress[timeIndex] +
+                                   devInitialStressInFaultCS[ctx.ltsFace][ctx.pointIndex][0] -
+                                   TPMethod::getFluidPressure(ctx));
   }
 
   protected:

--- a/src/DynamicRupture/FrictionLaws/GpuImpl/SlipLaw.h
+++ b/src/DynamicRupture/FrictionLaws/GpuImpl/SlipLaw.h
@@ -17,28 +17,24 @@ class SlipLaw : public SlowVelocityWeakeningLaw<SlipLaw<TPMethod>, TPMethod> {
   using SlowVelocityWeakeningLaw<SlipLaw<TPMethod>, TPMethod>::SlowVelocityWeakeningLaw;
   using SlowVelocityWeakeningLaw<SlipLaw<TPMethod>, TPMethod>::copyLtsTreeToLocal;
 
-  void updateStateVariable(double timeIncrement) {
-    auto* devSl0{this->sl0};
-    auto* devStateVarReference{this->initialVariables.stateVarReference};
-    auto* devLocalSlipRate{this->initialVariables.localSlipRate};
-    auto* devStateVariableBuffer{this->stateVariableBuffer};
+  static void
+      copySpecificLtsDataTreeToLocal(FrictionLawData* data,
+                                     seissol::initializer::Layer& layerData,
+                                     const seissol::initializer::DynamicRupture* const dynRup,
+                                     real fullUpdateTime) {}
 
-    sycl::nd_range rng{{this->currLayerSize * misc::NumPaddedPoints}, {misc::NumPaddedPoints}};
-    this->queue.submit([&](sycl::handler& cgh) {
-      cgh.parallel_for(rng, [=](sycl::nd_item<1> item) {
-        const auto ltsFace = item.get_group().get_group_id(0);
-        const auto pointIndex = item.get_local_id(0);
+  static void updateStateVariable(FrictionLawContext& ctx, double timeIncrement) {
+    auto* devSl0{ctx.data->sl0};
+    auto& devStateVarReference{ctx.initialVariables.stateVarReference};
+    auto& devLocalSlipRate{ctx.initialVariables.localSlipRate};
+    auto& devStateVariableBuffer{ctx.stateVariableBuffer};
+    const double localSl0 = devSl0[ctx.ltsFace][ctx.pointIndex];
+    const double localSlipRate = devLocalSlipRate;
+    const double exp1 = sycl::exp(-localSlipRate * (timeIncrement / localSl0));
 
-        const double localSl0 = devSl0[ltsFace][pointIndex];
-        const double localSlipRate = devLocalSlipRate[ltsFace][pointIndex];
-        const double exp1 = sycl::exp(-localSlipRate * (timeIncrement / localSl0));
-
-        const double stateVarReference = devStateVarReference[ltsFace][pointIndex];
-        devStateVariableBuffer[ltsFace][pointIndex] =
-            localSl0 / localSlipRate *
-            sycl::pow(localSlipRate * stateVarReference / localSl0, exp1);
-      });
-    });
+    const double stateVarReference = devStateVarReference;
+    devStateVariableBuffer =
+        localSl0 / localSlipRate * sycl::pow(localSlipRate * stateVarReference / localSl0, exp1);
   }
 };
 

--- a/src/DynamicRupture/FrictionLaws/GpuImpl/SlowVelocityWeakeningLaw.h
+++ b/src/DynamicRupture/FrictionLaws/GpuImpl/SlowVelocityWeakeningLaw.h
@@ -9,6 +9,8 @@
 #define SEISSOL_SRC_DYNAMICRUPTURE_FRICTIONLAWS_GPUIMPL_SLOWVELOCITYWEAKENINGLAW_H_
 
 #include "DynamicRupture/FrictionLaws/GpuImpl/RateAndState.h"
+#include <DynamicRupture/FrictionLaws/GpuImpl/BaseFrictionSolver.h>
+#include <DynamicRupture/FrictionLaws/GpuImpl/FrictionSolverInterface.h>
 
 namespace seissol::dr::friction_law::gpu {
 template <class Derived, class TPMethod>
@@ -17,13 +19,15 @@ class SlowVelocityWeakeningLaw
   public:
   using RateAndStateBase<SlowVelocityWeakeningLaw, TPMethod>::RateAndStateBase;
 
-  void copyLtsTreeToLocal(seissol::initializer::Layer& layerData,
-                          const seissol::initializer::DynamicRupture* const dynRup,
-                          real fullUpdateTime) {}
+  static void
+      copySpecificLtsDataTreeToLocal(FrictionLawData* data,
+                                     seissol::initializer::Layer& layerData,
+                                     const seissol::initializer::DynamicRupture* const dynRup,
+                                     real fullUpdateTime) {}
 
   // Note that we need double precision here, since single precision led to NaNs.
-  void updateStateVariable(double timeIncrement) {
-    static_cast<Derived*>(this)->updateStateVariable(timeIncrement);
+  static void updateStateVariable(FrictionLawContext& ctx, double timeIncrement) {
+    Derived::updateStateVariable(ctx, timeIncrement);
   }
 
   struct Details {
@@ -34,39 +38,26 @@ class SlowVelocityWeakeningLaw
     decltype(seissol::initializer::parameters::DRParameters::rsB) rsB;
   };
 
-  Details getCurrentLtsLayerDetails() {
-    Details details{};
-    details.a = this->a;
-    details.sl0 = this->sl0;
-    details.rsSr0 = this->drParameters->rsSr0;
-    details.rsF0 = this->drParameters->rsF0;
-    details.rsB = this->drParameters->rsB;
-    return details;
-  }
-
-  static double updateMu(double localSlipRateMagnitude,
-                         double localStateVariable,
-                         Details details,
-                         size_t ltsFace,
-                         size_t pointIndex) {
-    const double localA = details.a[ltsFace][pointIndex];
-    const double localSl0 = details.sl0[ltsFace][pointIndex];
-    const double log1 = sycl::log(details.rsSr0 * localStateVariable / localSl0);
-    const double x = 0.5 * (localSlipRateMagnitude / details.rsSr0) *
-                     sycl::exp((details.rsF0 + details.rsB * log1) / localA);
+  static double
+      updateMu(FrictionLawContext& ctx, double localSlipRateMagnitude, double localStateVariable) {
+    const double localA = ctx.data->a[ctx.ltsFace][ctx.pointIndex];
+    const double localSl0 = ctx.data->sl0[ctx.ltsFace][ctx.pointIndex];
+    const double log1 = sycl::log(ctx.data->drParameters.rsSr0 * localStateVariable / localSl0);
+    const double x =
+        0.5 * (localSlipRateMagnitude / ctx.data->drParameters.rsSr0) *
+        sycl::exp((ctx.data->drParameters.rsF0 + ctx.data->drParameters.rsB * log1) / localA);
     return localA * sycl::asinh(x);
   }
 
-  static double updateMuDerivative(double localSlipRateMagnitude,
-                                   double localStateVariable,
-                                   Details details,
-                                   size_t ltsFace,
-                                   size_t pointIndex) {
-    const double localA = details.a[ltsFace][pointIndex];
-    const double localSl0 = details.sl0[ltsFace][pointIndex];
-    const double log1 = sycl::log(details.rsSr0 * localStateVariable / localSl0);
+  static double updateMuDerivative(FrictionLawContext& ctx,
+                                   double localSlipRateMagnitude,
+                                   double localStateVariable) {
+    const double localA = ctx.data->a[ctx.ltsFace][ctx.pointIndex];
+    const double localSl0 = ctx.data->sl0[ctx.ltsFace][ctx.pointIndex];
+    const double log1 = sycl::log(ctx.data->drParameters.rsSr0 * localStateVariable / localSl0);
     const double c =
-        (0.5 / details.rsSr0) * sycl::exp((details.rsF0 + details.rsB * log1) / localA);
+        (0.5 / ctx.data->drParameters.rsSr0) *
+        sycl::exp((ctx.data->drParameters.rsF0 + ctx.data->drParameters.rsB * log1) / localA);
     return localA * c / sycl::sqrt(sycl::pown(localSlipRateMagnitude * c, 2) + 1.0);
   }
 
@@ -74,22 +65,13 @@ class SlowVelocityWeakeningLaw
    * Resample the state variable. For Slow Velocity Weakening Laws,
    * we just copy the buffer into the member variable.
    */
-  void resampleStateVar(real (*stateVariableBuffer)[misc::NumPaddedPoints]) {
-    const auto layerSize{this->currLayerSize};
-    auto* stateVariable{this->stateVariable};
+  static void resampleStateVar(FrictionLawContext& ctx) {
+    auto* stateVariable{ctx.data->stateVariable};
 
-    sycl::nd_range rng{{layerSize * misc::NumPaddedPoints}, {misc::NumPaddedPoints}};
-    this->queue.submit([&](sycl::handler& cgh) {
-      cgh.parallel_for(rng, [=](sycl::nd_item<1> item) {
-        const auto ltsFace = item.get_group().get_group_id(0);
-        const auto pointIndex = item.get_local_id(0);
-
-        stateVariable[ltsFace][pointIndex] = stateVariableBuffer[ltsFace][pointIndex];
-      });
-    });
+    stateVariable[ctx.ltsFace][ctx.pointIndex] = ctx.stateVariableBuffer;
   }
 
-  void executeIfNotConverged() {}
+  static void executeIfNotConverged() {}
 };
 } // namespace seissol::dr::friction_law::gpu
 

--- a/src/DynamicRupture/FrictionLaws/GpuImpl/ThermalPressurization/NoTP.h
+++ b/src/DynamicRupture/FrictionLaws/GpuImpl/ThermalPressurization/NoTP.h
@@ -9,25 +9,22 @@
 #define SEISSOL_SRC_DYNAMICRUPTURE_FRICTIONLAWS_GPUIMPL_THERMALPRESSURIZATION_NOTP_H_
 
 #include "DynamicRupture/FrictionLaws/FrictionSolver.h"
+#include <DynamicRupture/FrictionLaws/GpuImpl/BaseFrictionSolver.h>
+#include <DynamicRupture/FrictionLaws/GpuImpl/FrictionSolverInterface.h>
 
 namespace seissol::dr::friction_law::gpu {
 class NoTP {
   public:
   NoTP(seissol::initializer::parameters::DRParameters* drParameters) {};
 
-  void copyLtsTreeToLocal(seissol::initializer::Layer& layerData,
-                          const seissol::initializer::DynamicRupture* const dynRup,
-                          real fullUpdateTime) {}
+  static void copyLtsTreeToLocal(FrictionLawData* data,
+                                 seissol::initializer::Layer& layerData,
+                                 const seissol::initializer::DynamicRupture* const dynRup,
+                                 real fullUpdateTime) {}
 
-  void calcFluidPressure(real (*normalStress)[misc::NumPaddedPoints],
-                         real (*mu)[misc::NumPaddedPoints],
-                         real (*slipRateMagnitude)[misc::NumPaddedPoints],
-                         real deltaT,
-                         bool saveTmpInTP) {}
+  static void calcFluidPressure(FrictionLawContext& ctx, bool saveTmpInTP) {}
 
-  struct Details {};
-  Details getCurrentLayerDetails() { return Details{}; }
-  static real getFluidPressure(Details, unsigned, unsigned) { return static_cast<real>(0.0); };
+  static real getFluidPressure(FrictionLawContext& /*unused*/) { return static_cast<real>(0.0); };
 };
 
 } // namespace seissol::dr::friction_law::gpu

--- a/src/DynamicRupture/FrictionLaws/ImposedSlipRates.h
+++ b/src/DynamicRupture/FrictionLaws/ImposedSlipRates.h
@@ -29,8 +29,8 @@ class ImposedSlipRates : public BaseFrictionLaw<ImposedSlipRates<STF>> {
     stf.copyLtsTreeToLocal(layerData, dynRup, fullUpdateTime);
   }
 
-  void updateFrictionAndSlip(const FaultStresses& faultStresses,
-                             TractionResults& tractionResults,
+  void updateFrictionAndSlip(const FaultStresses<Executor::Host>& faultStresses,
+                             TractionResults<Executor::Host>& tractionResults,
                              std::array<real, misc::NumPaddedPoints>& stateVariableBuffer,
                              std::array<real, misc::NumPaddedPoints>& strengthBuffer,
                              unsigned ltsFace,

--- a/src/DynamicRupture/FrictionLaws/LinearSlipWeakening.h
+++ b/src/DynamicRupture/FrictionLaws/LinearSlipWeakening.h
@@ -25,8 +25,8 @@ class LinearSlipWeakeningLaw : public BaseFrictionLaw<LinearSlipWeakeningLaw<Spe
       : BaseFrictionLaw<LinearSlipWeakeningLaw<SpecializationT>>(drParameters),
         specialization(drParameters) {}
 
-  void updateFrictionAndSlip(const FaultStresses& faultStresses,
-                             TractionResults& tractionResults,
+  void updateFrictionAndSlip(const FaultStresses<Executor::Host>& faultStresses,
+                             TractionResults<Executor::Host>& tractionResults,
                              std::array<real, misc::NumPaddedPoints>& stateVariableBuffer,
                              std::array<real, misc::NumPaddedPoints>& strengthBuffer,
                              unsigned int ltsFace,
@@ -63,8 +63,8 @@ class LinearSlipWeakeningLaw : public BaseFrictionLaw<LinearSlipWeakeningLaw<Spe
    *  compute the slip rate and the traction from the fault strength and fault stresses
    *  also updates the directional slip1 and slip2
    */
-  void calcSlipRateAndTraction(const FaultStresses& faultStresses,
-                               TractionResults& tractionResults,
+  void calcSlipRateAndTraction(const FaultStresses<Executor::Host>& faultStresses,
+                               TractionResults<Executor::Host>& tractionResults,
                                std::array<real, misc::NumPaddedPoints>& strength,
                                unsigned int timeIndex,
                                unsigned int ltsFace) {
@@ -147,7 +147,7 @@ class LinearSlipWeakeningLaw : public BaseFrictionLaw<LinearSlipWeakeningLaw<Spe
     }
   }
 
-  void calcStrengthHook(const FaultStresses& faultStresses,
+  void calcStrengthHook(const FaultStresses<Executor::Host>& faultStresses,
                         std::array<real, misc::NumPaddedPoints>& strength,
                         unsigned int timeIndex,
                         unsigned int ltsFace) {

--- a/src/DynamicRupture/FrictionLaws/NoFault.cpp
+++ b/src/DynamicRupture/FrictionLaws/NoFault.cpp
@@ -12,8 +12,8 @@
 #include <array>
 
 namespace seissol::dr::friction_law {
-void NoFault::updateFrictionAndSlip(const FaultStresses& faultStresses,
-                                    TractionResults& tractionResults,
+void NoFault::updateFrictionAndSlip(const FaultStresses<Executor::Host>& faultStresses,
+                                    TractionResults<Executor::Host>& tractionResults,
                                     std::array<real, misc::NumPaddedPoints>& stateVariableBuffer,
                                     std::array<real, misc::NumPaddedPoints>& strengthBuffer,
                                     unsigned ltsFace,

--- a/src/DynamicRupture/FrictionLaws/NoFault.cpp
+++ b/src/DynamicRupture/FrictionLaws/NoFault.cpp
@@ -6,6 +6,7 @@
 // SPDX-FileContributor: Author lists in /AUTHORS and /CITATION.cff
 
 #include "NoFault.h"
+#include "Common/Executor.h"
 #include "DynamicRupture/Misc.h"
 #include "DynamicRupture/Typedefs.h"
 #include "Kernels/Precision.h"

--- a/src/DynamicRupture/FrictionLaws/NoFault.h
+++ b/src/DynamicRupture/FrictionLaws/NoFault.h
@@ -22,8 +22,8 @@ class NoFault : public BaseFrictionLaw<NoFault> {
                           const seissol::initializer::DynamicRupture* const dynRup,
                           real fullUpdateTime) {}
 
-  static void updateFrictionAndSlip(const FaultStresses& faultStresses,
-                                    TractionResults& tractionResults,
+  static void updateFrictionAndSlip(const FaultStresses<Executor::Host>& faultStresses,
+                                    TractionResults<Executor::Host>& tractionResults,
                                     std::array<real, misc::NumPaddedPoints>& stateVariableBuffer,
                                     std::array<real, misc::NumPaddedPoints>& strengthBuffer,
                                     unsigned ltsFace,

--- a/src/DynamicRupture/FrictionLaws/RateAndState.h
+++ b/src/DynamicRupture/FrictionLaws/RateAndState.h
@@ -23,8 +23,8 @@ class RateAndStateBase : public BaseFrictionLaw<RateAndStateBase<Derived, TPMeth
       : BaseFrictionLaw<RateAndStateBase<Derived, TPMethod>>::BaseFrictionLaw(drParameters),
         tpMethod(TPMethod(drParameters)) {}
 
-  void updateFrictionAndSlip(const FaultStresses& faultStresses,
-                             TractionResults& tractionResults,
+  void updateFrictionAndSlip(const FaultStresses<Executor::Host>& faultStresses,
+                             TractionResults<Executor::Host>& tractionResults,
                              std::array<real, misc::NumPaddedPoints>& stateVariableBuffer,
                              std::array<real, misc::NumPaddedPoints>& strengthBuffer,
                              unsigned ltsFace,
@@ -111,7 +111,7 @@ class RateAndStateBase : public BaseFrictionLaw<RateAndStateBase<Derived, TPMeth
    * variable. Also sets slipRateMagnitude member to reference value.
    */
   InitialVariables
-      calcInitialVariables(const FaultStresses& faultStresses,
+      calcInitialVariables(const FaultStresses<Executor::Host>& faultStresses,
                            const std::array<real, misc::NumPaddedPoints>& localStateVariable,
                            unsigned int timeIndex,
                            unsigned int ltsFace) {
@@ -151,7 +151,7 @@ class RateAndStateBase : public BaseFrictionLaw<RateAndStateBase<Derived, TPMeth
       std::array<real, misc::NumPaddedPoints>& localStateVariable,
       std::array<real, misc::NumPaddedPoints>& normalStress,
       const std::array<real, misc::NumPaddedPoints>& absoluteShearStress,
-      const FaultStresses& faultStresses,
+      const FaultStresses<Executor::Host>& faultStresses,
       unsigned int timeIndex,
       unsigned int ltsFace) {
     std::array<real, misc::NumPaddedPoints> testSlipRate{0};
@@ -207,8 +207,8 @@ class RateAndStateBase : public BaseFrictionLaw<RateAndStateBase<Derived, TPMeth
                                std::array<real, misc::NumPaddedPoints>& localStateVariable,
                                const std::array<real, misc::NumPaddedPoints>& normalStress,
                                const std::array<real, misc::NumPaddedPoints>& absoluteTraction,
-                               const FaultStresses& faultStresses,
-                               TractionResults& tractionResults,
+                               const FaultStresses<Executor::Host>& faultStresses,
+                               TractionResults<Executor::Host>& tractionResults,
                                unsigned int timeIndex,
                                unsigned int ltsFace) {
 #pragma omp simd
@@ -346,7 +346,7 @@ class RateAndStateBase : public BaseFrictionLaw<RateAndStateBase<Derived, TPMeth
   }
 
   void updateNormalStress(std::array<real, misc::NumPaddedPoints>& normalStress,
-                          const FaultStresses& faultStresses,
+                          const FaultStresses<Executor::Host>& faultStresses,
                           size_t timeIndex,
                           size_t ltsFace) {
     // Todo(SW): consider poroelastic materials together with thermal pressurisation

--- a/src/DynamicRupture/Typedefs.h
+++ b/src/DynamicRupture/Typedefs.h
@@ -11,6 +11,7 @@
 #include "Common/Constants.h"
 #include "DynamicRupture/Misc.h"
 #include "Kernels/Precision.h"
+#include <Common/Executor.h>
 
 namespace seissol::dr {
 
@@ -32,12 +33,19 @@ struct ImpedanceMatrices {
   alignas(Alignment) real eta[tensor::eta::size()] = {};
 };
 
+template <Executor Executor>
+struct FaultStresses;
+
+template <Executor Executor>
+struct TractionResults;
+
 /**
  * Struct that contains all input stresses
  * normalStress in direction of the face normal, traction1, traction2 in the direction of the
  * respective tangential vectors
  */
-struct FaultStresses {
+template <>
+struct FaultStresses<Executor::Host> {
   alignas(Alignment) real normalStress[ConvergenceOrder][misc::NumPaddedPoints] = {{}};
   alignas(Alignment) real traction1[ConvergenceOrder][misc::NumPaddedPoints] = {{}};
   alignas(Alignment) real traction2[ConvergenceOrder][misc::NumPaddedPoints] = {{}};
@@ -48,9 +56,33 @@ struct FaultStresses {
  * Struct that contains all traction results
  * traction1, traction2 in the direction of the respective tangential vectors
  */
-struct TractionResults {
+template <>
+struct TractionResults<Executor::Host> {
   alignas(Alignment) real traction1[ConvergenceOrder][misc::NumPaddedPoints] = {{}};
   alignas(Alignment) real traction2[ConvergenceOrder][misc::NumPaddedPoints] = {{}};
+};
+
+/**
+ * Struct that contains all input stresses
+ * normalStress in direction of the face normal, traction1, traction2 in the direction of the
+ * respective tangential vectors
+ */
+template <>
+struct FaultStresses<Executor::Device> {
+  real normalStress[ConvergenceOrder] = {{}};
+  real traction1[ConvergenceOrder] = {{}};
+  real traction2[ConvergenceOrder] = {{}};
+  real fluidPressure[ConvergenceOrder] = {{}};
+};
+
+/**
+ * Struct that contains all traction results
+ * traction1, traction2 in the direction of the respective tangential vectors
+ */
+template <>
+struct TractionResults<Executor::Device> {
+  real traction1[ConvergenceOrder] = {{}};
+  real traction2[ConvergenceOrder] = {{}};
 };
 
 } // namespace seissol::dr

--- a/src/tests/DynamicRupture/FrictionLaws/FrictionSolverCommon.t.h
+++ b/src/tests/DynamicRupture/FrictionLaws/FrictionSolverCommon.t.h
@@ -19,8 +19,8 @@ using namespace seissol;
 using namespace seissol::dr;
 
 TEST_CASE("Friction Solver Common") {
-  FaultStresses faultStresses{};
-  TractionResults tractionResults{};
+  FaultStresses<Executor::Host> faultStresses{};
+  TractionResults<Executor::Host> tractionResults{};
   ImpedancesAndEta impAndEta;
   alignas(Alignment) real qInterpolatedPlus[ConvergenceOrder][tensor::QInterpolated::size()] = {{}};
   alignas(Alignment)


### PR DESCRIPTION
Merge all DR kernels on the GPU; thus reducing the amount of temporary memory needed and reducing the launch overhead. Also, we're able to keep more temporary variables in registers.

Preliminary tests for LSW (precomputed-seissol/tpv5, on my laptop; RTX 3070 mobile—there's probably similar behavior on at least all gaming cards) show a speedup of around 2× for the LSW DR kernels. The R+S kernels show less speedup (however: maybe that's due to the FP64 performance of the card used), most show ~no speedup at all~ [correction: they also seem to show something about 1.2-1.3×]; but FVW has something around 1.3×.

Tested with precomputed-seissol; there tpv5, tpv6, tpv101, tpv101-slip, tpv104 by comparing the energy values.

EDIT: now also pre-computed some values in the R+S fixed-point iteration that don't change (but involve e.g. a `log` operation). That sped up R+S SVW quite a bit. Together with the kernel fusion, it now gives us a 2× speedup for the DR kernel on the precomputed tpv101/tpv101-slip, on my local card at least (the advantage will have more effect for longer fixed-point iterations).
