### PR TITLE
Refactor model info printing a tiny bit

### DIFF
--- a/src/DynamicRupture/Initializer/BaseDRInitializer.cpp
+++ b/src/DynamicRupture/Initializer/BaseDRInitializer.cpp
@@ -146,8 +146,8 @@ std::vector<unsigned> BaseDRInitializer::getFaceIDsInIterator(
 void BaseDRInitializer::queryModel(seissol::initializer::FaultParameterDB& faultParameterDB,
                                    const std::vector<unsigned>& faceIDs) {
   // create a query and evaluate the model
-  seissol::initializer::FaultGPGenerator queryGen(seissolInstance.meshReader(), faceIDs);
-  faultParameterDB.evaluateModel(drParameters->faultFileName, &queryGen);
+  const seissol::initializer::FaultGPGenerator queryGen(seissolInstance.meshReader(), faceIDs);
+  faultParameterDB.evaluateModel(drParameters->faultFileName, queryGen);
 }
 
 void BaseDRInitializer::rotateTractionToCartesianStress(

--- a/src/Initializer/InitProcedure/InitModel.cpp
+++ b/src/Initializer/InitProcedure/InitModel.cpp
@@ -15,11 +15,13 @@
 #include "Initializer/Tree/LTSTree.h"
 #include "Initializer/Tree/Lut.h"
 #include "Initializer/Typedefs.h"
+#include <Common/Constants.h>
 #include <Initializer/BasicTypedefs.h>
 #include <Initializer/MemoryManager.h>
 #include <Initializer/Parameters/ModelParameters.h>
 #include <Initializer/Tree/Layer.h>
 #include <Kernels/Common.h>
+#include <Kernels/Precision.h>
 #include <Model/CommonDatastructures.h>
 #include <Model/Plasticity.h>
 #include <Modules/Modules.h>
@@ -29,6 +31,7 @@
 #include <array>
 #include <cassert>
 #include <cstddef>
+#include <memory>
 #include <string>
 #include <unordered_map>
 #include <utils/env.h>
@@ -55,13 +58,13 @@ using MaterialT = seissol::model::MaterialT;
 using Plasticity = seissol::model::Plasticity;
 
 template <typename T>
-std::vector<T> queryDB(seissol::initializer::QueryGenerator* queryGen,
+std::vector<T> queryDB(const std::shared_ptr<seissol::initializer::QueryGenerator>& queryGen,
                        const std::string& fileName,
                        size_t size) {
   std::vector<T> vectorDB(size);
   seissol::initializer::MaterialParameterDB<T> parameterDB;
   parameterDB.setMaterialVector(&vectorDB);
-  parameterDB.evaluateModel(fileName, queryGen);
+  parameterDB.evaluateModel(fileName, *queryGen);
   return vectorDB;
 }
 
@@ -91,18 +94,13 @@ void initializeCellMaterial(seissol::SeisSol& seissolInstance) {
   }
 
   // just a helper function for better readability
-  auto getBestQueryGenerator = [&](const seissol::initializer::CellToVertexArray& ctvArray) {
+  const auto getBestQueryGenerator = [&](const seissol::initializer::CellToVertexArray& ctvArray) {
     return seissol::initializer::getBestQueryGenerator(
-        seissol::initializer::parameters::isModelAnelastic(),
-        seissolParams.model.plasticity,
-        seissol::initializer::parameters::isModelAnisotropic(),
-        seissol::initializer::parameters::isModelPoroelastic(),
-        seissolParams.model.useCellHomogenizedMaterial,
-        ctvArray);
+        seissolParams.model.plasticity, seissolParams.model.useCellHomogenizedMaterial, ctvArray);
   };
 
   // material retrieval for copy+interior layers
-  seissol::initializer::QueryGenerator* queryGen =
+  const auto queryGen =
       getBestQueryGenerator(seissol::initializer::CellToVertexArray::fromMeshReader(meshReader));
   auto materialsDB = queryDB<MaterialT>(
       queryGen, seissolParams.model.materialFileName, meshReader.getElements().size());
@@ -116,7 +114,7 @@ void initializeCellMaterial(seissol::SeisSol& seissolInstance) {
   }
 
   // material retrieval for ghost layers
-  seissol::initializer::QueryGenerator* queryGenGhost = getBestQueryGenerator(
+  auto queryGenGhost = getBestQueryGenerator(
       seissol::initializer::CellToVertexArray::fromVectors(ghostVertices, ghostGroups));
   auto materialsDBGhost =
       queryDB<MaterialT>(queryGenGhost, seissolParams.model.materialFileName, ghostVertices.size());
@@ -401,6 +399,17 @@ void seissol::initializer::initprocedure::initModel(seissol::SeisSol& seissolIns
   LtsInfo ltsInfo;
 
   // these four methods need to be called in this order.
+  logInfo() << "Model info:";
+  logInfo() << "Material:" << MaterialT::Text.c_str();
+  logInfo() << "Order:" << ConvergenceOrder;
+  logInfo() << "Precision:" << (sizeof(real) == 4 ? "single (f32)" : "double (f64)");
+  logInfo() << "Plasticity:"
+            << (seissolInstance.getSeisSolParameters().model.plasticity ? "on" : "off");
+  logInfo() << "Flux:"
+            << parameters::fluxToString(seissolInstance.getSeisSolParameters().model.flux).c_str();
+  logInfo() << "Flux near fault:"
+            << parameters::fluxToString(seissolInstance.getSeisSolParameters().model.fluxNearFault)
+                   .c_str();
 
   // init LTS
   logInfo() << "Initialize LTS.";

--- a/src/Initializer/Parameters/LtsParameters.cpp
+++ b/src/Initializer/Parameters/LtsParameters.cpp
@@ -7,7 +7,9 @@
 
 #include "LtsParameters.h"
 
+#include <Equations/Datastructures.h>
 #include <Initializer/Parameters/ParameterReader.h>
+#include <Model/CommonDatastructures.h>
 #include <algorithm>
 #include <cassert>
 #include <cmath>
@@ -17,8 +19,6 @@
 #include <stdexcept>
 #include <string>
 #include <utils/logger.h>
-
-#include "ModelParameters.h"
 
 namespace seissol::initializer::parameters {
 
@@ -153,11 +153,13 @@ TimeSteppingParameters readTimeSteppingParameters(ParameterReader* baseReader) {
   const double cfl = reader->readWithDefault("cfl", 0.5);
   double maxTimestepWidth = std::numeric_limits<double>::max();
 
-  if constexpr (isModelViscoelastic()) {
+  constexpr auto IsViscoelastic =
+      seissol::model::MaterialT::Type == seissol::model::MaterialType::Viscoelastic;
+
+  if constexpr (IsViscoelastic) {
     auto* modelReader = baseReader->readSubNode("equations");
-    const auto freqCentral =
-        modelReader->readIfRequired<double>("freqcentral", isModelViscoelastic());
-    const auto freqRatio = modelReader->readIfRequired<double>("freqratio", isModelViscoelastic());
+    const auto freqCentral = modelReader->readIfRequired<double>("freqcentral", IsViscoelastic);
+    const auto freqRatio = modelReader->readIfRequired<double>("freqratio", IsViscoelastic);
     const double maxTimestepWidthDefault = 0.25 / (freqCentral * std::sqrt(freqRatio));
     maxTimestepWidth = reader->readWithDefault("fixtimestep", maxTimestepWidthDefault);
     if (maxTimestepWidth > maxTimestepWidthDefault) {

--- a/src/Initializer/Parameters/ModelParameters.h
+++ b/src/Initializer/Parameters/ModelParameters.h
@@ -14,40 +14,6 @@
 
 namespace seissol::initializer::parameters {
 
-constexpr bool isModelAnelastic() { return NUMBER_OF_RELAXATION_MECHANISMS > 0; }
-
-constexpr bool isModelElastic() {
-#ifdef USE_ELASTIC
-  return true;
-#else
-  return false;
-#endif
-}
-
-constexpr bool isModelViscoelastic() {
-#if defined(USE_VISCOELASTIC) || defined(USE_VISCOELASTIC2)
-  return true;
-#else
-  return false;
-#endif
-}
-
-constexpr bool isModelPoroelastic() {
-#ifdef USE_POROELASTIC
-  return true;
-#else
-  return false;
-#endif
-}
-
-constexpr bool isModelAnisotropic() {
-#ifdef USE_ANISOTROPIC
-  return true;
-#else
-  return false;
-#endif
-}
-
 enum class ReflectionType { BothWaves = 1, BothWavesVelocity, Pwave, Swave };
 
 struct ITMParameters {
@@ -59,6 +25,8 @@ struct ITMParameters {
 };
 
 enum class NumericalFlux { Godunov, Rusanov };
+
+std::string fluxToString(NumericalFlux flux);
 
 struct ModelParameters {
   bool hasBoundaryFile;

--- a/src/Initializer/Parameters/SeisSolParameters.cpp
+++ b/src/Initializer/Parameters/SeisSolParameters.cpp
@@ -51,16 +51,6 @@ SeisSolParameters readSeisSolParameters(ParameterReader* parameterReader) {
 
   logInfo() << "SeisSol parameter file read successfully.";
 
-  auto printYesNo = [](bool yesno) { return yesno ? "yes" : "no"; };
-
-  logInfo() << "Model information:";
-  logInfo() << "Elastic model:" << printYesNo(isModelElastic());
-  logInfo() << "Viscoelastic model:" << printYesNo(isModelViscoelastic());
-  logInfo() << "Anelastic model:" << printYesNo(isModelAnelastic());
-  logInfo() << "Poroelastic model:" << printYesNo(isModelPoroelastic());
-  logInfo() << "Anisotropic model:" << printYesNo(isModelAnisotropic());
-  logInfo() << "Plasticity:" << printYesNo(modelParameters.plasticity);
-
   return SeisSolParameters{cubeGeneratorParameters,
                            drParameters,
                            initializationParameters,

--- a/src/Initializer/TimeStepping/GlobalTimestep.cpp
+++ b/src/Initializer/TimeStepping/GlobalTimestep.cpp
@@ -59,17 +59,12 @@ GlobalTimestep
                      const seissol::initializer::parameters::SeisSolParameters& seissolParams) {
   using Material = seissol::model::MaterialT;
 
-  auto* queryGen = seissol::initializer::getBestQueryGenerator(
-      seissol::initializer::parameters::isModelAnelastic(),
-      seissolParams.model.plasticity,
-      seissol::initializer::parameters::isModelAnisotropic(),
-      seissol::initializer::parameters::isModelPoroelastic(),
-      seissolParams.model.useCellHomogenizedMaterial,
-      cellToVertex);
+  const auto queryGen = seissol::initializer::getBestQueryGenerator(
+      seissolParams.model.plasticity, seissolParams.model.useCellHomogenizedMaterial, cellToVertex);
   std::vector<Material> materials(cellToVertex.size);
   seissol::initializer::MaterialParameterDB<Material> parameterDB;
   parameterDB.setMaterialVector(&materials);
-  parameterDB.evaluateModel(velocityModel, queryGen);
+  parameterDB.evaluateModel(velocityModel, *queryGen);
 
   GlobalTimestep timestep;
   timestep.cellTimeStepWidths.resize(cellToVertex.size);

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -26,7 +26,6 @@
 #include "Initializer/Parameters/SeisSolParameters.h"
 #include "SeisSol.h"
 
-#include "Common/Constants.h"
 #include "Parallel/MPI.h"
 
 #ifdef USE_ASAGI
@@ -109,7 +108,6 @@ int main(int argc, char* argv[]) {
   logInfo() << "Copyright (c) 2012 -" << COMMIT_YEAR << " SeisSol Group";
   logInfo() << "Version:" << VERSION_STRING;
   logInfo() << "Built on:" << __DATE__ << __TIME__;
-  logInfo() << "Built with Convergence Order:" << ConvergenceOrder;
 #ifdef COMMIT_HASH
   logInfo() << "Last commit:" << COMMIT_HASH << "at" << COMMIT_TIMESTAMP;
 #endif


### PR DESCRIPTION
That is:

* print the precision built with
* print the flux used for the run
* remove the old yes/no model printing inherited from the FORTRAN code, and replace it by checking `MaterialT::Text` instead
