### PR TITLE
Make the whole repository adhere to the REUSE spec for licensing metadata (sort of)

### DIFF
--- a/.github/workflows/reuse.yml
+++ b/.github/workflows/reuse.yml
@@ -1,0 +1,28 @@
+# SPDX-FileCopyrightText: 2025 SeisSol Group
+# 
+# SPDX-License-Identifier: BSD-3-Clause
+
+name: reuse
+on:
+  - push
+
+jobs:
+  reuse:
+    name: reuse
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: apt-get
+        run: |
+          sudo apt-get update
+          sudo apt-get -y install python3 python3-pip
+
+          # fix version here for now
+          pip3 install --break-system-packages reuse==5.0.2
+
+      - name: run-reuse-lint
+        run: |
+          set -euo pipefail
+          
+          reuse lint

--- a/postprocessing/REUSE.toml
+++ b/postprocessing/REUSE.toml
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: 2025 SeisSol Group
+# 
+# SPDX-License-Identifier: BSD-3-Clause
+# SPDX-LicenseComments: Full text under /LICENSE and /LICENSES/
+#
+# SPDX-FileContributor: Author lists in /AUTHORS and /CITATION.cff
+
+version = 1
+
+[[annotations]]
+path = ["**/*"]
+SPDX-FileCopyrightText = "2012-2025 SeisSol Group"
+SPDX-License-Identifier = "BSD-3-Clause"

--- a/postprocessing/science/Calc_CohesiveZoneError.py
+++ b/postprocessing/science/Calc_CohesiveZoneError.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: BSD-3-Clause
 ##
 # @file
 # This file is part of SeisSol.

--- a/postprocessing/science/Compute_order.m
+++ b/postprocessing/science/Compute_order.m
@@ -1,6 +1,7 @@
 %%
 % @file
 % This file is part of SeisSol.
+% SPDX-License-Identifier: BSD-3-Clause
 %
 % @author Martin Kaeser (martin.kaeser AT geophysik.uni-muenchen.de, http://www.geophysik.uni-muenchen.de/Members/kaeser)
 %

--- a/postprocessing/science/GroundMotionParametersMaps/ComputeGroundMotionParametersFromSurfaceOutput_Hybrid.py
+++ b/postprocessing/science/GroundMotionParametersMaps/ComputeGroundMotionParametersFromSurfaceOutput_Hybrid.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: BSD-3-Clause
 ##
 # @file
 # This file is part of SeisSol.

--- a/postprocessing/science/Read_faultreceiver.m
+++ b/postprocessing/science/Read_faultreceiver.m
@@ -1,6 +1,7 @@
 %%
 % @file
 % This file is part of SeisSol.
+% SPDX-License-Identifier: BSD-3-Clause
 %
 % @author Martin Kaeser (martin.kaeser AT geophysik.uni-muenchen.de, http://www.geophysik.uni-muenchen.de/Members/kaeser)
 % @author Christian Pelties (pelties AT geophysik.uni-muenchen.de, http://www.geophysik.uni-muenchen.de/Members/pelties)

--- a/postprocessing/science/Reformat_ADERDG_Seismograms.m
+++ b/postprocessing/science/Reformat_ADERDG_Seismograms.m
@@ -1,6 +1,7 @@
 %%
 % @file
 % This file is part of SeisSol.
+% SPDX-License-Identifier: BSD-3-Clause
 %
 % @author Martin Kaeser (martin.kaeser AT geophysik.uni-muenchen.de, http://www.geophysik.uni-muenchen.de/Members/kaeser)
 %

--- a/postprocessing/science/Restart_fix.m
+++ b/postprocessing/science/Restart_fix.m
@@ -1,6 +1,7 @@
 %%
 % @file
 % This file is part of SeisSol.
+% SPDX-License-Identifier: BSD-3-Clause
 %
 % @author Martin Kaeser (martin.kaeser AT geophysik.uni-muenchen.de, http://www.geophysik.uni-muenchen.de/Members/kaeser)
 %

--- a/postprocessing/science/SlipRate.m
+++ b/postprocessing/science/SlipRate.m
@@ -1,6 +1,7 @@
 %%
 % @file
 % This file is part of SeisSol.
+% SPDX-License-Identifier: BSD-3-Clause
 %
 % @author Josep de la Puente Alvarez (josep.delapuente AT bsc.es, http://www.geophysik.uni-muenchen.de/Members/jdelapuente)
 %

--- a/postprocessing/science/analyse_results.awk
+++ b/postprocessing/science/analyse_results.awk
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: BSD-3-Clause
 ##
 # @file
 # This file is part of SeisSol.

--- a/postprocessing/science/bandpass_filter.m
+++ b/postprocessing/science/bandpass_filter.m
@@ -2,6 +2,7 @@ function s_filt = bandpass_filter(s,dt,cf_lowleft,cf_lowright,c_highcut,deg)
 %%
 % @file
 % This file is part of SeisSol.
+% SPDX-License-Identifier: BSD-3-Clause
 %
 % @section LICENSE
 % Copyright (c) SeisSol Group

--- a/postprocessing/science/decon_con.m
+++ b/postprocessing/science/decon_con.m
@@ -2,6 +2,7 @@ function signal2 = decon_con(wavelet1,signal1,wavelet2,dt,cf_left,cf_right)
 %%
 % @file
 % This file is part of SeisSol.
+% SPDX-License-Identifier: BSD-3-Clause
 %
 % @section LICENSE
 % Copyright (c) SeisSol Group

--- a/postprocessing/science/format_RF_contourplot.m
+++ b/postprocessing/science/format_RF_contourplot.m
@@ -1,6 +1,7 @@
 %%
 % @file
 % This file is part of SeisSol.
+% SPDX-License-Identifier: BSD-3-Clause
 %
 % @author Christian Pelties (pelties AT geophysik.uni-muenchen.de, http://www.geophysik.uni-muenchen.de/Members/pelties)
 %

--- a/postprocessing/science/highpass_filter.m
+++ b/postprocessing/science/highpass_filter.m
@@ -2,6 +2,7 @@ function s_filt = highpass_filter(s,dt,cf_left,cf_right)
 %%
 % @file
 % This file is part of SeisSol.
+% SPDX-License-Identifier: BSD-3-Clause
 %
 % @section LICENSE
 % Copyright (c) SeisSol Group

--- a/postprocessing/science/loaddatfile.m
+++ b/postprocessing/science/loaddatfile.m
@@ -2,6 +2,7 @@ function [data]=loaddatfile(name,headerlines)
 %%
 % @file
 % This file is part of SeisSol.
+% SPDX-License-Identifier: BSD-3-Clause
 %
 % @author Christian Pelties (pelties AT geophysik.uni-muenchen.de, http://www.geophysik.uni-muenchen.de/Members/pelties)
 %

--- a/postprocessing/science/loadmatfile.m
+++ b/postprocessing/science/loadmatfile.m
@@ -2,6 +2,7 @@ function [data]=loadmatfile(name)
 %%
 % @file
 % This file is part of SeisSol.
+% SPDX-License-Identifier: BSD-3-Clause
 %
 % @author Christian Pelties (pelties AT geophysik.uni-muenchen.de, http://www.geophysik.uni-muenchen.de/Members/pelties)
 %

--- a/postprocessing/science/lowpass_filter.m
+++ b/postprocessing/science/lowpass_filter.m
@@ -2,6 +2,7 @@ function s_filt = lowpass_filter(s,dt,cf_left,cf_right)
 %%
 % @file
 % This file is part of SeisSol.
+% SPDX-License-Identifier: BSD-3-Clause
 %
 % @section LICENSE
 % Copyright (c) SeisSol Group

--- a/postprocessing/science/pickpoint2netcdf/pickpoint2netcdf.m
+++ b/postprocessing/science/pickpoint2netcdf/pickpoint2netcdf.m
@@ -1,6 +1,7 @@
 %%
 % @file
 % This file is part of SeisSol.
+% SPDX-License-Identifier: BSD-3-Clause
 %
 % @author Martin Kaeser (martin.kaeser AT geophysik.uni-muenchen.de, http://www.geophysik.uni-muenchen.de/Members/kaeser)
 % @author Sebastian Rettenberger (rettenbs AT in.tum.de, http://www5.in.tum.de/wiki/index.php/Sebastian_Rettenberger,_M.Sc.)

--- a/postprocessing/science/read_EN.m
+++ b/postprocessing/science/read_EN.m
@@ -1,6 +1,7 @@
 %%
 % @file
 % This file is part of SeisSol.
+% SPDX-License-Identifier: BSD-3-Clause
 %
 % @author Stephanie Wollherr
 %

--- a/postprocessing/science/read_RF.m
+++ b/postprocessing/science/read_RF.m
@@ -2,6 +2,7 @@
 %%
 % @file
 % This file is part of SeisSol.
+% SPDX-License-Identifier: BSD-3-Clause
 %
 % @author Christian Pelties (pelties AT geophysik.uni-muenchen.de, http://www.geophysik.uni-muenchen.de/Members/pelties)
 %

--- a/postprocessing/science/seissol2d_read_fault.m
+++ b/postprocessing/science/seissol2d_read_fault.m
@@ -2,6 +2,7 @@ function data = seissol2d_read_fault_parallel(name,nCPU,sp_sample)
 %%
 % @file
 % This file is part of SeisSol.
+% SPDX-License-Identifier: BSD-3-Clause
 %
 % @author Christian Pelties (pelties AT geophysik.uni-muenchen.de, http://www.geophysik.uni-muenchen.de/Members/pelties)
 %

--- a/postprocessing/science/sfft.m
+++ b/postprocessing/science/sfft.m
@@ -2,6 +2,7 @@ function [am,f,ph] = sfft(y,dt,whole)
 %%
 % @file
 % This file is part of SeisSol.
+% SPDX-License-Identifier: BSD-3-Clause
 %
 % @author Martin Mai (Martin.Mai AT kaust.edu.sa, http://www.kaust.edu.sa/faculty/mai.html)
 %

--- a/postprocessing/science/sliprate2.m
+++ b/postprocessing/science/sliprate2.m
@@ -1,6 +1,7 @@
 %%
 % @file
 % This file is part of SeisSol.
+% SPDX-License-Identifier: BSD-3-Clause
 %
 % @author Josep de la Puente Alvarez (josep.delapuente AT bsc.es, http://www.geophysik.uni-muenchen.de/Members/jdelapuente)
 % @author Christian Pelties (pelties AT geophysik.uni-muenchen.de, http://www.geophysik.uni-muenchen.de/Members/pelties)

--- a/postprocessing/science/tfmisfit.m
+++ b/postprocessing/science/tfmisfit.m
@@ -2,6 +2,7 @@ function tfmisfit(file,file_ref,keep)
 %%
 % @file
 % This file is part of SeisSol.
+% SPDX-License-Identifier: BSD-3-Clause
 %
 % @author Christian Pelties (pelties AT geophysik.uni-muenchen.de, http://www.geophysik.uni-muenchen.de/Members/pelties)
 %

--- a/postprocessing/validation/XDMFCubeCheck/SConscript
+++ b/postprocessing/validation/XDMFCubeCheck/SConscript
@@ -1,4 +1,5 @@
 #! /usr/bin/python
+# SPDX-License-Identifier: BSD-3-Clause
 ##
 # @file
 # This file is part of SeisSol.

--- a/postprocessing/validation/XDMFCubeCheck/src/SConscript
+++ b/postprocessing/validation/XDMFCubeCheck/src/SConscript
@@ -1,4 +1,5 @@
 #! /usr/bin/python
+# SPDX-License-Identifier: BSD-3-Clause
 ##
 # @file
 # This file is part of SeisSol.

--- a/postprocessing/validation/XDMFCubeCheck/src/main.cpp
+++ b/postprocessing/validation/XDMFCubeCheck/src/main.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BSD-3-Clause
 /**
  * @file
  * This file is part of SeisSol.

--- a/postprocessing/visualization/receiver/bin/viewrec
+++ b/postprocessing/visualization/receiver/bin/viewrec
@@ -1,3 +1,7 @@
 #!/bin/bash
+# SPDX-FileCopyrightText: 2015 SeisSol Group
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
 DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 python3 $DIR/../src/viewrec.py

--- a/postprocessing/visualization/receiver/src/Filters.py
+++ b/postprocessing/visualization/receiver/src/Filters.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: BSD-3-Clause
 ##
 # @file
 # This file is part of SeisSol.

--- a/postprocessing/visualization/receiver/src/Navigation.py
+++ b/postprocessing/visualization/receiver/src/Navigation.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: BSD-3-Clause
 ##
 # @file
 # This file is part of SeisSol.

--- a/postprocessing/visualization/receiver/src/Tecplot.py
+++ b/postprocessing/visualization/receiver/src/Tecplot.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: BSD-3-Clause
 ##
 # @file
 # This file is part of SeisSol.

--- a/postprocessing/visualization/receiver/src/View.py
+++ b/postprocessing/visualization/receiver/src/View.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: BSD-3-Clause
 ##
 # @file
 # This file is part of SeisSol.

--- a/postprocessing/visualization/receiver/src/Watchdog.py
+++ b/postprocessing/visualization/receiver/src/Watchdog.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
+# SPDX-License-Identifier: BSD-3-Clause
 ##
 # @file
 # This file is part of SeisSol.

--- a/postprocessing/visualization/receiver/src/Waveform.py
+++ b/postprocessing/visualization/receiver/src/Waveform.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: BSD-3-Clause
 ##
 # @file
 # This file is part of SeisSol.

--- a/postprocessing/visualization/receiver/src/__init__.py
+++ b/postprocessing/visualization/receiver/src/__init__.py
@@ -1,1 +1,3 @@
-
+# SPDX-FileCopyrightText: 2015 SeisSol Group
+#
+# SPDX-License-Identifier: BSD-3-Clause

--- a/postprocessing/visualization/receiver/src/viewrec.py
+++ b/postprocessing/visualization/receiver/src/viewrec.py
@@ -1,4 +1,5 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
+# SPDX-License-Identifier: BSD-3-Clause
 ##
 # @file
 # This file is part of SeisSol.

--- a/postprocessing/visualization/tools/Create_movie.m
+++ b/postprocessing/visualization/tools/Create_movie.m
@@ -1,6 +1,7 @@
 %%
 % @file
 % This file is part of SeisSol.
+% SPDX-License-Identifier: BSD-3-Clause
 %
 % @author Martin Kaeser (martin.kaeser AT geophysik.uni-muenchen.de, http://www.geophysik.uni-muenchen.de/Members/kaeser)
 %

--- a/postprocessing/visualization/tools/Plot_seissol_snapshot.m
+++ b/postprocessing/visualization/tools/Plot_seissol_snapshot.m
@@ -1,6 +1,7 @@
 %%
 % @file
 % This file is part of SeisSol.
+% SPDX-License-Identifier: BSD-3-Clause
 %
 % @author Martin Kaeser (martin.kaeser AT geophysik.uni-muenchen.de, http://www.geophysik.uni-muenchen.de/Members/kaeser)
 %

--- a/postprocessing/visualization/tools/generate_rec_vtp.py
+++ b/postprocessing/visualization/tools/generate_rec_vtp.py
@@ -1,4 +1,5 @@
 #! /usr/bin/python
+# SPDX-License-Identifier: BSD-3-Clause
 ##
 # @file
 # This file is part of SeisSol.

--- a/postprocessing/visualization/tools/neu2vtk.py
+++ b/postprocessing/visualization/tools/neu2vtk.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# SPDX-License-Identifier: BSD-3-Clause
 ##
 # @file
 # This file is part of SeisSol.

--- a/postprocessing/visualization/tools/pickpoint2mseed.py
+++ b/postprocessing/visualization/tools/pickpoint2mseed.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# SPDX-License-Identifier: BSD-3-Clause
 ##
 # @file
 # This file is part of SeisSol.

--- a/postprocessing/visualization/tools/sismowine2receiver.py
+++ b/postprocessing/visualization/tools/sismowine2receiver.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# SPDX-License-Identifier: BSD-3-Clause
 ##
 # @file
 # This file is part of SeisSol.

--- a/postprocessing/visualization/tools/tecp2vtk.py
+++ b/postprocessing/visualization/tools/tecp2vtk.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# SPDX-License-Identifier: BSD-3-Clause
 ##
 # @file
 # This file is part of SeisSol.

--- a/postprocessing/visualization/tools/tecp2vtk_merge.py
+++ b/postprocessing/visualization/tools/tecp2vtk_merge.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# SPDX-License-Identifier: BSD-3-Clause
 ##
 # @file
 # This file is part of SeisSol.

--- a/postprocessing/visualization/tools/tecp2vtk_merge_loop.py
+++ b/postprocessing/visualization/tools/tecp2vtk_merge_loop.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# SPDX-License-Identifier: BSD-3-Clause
 ##
 # @file
 # This file is part of SeisSol.

--- a/postprocessing/visualization/tools/tecp2vtu.py
+++ b/postprocessing/visualization/tools/tecp2vtu.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# SPDX-License-Identifier: BSD-3-Clause
 ##
 # @file
 # This file is part of SeisSol.

--- a/postprocessing/visualization/tools/tecp2vtu_merge.py
+++ b/postprocessing/visualization/tools/tecp2vtu_merge.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# SPDX-License-Identifier: BSD-3-Clause
 ##
 # @file
 # This file is part of SeisSol.

--- a/postprocessing/visualization/tools/tecp2vtu_merge_loop.py
+++ b/postprocessing/visualization/tools/tecp2vtu_merge_loop.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# SPDX-License-Identifier: BSD-3-Clause
 ##
 # @file
 # This file is part of SeisSol.

--- a/postprocessing/visualization/tools/visz_fine.py
+++ b/postprocessing/visualization/tools/visz_fine.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# SPDX-License-Identifier: BSD-3-Clause
 ##
 # @file
 # This file is part of SeisSol.

--- a/postprocessing/visualization/tools/visz_snap.py
+++ b/postprocessing/visualization/tools/visz_snap.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# SPDX-License-Identifier: BSD-3-Clause
 ##
 # @file
 # This file is part of SeisSol.

--- a/preprocessing/REUSE.toml
+++ b/preprocessing/REUSE.toml
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: 2025 SeisSol Group
+# 
+# SPDX-License-Identifier: BSD-3-Clause
+# SPDX-LicenseComments: Full text under /LICENSE and /LICENSES/
+#
+# SPDX-FileContributor: Author lists in /AUTHORS and /CITATION.cff
+
+version = 1
+
+[[annotations]]
+path = ["**/*"]
+SPDX-FileCopyrightText = "2012-2025 SeisSol Group"
+SPDX-License-Identifier = "BSD-3-Clause"

--- a/preprocessing/meshing/cube_c/src/SConscript
+++ b/preprocessing/meshing/cube_c/src/SConscript
@@ -1,4 +1,5 @@
 #! /usr/bin/python
+# SPDX-License-Identifier: BSD-3-Clause
 ##
 # @file
 # This file is part of SeisSol.

--- a/preprocessing/meshing/cube_c/src/main.cpp
+++ b/preprocessing/meshing/cube_c/src/main.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BSD-3-Clause
 /**
  * @file
  * This file is part of SeisSol.

--- a/preprocessing/meshing/cube_c/src/utils/args.h
+++ b/preprocessing/meshing/cube_c/src/utils/args.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BSD-3-Clause
 /**
  * @file
  * This file is part of SeisSol.

--- a/preprocessing/meshing/gmsh2gambit/SConstruct
+++ b/preprocessing/meshing/gmsh2gambit/SConstruct
@@ -1,4 +1,5 @@
 #! /usr/bin/python
+# SPDX-License-Identifier: BSD-3-Clause
 ##
 # @file
 # This file is part of SeisSol.

--- a/preprocessing/meshing/gmsh2gambit/src/GAMBITWriter.cpp
+++ b/preprocessing/meshing/gmsh2gambit/src/GAMBITWriter.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BSD-3-Clause
 /**
  * @file
  * This file is part of SeisSol.

--- a/preprocessing/meshing/gmsh2gambit/src/GAMBITWriter.h
+++ b/preprocessing/meshing/gmsh2gambit/src/GAMBITWriter.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BSD-3-Clause
 /**
  * @file
  * This file is part of SeisSol.

--- a/preprocessing/meshing/gmsh2gambit/src/GMSH.cpp
+++ b/preprocessing/meshing/gmsh2gambit/src/GMSH.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BSD-3-Clause
 /**
  * @file
  * This file is part of SeisSol.

--- a/preprocessing/meshing/gmsh2gambit/src/GMSH.h
+++ b/preprocessing/meshing/gmsh2gambit/src/GMSH.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BSD-3-Clause
 /**
  * @file
  * This file is part of SeisSol.

--- a/preprocessing/meshing/gmsh2gambit/src/SConscript
+++ b/preprocessing/meshing/gmsh2gambit/src/SConscript
@@ -1,4 +1,5 @@
 #! /usr/bin/python
+# SPDX-License-Identifier: BSD-3-Clause
 ##
 # @file
 # This file is part of SeisSol.

--- a/preprocessing/meshing/gmsh2gambit/src/main.cpp
+++ b/preprocessing/meshing/gmsh2gambit/src/main.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BSD-3-Clause
 /**
  * @file
  * This file is part of SeisSol.

--- a/preprocessing/meshing/gmsh_example/planar-anydip.geo
+++ b/preprocessing/meshing/gmsh_example/planar-anydip.geo
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BSD-3-Clause
 /*
 /**
  * @file

--- a/preprocessing/meshing/gmsh_example/tpv33_half.geo
+++ b/preprocessing/meshing/gmsh_example/tpv33_half.geo
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: BSD-3-Clause
+
 lc= 5000;
 lc_fault = 100;
 

--- a/preprocessing/science/Create_Matterhorn.m
+++ b/preprocessing/science/Create_Matterhorn.m
@@ -1,6 +1,7 @@
 %%
 % @file
 % This file is part of SeisSol.
+% SPDX-License-Identifier: BSD-3-Clause
 %
 % @author Martin Kaeser (martin.kaeser AT geophysik.uni-muenchen.de, http://www.geophysik.uni-muenchen.de/Members/kaeser)
 %

--- a/preprocessing/science/Delaunay.py
+++ b/preprocessing/science/Delaunay.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: BSD-3-Clause
 ##
 # @file
 # This file is part of SeisSol.

--- a/preprocessing/science/Generate_Eigenvectors.m
+++ b/preprocessing/science/Generate_Eigenvectors.m
@@ -1,6 +1,7 @@
 %%
 % @file
 % This file is part of SeisSol.
+% SPDX-License-Identifier: BSD-3-Clause
 %
 % @author Josep de la Puente Alvarez (josep.delapuente AT bsc.es, http://www.geophysik.uni-muenchen.de/Members/jdelapuente)
 %

--- a/preprocessing/science/ViscoelasticModComp.m
+++ b/preprocessing/science/ViscoelasticModComp.m
@@ -1,6 +1,7 @@
 %%
 % @file
 % This file is part of SeisSol.
+% SPDX-License-Identifier: BSD-3-Clause
 %
 % @author Josep de la Puente Alvarez (josep.delapuente AT bsc.es, http://www.geophysik.uni-muenchen.de/Members/jdelapuente)
 %

--- a/preprocessing/science/XYinElement.m
+++ b/preprocessing/science/XYinElement.m
@@ -2,6 +2,7 @@ function inside = XYinElement(x,y,xS,yS)
 %%
 % @file
 % This file is part of SeisSol.
+% SPDX-License-Identifier: BSD-3-Clause
 %
 % @section LICENSE
 % Copyright (c) SeisSol Group

--- a/preprocessing/science/asagiconv/SConstruct
+++ b/preprocessing/science/asagiconv/SConstruct
@@ -1,4 +1,5 @@
 #! /usr/bin/python
+# SPDX-License-Identifier: BSD-3-Clause
 ##
 # @file
 # This file is part of SeisSol.

--- a/preprocessing/science/asagiconv/src/SConscript
+++ b/preprocessing/science/asagiconv/src/SConscript
@@ -1,4 +1,5 @@
 #! /usr/bin/python
+# SPDX-License-Identifier: BSD-3-Clause
 ##
 # @file
 # This file is part of SeisSol.

--- a/preprocessing/science/asagiconv/src/main.cpp
+++ b/preprocessing/science/asagiconv/src/main.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BSD-3-Clause
 /**
  * @file
  * This file is part of SeisSol.

--- a/preprocessing/science/convert_faultreceivers.m
+++ b/preprocessing/science/convert_faultreceivers.m
@@ -1,6 +1,7 @@
 %%
 % @file
 % This file is part of SeisSol.
+% SPDX-License-Identifier: BSD-3-Clause
 %
 % @author Alice Gabriel (gabriel AT geophysik.uni-muenchen.de, http://www.geophysik.uni-muenchen.de/Members/gabriel)
 %

--- a/preprocessing/science/distances.py
+++ b/preprocessing/science/distances.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# SPDX-License-Identifier: BSD-3-Clause
 ##
 # @file
 # This file is part of SeisSol.

--- a/preprocessing/science/gambit_receivers.m
+++ b/preprocessing/science/gambit_receivers.m
@@ -1,6 +1,7 @@
 %%
 % @file
 % This file is part of SeisSol.
+% SPDX-License-Identifier: BSD-3-Clause
 %
 % @author Martin Kaeser (martin.kaeser AT geophysik.uni-muenchen.de, http://www.geophysik.uni-muenchen.de/Members/kaeser)
 %

--- a/preprocessing/science/gambit_receivers_fast.m
+++ b/preprocessing/science/gambit_receivers_fast.m
@@ -1,6 +1,7 @@
 %%
 % @file
 % This file is part of SeisSol.
+% SPDX-License-Identifier: BSD-3-Clause
 %
 % @author Martin Kaeser (martin.kaeser AT geophysik.uni-muenchen.de, http://www.geophysik.uni-muenchen.de/Members/kaeser)
 %

--- a/preprocessing/science/gambit_receivers_fast_updated.m
+++ b/preprocessing/science/gambit_receivers_fast_updated.m
@@ -1,6 +1,7 @@
 %%
 % @file
 % This file is part of SeisSol.
+% SPDX-License-Identifier: BSD-3-Clause
 %
 % @author Martin Kaeser (martin.kaeser AT geophysik.uni-muenchen.de, http://www.geophysik.uni-muenchen.de/Members/kaeser)
 % @author Alice Gabriel (gabriel AT geophysik.uni-muenchen.de, http://www.geophysik.uni-muenchen.de/Members/gabriel)

--- a/preprocessing/science/gambit_receivers_updated.m
+++ b/preprocessing/science/gambit_receivers_updated.m
@@ -1,6 +1,7 @@
 %%
 % @file
 % This file is part of SeisSol.
+% SPDX-License-Identifier: BSD-3-Clause
 %
 % @author Martin Kaeser (martin.kaeser AT geophysik.uni-muenchen.de, http://www.geophysik.uni-muenchen.de/Members/kaeser)
 % @author Alice Gabriel (gabriel AT geophysik.uni-muenchen.de, http://www.geophysik.uni-muenchen.de/Members/gabriel)

--- a/preprocessing/science/icem_receivers.m
+++ b/preprocessing/science/icem_receivers.m
@@ -1,6 +1,7 @@
 %%
 % @file
 % This file is part of SeisSol.
+% SPDX-License-Identifier: BSD-3-Clause
 %
 % @author Martin Kaeser (martin.kaeser AT geophysik.uni-muenchen.de, http://www.geophysik.uni-muenchen.de/Members/kaeser)
 %

--- a/preprocessing/science/icem_receivers_sphere.m
+++ b/preprocessing/science/icem_receivers_sphere.m
@@ -1,6 +1,7 @@
 %%
 % @file
 % This file is part of SeisSol.
+% SPDX-License-Identifier: BSD-3-Clause
 %
 % @author Martin Kaeser (martin.kaeser AT geophysik.uni-muenchen.de, http://www.geophysik.uni-muenchen.de/Members/kaeser)
 %

--- a/preprocessing/science/place_faultreceivers.m
+++ b/preprocessing/science/place_faultreceivers.m
@@ -1,6 +1,7 @@
 %%
 % @file
 % This file is part of SeisSol.
+% SPDX-License-Identifier: BSD-3-Clause
 %
 % @author Martin Kaeser (martin.kaeser AT geophysik.uni-muenchen.de, http://www.geophysik.uni-muenchen.de/Members/kaeser)
 % @author Christian Pelties (pelties AT geophysik.uni-muenchen.de, http://www.geophysik.uni-muenchen.de/Members/pelties)

--- a/preprocessing/science/place_quickly_faultreceivers.m
+++ b/preprocessing/science/place_quickly_faultreceivers.m
@@ -1,6 +1,7 @@
 %%
 % @file
 % This file is part of SeisSol.
+% SPDX-License-Identifier: BSD-3-Clause
 %
 % @author Martin Kaeser (martin.kaeser AT geophysik.uni-muenchen.de, http://www.geophysik.uni-muenchen.de/Members/kaeser)
 % @author Christian Pelties (pelties AT geophysik.uni-muenchen.de, http://www.geophysik.uni-muenchen.de/Members/pelties)

--- a/preprocessing/science/place_quickly_faultreceivers_netcdf_any_normal.m
+++ b/preprocessing/science/place_quickly_faultreceivers_netcdf_any_normal.m
@@ -1,6 +1,7 @@
 %%
 % @file
 % This file is part of SeisSol.
+% SPDX-License-Identifier: BSD-3-Clause
 %
 % @author Thomas Ulrich (ulrich AT geophysik.uni-muenchen.de, http://www.geophysik.uni-muenchen.de/Members/ulrich)
 %

--- a/preprocessing/science/rconv/src/Map.cpp
+++ b/preprocessing/science/rconv/src/Map.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BSD-3-Clause
 /**
  * @file
  * This file is part of SeisSol.

--- a/preprocessing/science/rconv/src/Map.h
+++ b/preprocessing/science/rconv/src/Map.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BSD-3-Clause
 /**
  * @file
  * This file is part of SeisSol.

--- a/preprocessing/science/rconv/src/NRFWriter.cpp
+++ b/preprocessing/science/rconv/src/NRFWriter.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BSD-3-Clause
 /**
  * @file
  * This file is part of SeisSol.

--- a/preprocessing/science/rconv/src/NRFWriter.h
+++ b/preprocessing/science/rconv/src/NRFWriter.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BSD-3-Clause
 /**
  * @file
  * This file is part of SeisSol.

--- a/preprocessing/science/rconv/src/SConscript
+++ b/preprocessing/science/rconv/src/SConscript
@@ -1,4 +1,5 @@
 #! /usr/bin/python
+# SPDX-License-Identifier: BSD-3-Clause
 ##
 # @file
 # This file is part of SeisSol.

--- a/preprocessing/science/rconv/src/SRF.cpp
+++ b/preprocessing/science/rconv/src/SRF.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BSD-3-Clause
 /**
  * @file
  * This file is part of SeisSol.

--- a/preprocessing/science/rconv/src/SRF.h
+++ b/preprocessing/science/rconv/src/SRF.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BSD-3-Clause
 /**
  * @file
  * This file is part of SeisSol.

--- a/preprocessing/science/rconv/src/XMFWriter.cpp
+++ b/preprocessing/science/rconv/src/XMFWriter.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BSD-3-Clause
 /**
  * @file
  * This file is part of SeisSol.

--- a/preprocessing/science/rconv/src/XMFWriter.h
+++ b/preprocessing/science/rconv/src/XMFWriter.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BSD-3-Clause
 /**
  * @file
  * This file is part of SeisSol.

--- a/preprocessing/science/rconv/src/main.cpp
+++ b/preprocessing/science/rconv/src/main.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BSD-3-Clause
 /**
  * @file
  * This file is part of SeisSol.

--- a/preprocessing/science/stations2reference.py
+++ b/preprocessing/science/stations2reference.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# SPDX-License-Identifier: BSD-3-Clause
 ##
 # @file
 # This file is part of SeisSol.

--- a/preprocessing/science/stressrotation2D.m
+++ b/preprocessing/science/stressrotation2D.m
@@ -1,6 +1,7 @@
 %%
 % @file
 % This file is part of SeisSol.
+% SPDX-License-Identifier: BSD-3-Clause
 %
 % @author Amaryllis Nerger (amaryllis.nerger AT geophysik.uni-muenchen.de, http://www.geophysik.uni-muenchen.de/Members/anerger)
 % @author Christian Pelties (pelties AT geophysik.uni-muenchen.de, http://www.geophysik.uni-muenchen.de/Members/pelties)

--- a/preprocessing/science/stressrotation3D.m
+++ b/preprocessing/science/stressrotation3D.m
@@ -1,6 +1,7 @@
 %%
 % @file
 % This file is part of SeisSol.
+% SPDX-License-Identifier: BSD-3-Clause
 %
 % @author Alice Gabriel (gabriel AT geophysik.uni-muenchen.de, http://www.geophysik.uni-muenchen.de/Members/gabriel)
 %


### PR DESCRIPTION
We make SeisSol compatible to the REUSE spec; i.e. add a license header everywhere, or state that all files in a folder follow a specific license.

All other code had previously been already annotated by other PRs; so all that was left is pre/postprocessing. Thus, I've now added license identifiers everywhere where there's a license, and just added a `REUSE.toml` for preprocessing and one for postprocessing to catch all other cases. (might be the "cheaper" option; but we can still change it if we really keep pre/postprocessing in the SeisSol main repo here)

Also, we get a GHA workflow.
