### PR TITLE
Enforce more Godunov boundaries (when Rusanov is chosen)

### DIFF
--- a/src/Initializer/CellLocalMatrices.cpp
+++ b/src/Initializer/CellLocalMatrices.cpp
@@ -12,6 +12,7 @@
 #include <Initializer/BasicTypedefs.h>
 #include <cassert>
 
+#include "BasicTypedefs.h"
 #include "Initializer/MemoryManager.h"
 #include "Initializer/ParameterDB.h"
 #include "Parameters/ModelParameters.h"
@@ -203,12 +204,17 @@ void seissol::initializer::initializeCellLocalMatrices( seissol::geometry::MeshR
         static const std::vector<FaceType> GodunovBoundaryConditions = {
           FaceType::FreeSurface,
           FaceType::FreeSurfaceGravity,
-          FaceType::Analytical
+          FaceType::Analytical,
+          FaceType::Outflow
         };
 
-        const auto enforceGodunov
+        const auto enforceGodunovBc
           = std::any_of(GodunovBoundaryConditions.begin(), GodunovBoundaryConditions.end(),
               [&](auto condition) {return condition == cellInformation[cell].faceTypes[side];});
+
+        const auto enforceGodunovEa = isAtElasticAcousticInterface(material[cell], side);
+
+        const auto enforceGodunov = enforceGodunovBc || enforceGodunovEa;
 
         const auto flux = enforceGodunov ? parameters::NumericalFlux::Godunov : fluxDefault;
 


### PR DESCRIPTION
Enforce Godunov boundaries at:

* elastic-acoustic boundaries
* outflow boundaries

(not 100%ly sure if the latter is really necessary)
