### PR TITLE
Fix the energy output

### DIFF
--- a/.github/workflows/build-seissol-cpu.yml
+++ b/.github/workflows/build-seissol-cpu.yml
@@ -286,7 +286,7 @@ jobs:
             multisim: 8
             energies: true
             receivers: true
-            fault: true
+            fault: false # NYI
         precision:
           - single
           - double

--- a/.github/workflows/build-seissol-gpu.yml
+++ b/.github/workflows/build-seissol-gpu.yml
@@ -276,7 +276,7 @@ jobs:
           #  multisim: 8
           #  energies: true
           #  receivers: true
-          #  fault: true
+          #  fault: false # NYI
         precision:
           - single
         order:

--- a/postprocessing/validation/compare-energies.py
+++ b/postprocessing/validation/compare-energies.py
@@ -38,12 +38,12 @@ def get_sub_simulation(df, fused_index):
 
 def perform_check(energy, energy_ref, epsilon):
     print("Energies")
-    print(energy)
+    print(energy.to_string())
     print("Energies reference")
-    print(energy_ref)
+    print(energy_ref.to_string())
     relative_difference = ((energy - energy_ref).abs() / energy_ref).iloc[1:, :]
     print("Relative difference")
-    print(relative_difference)
+    print(relative_difference.to_string())
 
     relative_difference_larger_eps = (relative_difference.iloc[1:, :] > epsilon).values
     return np.any(relative_difference_larger_eps)

--- a/src/ResultWriter/EnergyOutput.cpp
+++ b/src/ResultWriter/EnergyOutput.cpp
@@ -462,10 +462,10 @@ void EnergyOutput::computeVolumeEnergies() {
         const double curMomentumY = rho * v;
         const double curMomentumZ = rho * w;
 
-        if (std::abs(material.local.mu) < 10e-14) {
+        if (std::abs(material.local.getMuBar()) < 10e-14) {
           // Acoustic
           constexpr int PIdx = 0;
-          const auto k = material.local.lambda;
+          const auto k = material.local.getLambdaBar();
           const auto p = numSub(qp, PIdx);
           const double curAcousticEnergy = (p * p) / (2 * k);
           totalAcousticEnergyLocal += curWeight * curAcousticEnergy;
@@ -484,8 +484,8 @@ void EnergyOutput::computeVolumeEnergies() {
 
           auto getStress = [&](int i, int j) { return numSub(qp, getStressIndex(i, j)); };
 
-          const auto lambda = material.local.lambda;
-          const auto mu = material.local.mu;
+          const auto lambda = material.local.getLambdaBar();
+          const auto mu = material.local.getMuBar();
           const auto sumUniaxialStresses = getStress(0, 0) + getStress(1, 1) + getStress(2, 2);
           auto computeStrain = [&](int i, int j) {
             double strain = 0.0;
@@ -726,7 +726,9 @@ void EnergyOutput::checkAbortCriterion(
   }
 }
 
-void EnergyOutput::writeHeader() { out << "time,variable,simulation_index,measurement" << std::endl; }
+void EnergyOutput::writeHeader() {
+  out << "time,variable,simulation_index,measurement" << std::endl;
+}
 
 void EnergyOutput::writeEnergies(double time) {
   for (size_t sim = 0; sim < multisim::NumSimulations; sim++) {
@@ -734,8 +736,8 @@ void EnergyOutput::writeEnergies(double time) {
     if (shouldComputeVolumeEnergies()) {
       out << time << ",gravitational_energy," << fusedSuffix << ","
           << energiesStorage.gravitationalEnergy(sim) << "\n"
-          << time << ",acoustic_energy," << fusedSuffix << "," << energiesStorage.acousticEnergy(sim)
-          << "\n"
+          << time << ",acoustic_energy," << fusedSuffix << ","
+          << energiesStorage.acousticEnergy(sim) << "\n"
           << time << ",acoustic_kinetic_energy," << fusedSuffix << ","
           << energiesStorage.acousticKineticEnergy(sim) << "\n"
           << time << ",elastic_energy," << fusedSuffix << "," << energiesStorage.elasticEnergy(sim)

--- a/src/ResultWriter/EnergyOutput.cpp
+++ b/src/ResultWriter/EnergyOutput.cpp
@@ -726,23 +726,23 @@ void EnergyOutput::checkAbortCriterion(
   }
 }
 
-void EnergyOutput::writeHeader() { out << "time,variable,measurement" << std::endl; }
+void EnergyOutput::writeHeader() { out << "time,variable,simulation_index,measurement" << std::endl; }
 
 void EnergyOutput::writeEnergies(double time) {
   for (size_t sim = 0; sim < multisim::NumSimulations; sim++) {
-    const std::string fusedSuffix = multisim::MultisimEnabled ? std::to_string(sim) : "";
+    const std::string fusedSuffix = std::to_string(sim);
     if (shouldComputeVolumeEnergies()) {
-      out << time << ",gravitational_energy" << fusedSuffix << ","
+      out << time << ",gravitational_energy," << fusedSuffix << ","
           << energiesStorage.gravitationalEnergy(sim) << "\n"
-          << time << ",acoustic_energy" << fusedSuffix << "," << energiesStorage.acousticEnergy(sim)
+          << time << ",acoustic_energy," << fusedSuffix << "," << energiesStorage.acousticEnergy(sim)
           << "\n"
-          << time << ",acoustic_kinetic_energy" << fusedSuffix << ","
+          << time << ",acoustic_kinetic_energy," << fusedSuffix << ","
           << energiesStorage.acousticKineticEnergy(sim) << "\n"
-          << time << ",elastic_energy" << fusedSuffix << "," << energiesStorage.elasticEnergy(sim)
+          << time << ",elastic_energy," << fusedSuffix << "," << energiesStorage.elasticEnergy(sim)
           << "\n"
-          << time << ",elastic_kinetic_energy" << fusedSuffix << ","
+          << time << ",elastic_kinetic_energy," << fusedSuffix << ","
           << energiesStorage.elasticKineticEnergy(sim) << "\n"
-          << time << ",plastic_moment" << fusedSuffix << "," << energiesStorage.plasticMoment(sim)
+          << time << ",plastic_moment," << fusedSuffix << "," << energiesStorage.plasticMoment(sim)
           << "\n"
           << time << ",momentumX," << fusedSuffix << "," << energiesStorage.totalMomentumX(sim)
           << "\n"
@@ -751,14 +751,14 @@ void EnergyOutput::writeEnergies(double time) {
           << time << ",momentumZ," << fusedSuffix << "," << energiesStorage.totalMomentumZ(sim)
           << "\n";
     }
-    out << time << ",total_frictional_work" << fusedSuffix << ","
+    out << time << ",total_frictional_work," << fusedSuffix << ","
         << energiesStorage.totalFrictionalWork(sim) << "\n"
-        << time << ",static_frictional_work" << fusedSuffix << ","
+        << time << ",static_frictional_work," << fusedSuffix << ","
         << energiesStorage.staticFrictionalWork(sim) << "\n"
-        << time << ",seismic_moment" << fusedSuffix << "," << energiesStorage.seismicMoment(sim)
+        << time << ",seismic_moment," << fusedSuffix << "," << energiesStorage.seismicMoment(sim)
         << "\n"
-        << time << ",potency" << fusedSuffix << "," << energiesStorage.potency(sim) << "\n"
-        << time << ",plastic_moment" << fusedSuffix << "," << energiesStorage.plasticMoment(sim)
+        << time << ",potency," << fusedSuffix << "," << energiesStorage.potency(sim) << "\n"
+        << time << ",plastic_moment," << fusedSuffix << "," << energiesStorage.plasticMoment(sim)
         << std::endl;
   }
 }

--- a/src/ResultWriter/EnergyOutput.h
+++ b/src/ResultWriter/EnergyOutput.h
@@ -104,7 +104,7 @@ class EnergyOutput : public Module {
 
   void printEnergies();
 
-  void checkAbortCriterion(const real (&timeSinceThreshold)[multisim::NumSimulations],
+  void checkAbortCriterion(const std::array<real, multisim::NumSimulations>& timeSinceThreshold,
                            const std::string& prefixMessage);
 
   void writeHeader();
@@ -143,12 +143,12 @@ class EnergyOutput : public Module {
   seissol::initializer::Lut* ltsLut = nullptr;
 
   EnergiesStorage energiesStorage{};
-  real minTimeSinceSlipRateBelowThreshold[multisim::NumSimulations] = {0.0};
-  real minTimeSinceMomentRateBelowThreshold[multisim::NumSimulations] = {0.0};
+  std::array<real, multisim::NumSimulations> minTimeSinceSlipRateBelowThreshold;
+  std::array<real, multisim::NumSimulations> minTimeSinceMomentRateBelowThreshold;
   double terminatorMaxTimePostRupture{};
   double energyOutputInterval{};
   double terminatorMomentRateThreshold{};
-  double seismicMomentPrevious[multisim::NumSimulations] = {0.0};
+  std::array<double, multisim::NumSimulations> seismicMomentPrevious;
 };
 
 } // namespace writer


### PR DESCRIPTION
The energy output and CI verification broke by #385. Thus, we fix it here.

Besides, we merge some MPI calls, and enable the energy output for all equations. (and print a warning if the energy is probably computed inaccurately)
