### PR TITLE
Merge most flux kernels

### DIFF
--- a/generated-code/kernels/aderdg.py
+++ b/generated-code/kernels/aderdg.py
@@ -438,6 +438,11 @@ class LinearADERDG(ADERDGBase):
                     h, j, i
                 ]["kl"]
 
+                dummyMinusFluxMatrix = Tensor(
+                    "dummyMinusFluxMatrix",
+                    shape=self.db.minusFluxMatrices[0, 0, 0].shape(),
+                )["kl"]
+
             neighborFlux = (
                 lambda h, j, i: self.Q["kp"]
                 <= self.Q["kp"]
@@ -447,6 +452,13 @@ class LinearADERDG(ADERDGBase):
                 "gpu_neighboringFlux",
                 simpleParameterSpace(3, 4, 4),
                 neighborFlux,
+                target="gpu",
+            )
+            generator.add(
+                "gpu_neighboringFlux2",
+                self.Q["kp"]
+                <= self.Q["kp"]
+                + dummyMinusFluxMatrix * self.I["lq"] * self.AminusT["qp"],
                 target="gpu",
             )
 

--- a/generated-code/kernels/dynamic_rupture.py
+++ b/generated-code/kernels/dynamic_rupture.py
@@ -142,6 +142,18 @@ def addKernels(generator, aderdg, matricesDir, drQuadRule, targets):
             target="gpu",
         )
 
+        dummyV3mTo2n = Tensor(
+            "dummyV3mTo2n",
+            shape=db.V3mTo2n[0, 0].shape(),
+            alignStride=aderdg.alignStride,
+        )
+        generator.add(
+            f"gpu_evaluateAndRotateQAtInterpolationPoints2",
+            QInterpolated["kp"]
+            <= dummyV3mTo2n[aderdg.t("kl")] * aderdg.Q["lq"] * TinvT["qp"],
+            target="gpu",
+        )
+
     # Energy output
     # Minus and plus refer to the original implementation of Christian Pelties,
     # where the normal points from the plus side to the minus side

--- a/generated-code/kernels/dynamic_rupture.py
+++ b/generated-code/kernels/dynamic_rupture.py
@@ -126,6 +126,22 @@ def addKernels(generator, aderdg, matricesDir, drQuadRule, targets):
             target=target,
         )
 
+    if "gpu" in targets:
+        dummyV3mTo2nTWDivM = Tensor(
+            "dummyV3mTo2nTWDivM",
+            shape=db.V3mTo2nTWDivM[0, 0].shape(),
+            alignStride=aderdg.alignStride,
+        )
+        generator.add(
+            f"gpu_nodalFlux2",
+            aderdg.extendedQTensor()["kp"]
+            <= aderdg.extendedQTensor()["kp"]
+            + dummyV3mTo2nTWDivM[aderdg.t("kl")]
+            * QInterpolated["lq"]
+            * fluxSolver["qp"],
+            target="gpu",
+        )
+
     # Energy output
     # Minus and plus refer to the original implementation of Christian Pelties,
     # where the normal points from the plus side to the minus side

--- a/src/Initializer/BatchRecorders/DataTypes/EncodedConstants.h
+++ b/src/Initializer/BatchRecorders/DataTypes/EncodedConstants.h
@@ -59,6 +59,7 @@ struct Dr {
     QInterpolatedPlus,
     QInterpolatedMinus,
     TinvT,
+    Global,
     Count
   };
 };

--- a/src/Initializer/BatchRecorders/DataTypes/EncodedConstants.h
+++ b/src/Initializer/BatchRecorders/DataTypes/EncodedConstants.h
@@ -40,6 +40,7 @@ struct Wp {
     EasiBoundaryMap,
     EasiBoundaryConstant,
     Analytical,
+    Global,
     Count
   };
 };

--- a/src/Initializer/BatchRecorders/Recorders.h
+++ b/src/Initializer/BatchRecorders/Recorders.h
@@ -109,6 +109,8 @@ class LocalIntegrationRecorder : public AbstractRecorder<seissol::initializer::L
 
 class NeighIntegrationRecorder : public AbstractRecorder<seissol::initializer::LTS> {
   public:
+  NeighIntegrationRecorder(GlobalData* global) : global(global) {}
+
   void record(LTS& handler, Layer& layer) override;
 
   private:
@@ -127,6 +129,7 @@ class NeighIntegrationRecorder : public AbstractRecorder<seissol::initializer::L
   kernels::NeighborData::Loader* currentLoaderHost{nullptr};
   std::unordered_map<real*, real*> idofsAddressRegistry{};
   size_t integratedDofsAddressCounter{0};
+  GlobalData* global;
 };
 
 class PlasticityRecorder : public AbstractRecorder<seissol::initializer::LTS> {

--- a/src/Initializer/BatchRecorders/Recorders.h
+++ b/src/Initializer/BatchRecorders/Recorders.h
@@ -150,6 +150,7 @@ class PlasticityRecorder : public AbstractRecorder<seissol::initializer::LTS> {
 
 class DynamicRuptureRecorder : public AbstractRecorder<seissol::initializer::DynamicRupture> {
   public:
+  DynamicRuptureRecorder(GlobalData* global) : global(global) {}
   void record(DynamicRupture& handler, Layer& layer) override;
 
   private:
@@ -159,6 +160,7 @@ class DynamicRuptureRecorder : public AbstractRecorder<seissol::initializer::Dyn
   void recordDofsTimeEvaluation();
   void recordSpaceInterpolation();
   std::unordered_map<real*, real*> idofsAddressRegistry{};
+  GlobalData* global;
 };
 
 } // namespace seissol::initializer::recording

--- a/src/Initializer/MemoryManager.cpp
+++ b/src/Initializer/MemoryManager.cpp
@@ -794,7 +794,7 @@ void seissol::initializer::MemoryManager::initializeEasiBoundaryReader(const cha
 void seissol::initializer::MemoryManager::recordExecutionPaths(bool usePlasticity) {
   recording::CompositeRecorder<seissol::initializer::LTS> recorder;
   recorder.addRecorder(new recording::LocalIntegrationRecorder);
-  recorder.addRecorder(new recording::NeighIntegrationRecorder);
+  recorder.addRecorder(new recording::NeighIntegrationRecorder(&m_globalDataOnDevice));
 
   if (usePlasticity) {
     recorder.addRecorder(new recording::PlasticityRecorder);

--- a/src/Initializer/MemoryManager.cpp
+++ b/src/Initializer/MemoryManager.cpp
@@ -797,7 +797,7 @@ void seissol::initializer::MemoryManager::recordExecutionPaths(bool usePlasticit
   }
 
   recording::CompositeRecorder<seissol::initializer::DynamicRupture> drRecorder;
-  drRecorder.addRecorder(new recording::DynamicRuptureRecorder);
+  drRecorder.addRecorder(new recording::DynamicRuptureRecorder(&m_globalDataOnDevice));
   for (auto& layer : m_dynRupTree.leaves(Ghost)) {
     drRecorder.record(*m_dynRup, layer);
   }

--- a/src/Proxy/Allocator.cpp
+++ b/src/Proxy/Allocator.cpp
@@ -276,7 +276,8 @@ void ProxyData::initDataStructuresOnDevice(bool enableDR) {
 
   seissol::initializer::recording::CompositeRecorder<seissol::initializer::LTS> recorder;
   recorder.addRecorder(new seissol::initializer::recording::LocalIntegrationRecorder);
-  recorder.addRecorder(new seissol::initializer::recording::NeighIntegrationRecorder);
+  recorder.addRecorder(
+      new seissol::initializer::recording::NeighIntegrationRecorder(&globalDataOnDevice));
 
   recorder.addRecorder(new seissol::initializer::recording::PlasticityRecorder);
   recorder.record(lts, layer);

--- a/src/Proxy/Allocator.cpp
+++ b/src/Proxy/Allocator.cpp
@@ -289,7 +289,7 @@ void ProxyData::initDataStructuresOnDevice(bool enableDR) {
     dynRupTree.allocateScratchPads();
 
     CompositeRecorder<seissol::initializer::DynamicRupture> drRecorder;
-    drRecorder.addRecorder(new DynamicRuptureRecorder);
+    drRecorder.addRecorder(new DynamicRuptureRecorder(&globalDataOnDevice));
 
     auto& drLayer = dynRupTree.child(0).child<Interior>();
     drRecorder.record(dynRup, drLayer);


### PR DESCRIPTION
A _very_ experimental PR. Might not be merged; but I wanted to put it forward.

In principle, since all flux matrices are of the same size, we can merge most of the kernels; at the cost of caching performance at least on NVIDIA GPUs. I.e. for those: the latency decreases, but so does the maximum throughput.

Again, a temporary solution until the kernels are merged in a better way (e.g. grid syncs?).
