### PR TITLE
Merge the two graphs in the predictor into one

### DIFF
--- a/src/Initializer/BasicTypedefs.h
+++ b/src/Initializer/BasicTypedefs.h
@@ -63,8 +63,7 @@ constexpr bool isExternalBoundaryFaceType(FaceType faceType) {
 }
 
 enum class ComputeGraphType {
-  LocalIntegral = 0,
-  AccumulatedVelocities,
+  AccumulatedVelocities = 0,
   StreamedVelocities,
   NeighborIntegral,
   DynamicRuptureInterface,

--- a/src/Proxy/KernelDevice.cpp
+++ b/src/Proxy/KernelDevice.cpp
@@ -32,7 +32,7 @@ void ProxyKernelDeviceAder::run(ProxyData& data,
   auto& materialTable = layer.getConditionalTable<inner_keys::Material>();
 
   const double timeStepWidth = static_cast<double>(Timestep);
-  ComputeGraphType graphType{ComputeGraphType::LocalIntegral};
+  ComputeGraphType graphType{ComputeGraphType::AccumulatedVelocities};
   auto computeGraphKey = initializer::GraphKey(graphType, timeStepWidth, false);
 
   runtime.runGraph(computeGraphKey, layer, [&](auto& runtime) {
@@ -53,7 +53,7 @@ void ProxyKernelDeviceLocalWOAder::run(ProxyData& data,
   auto& indicesTable = layer.getConditionalTable<inner_keys::Indices>();
 
   const double timeStepWidth = 0.0;
-  ComputeGraphType graphType{ComputeGraphType::LocalIntegral};
+  ComputeGraphType graphType{ComputeGraphType::AccumulatedVelocities};
   auto computeGraphKey = initializer::GraphKey(graphType, timeStepWidth, false);
 
   runtime.runGraph(computeGraphKey, layer, [&](auto& runtime) {
@@ -75,7 +75,7 @@ void ProxyKernelDeviceLocal::run(ProxyData& data,
   auto& indicesTable = layer.getConditionalTable<inner_keys::Indices>();
 
   const double timeStepWidth = static_cast<double>(Timestep);
-  ComputeGraphType graphType{ComputeGraphType::LocalIntegral};
+  ComputeGraphType graphType{ComputeGraphType::AccumulatedVelocities};
   auto computeGraphKey = initializer::GraphKey(graphType, timeStepWidth, false);
   runtime.runGraph(computeGraphKey, layer, [&](auto& runtime) {
     data.timeKernel.computeBatchedAder(


### PR DESCRIPTION
Currently, the predictor consists of two graphs; a large one and a short one, with a potential boundary application in between. However, both of them can be merged by moving the boundary application onto the GPU as well (which has been done by #1016 ).
