### PR TITLE
Disable the volume output by default

### DIFF
--- a/src/Initializer/Parameters/ParameterReader.h
+++ b/src/Initializer/Parameters/ParameterReader.h
@@ -8,6 +8,7 @@
 #ifndef SEISSOL_SRC_INITIALIZER_PARAMETERS_PARAMETERREADER_H_
 #define SEISSOL_SRC_INITIALIZER_PARAMETERS_PARAMETERREADER_H_
 
+#include <optional>
 #include <string>
 #include <unordered_set>
 


### PR DESCRIPTION
Other than that, nothing should change.

I.e. now we check:

* `output/wavefieldoutput` exists -> use its value (ignore `output/format`)
* if not, and `output/format` exists -> use its value, and warn that it's deprecated
* otherwise, the volume output is off.

(before, it was: `output/wavefieldoutput` and `output/format` both need to be enabled; while the former was enabled by default, and the latter disabled)
