### PR TITLE
Fault output/on-fault receiver messages, on-fault point finding overhaul

### DIFF
--- a/src/DynamicRupture/Output/OutputAux.h
+++ b/src/DynamicRupture/Output/OutputAux.h
@@ -49,6 +49,9 @@ std::pair<int, double> getNearestFacePoint(const double targetPoint[2],
                                            const double (*facePoints)[2],
                                            unsigned numFacePoints);
 
+double
+    isInsideFace(const ExtVrtxCoords& point, const ExtTriangle& face, const VrtxCoords faceNormal);
+
 void projectPointToFace(ExtVrtxCoords& point, const ExtTriangle& face, const VrtxCoords faceNormal);
 
 double getDistanceFromPointToFace(const ExtVrtxCoords& point,

--- a/src/DynamicRupture/Output/OutputManager.cpp
+++ b/src/DynamicRupture/Output/OutputManager.cpp
@@ -180,6 +180,7 @@ void OutputManager::setLtsData(seissol::initializer::LTSTree* userWpTree,
 }
 
 void OutputManager::initElementwiseOutput() {
+  logInfo() << "Setting up the fault output.";
   ewOutputBuilder->build(ewOutputData);
   const auto& seissolParameters = seissolInstance.getSeisSolParameters();
 
@@ -270,11 +271,12 @@ void OutputManager::initElementwiseOutput() {
 }
 
 void OutputManager::initPickpointOutput() {
+  logInfo() << "Setting up on-fault receivers.";
   ppOutputBuilder->build(ppOutputData);
   const auto& seissolParameters = seissolInstance.getSeisSolParameters();
 
   if (seissolParameters.output.pickpointParameters.collectiveio) {
-    logError() << "Collective IO for the Fault Pickpoint output is still under construction.";
+    logError() << "Collective IO for the on-fault receiver output is still under construction.";
   }
 
   std::stringstream baseHeader;


### PR DESCRIPTION
We

* add some messages for on-fault receivers being treated now
* refine the receiver containment mechanism to hopefully work better at the halo boundaries (copy/ghost layers). In essence, it's just porting over the hyperplane formulation from tetrahedron to (extruded) triangle.
