### PR TITLE
`fusedOriginalIndex` -> `simulationIndex`

### DIFF
--- a/src/Kernels/PointSourceCluster.h
+++ b/src/Kernels/PointSourceCluster.h
@@ -128,7 +128,7 @@ SEISSOL_HOSTDEVICE constexpr auto&
 SEISSOL_HOSTDEVICE inline void
     addTimeIntegratedPointSourceNRF(const memory::AlignedArray<real, 3>& __restrict slip,
                                     const real* __restrict mInvJInvPhisAtSources,
-                                    unsigned fusedOriginalIndex,
+                                    unsigned simulationIndex,
                                     const real* __restrict tensor,
                                     real a,
                                     const real* __restrict stiffnessTensor,
@@ -155,7 +155,7 @@ SEISSOL_HOSTDEVICE inline void
   const real moment[6] = {mom(0, 0), mom(1, 1), mom(2, 2), mom(0, 1), mom(1, 2), mom(0, 2)};
   for (unsigned t = 0; t < 6; ++t) {
     for (unsigned k = 0; k < MInvJInvPhisAtSourcesSpan; ++k) {
-      dofsAccessor(dofs, k, t, fusedOriginalIndex) += mInvJInvPhisAtSources[k] * moment[t];
+      dofsAccessor(dofs, k, t, simulationIndex) += mInvJInvPhisAtSources[k] * moment[t];
     }
   }
 }
@@ -167,7 +167,7 @@ SEISSOL_HOSTDEVICE inline void pointSourceKernelNRF(
     sourceterm::CellToPointSourcesMapping* __restrict mappingPtr,
     const seissol::memory::
         AlignedArray<real, tensor::mInvJInvPhisAtSources::size()>* __restrict mInvJInvPhisAtSources,
-    const unsigned* __restrict fusedOriginalIndex,
+    const unsigned* __restrict simulationIndex,
     const seissol::memory::AlignedArray<real,
                                         sourceterm::PointSources::TensorSize>* __restrict tensor,
     const real* __restrict a,
@@ -190,7 +190,7 @@ SEISSOL_HOSTDEVICE inline void pointSourceKernelNRF(
 
     addTimeIntegratedPointSourceNRF(slip,
                                     mInvJInvPhisAtSources[source].data(),
-                                    fusedOriginalIndex[source],
+                                    simulationIndex[source],
                                     tensor[source].data(),
                                     a[source],
                                     stiffnessTensor[source].data(),
@@ -203,14 +203,14 @@ SEISSOL_HOSTDEVICE inline void pointSourceKernelNRF(
 SEISSOL_HOSTDEVICE inline void
     addTimeIntegratedPointSourceFSRM(real slip,
                                      const real* __restrict mInvJInvPhisAtSources,
-                                     unsigned fusedOriginalIndex,
+                                     unsigned simulationIndex,
                                      const real* __restrict tensor,
                                      double from,
                                      double to,
                                      real* __restrict dofs) {
   for (unsigned p = 0; p < MomentFsrmSpan; ++p) {
     for (unsigned k = 0; k < MInvJInvPhisAtSourcesSpan; ++k) {
-      dofsAccessor(dofs, k, p, fusedOriginalIndex) += slip * mInvJInvPhisAtSources[k] * tensor[p];
+      dofsAccessor(dofs, k, p, simulationIndex) += slip * mInvJInvPhisAtSources[k] * tensor[p];
     }
   }
 }
@@ -222,7 +222,7 @@ SEISSOL_HOSTDEVICE inline void pointSourceKernelFSRM(
     sourceterm::CellToPointSourcesMapping* __restrict mappingPtr,
     const seissol::memory::
         AlignedArray<real, tensor::mInvJInvPhisAtSources::size()>* __restrict mInvJInvPhisAtSources,
-    const unsigned* __restrict fusedOriginalIndex,
+    const unsigned* __restrict simulationIndex,
     const seissol::memory::AlignedArray<real,
                                         sourceterm::PointSources::TensorSize>* __restrict tensor,
     const real* __restrict a,
@@ -241,7 +241,7 @@ SEISSOL_HOSTDEVICE inline void pointSourceKernelFSRM(
         from, to, onsetTime[source], samplingInterval[source], sample[0] + o0, o1 - o0);
     addTimeIntegratedPointSourceFSRM(slip,
                                      mInvJInvPhisAtSources[source].data(),
-                                     fusedOriginalIndex[source],
+                                     simulationIndex[source],
                                      tensor[source].data(),
                                      from,
                                      to,

--- a/src/Kernels/PointSourceClusterCudaHip.cpp
+++ b/src/Kernels/PointSourceClusterCudaHip.cpp
@@ -25,7 +25,7 @@ __launch_bounds__(Blocksize) __global__ void launchKernelNRF(
     sourceterm::CellToPointSourcesMapping* __restrict mappingPtr,
     const seissol::memory::
         AlignedArray<real, tensor::mInvJInvPhisAtSources::size()>* __restrict mInvJInvPhisAtSources,
-    const unsigned* __restrict fusedOriginalIndex,
+    const unsigned* __restrict simulationIndex,
     const seissol::memory::AlignedArray<real,
                                         sourceterm::PointSources::TensorSize>* __restrict tensor,
     const real* __restrict a,
@@ -41,7 +41,7 @@ __launch_bounds__(Blocksize) __global__ void launchKernelNRF(
                          to,
                          mappingPtr,
                          mInvJInvPhisAtSources,
-                         fusedOriginalIndex,
+                         simulationIndex,
                          tensor,
                          a,
                          stiffnessTensor,
@@ -59,7 +59,7 @@ __launch_bounds__(Blocksize) __global__ void launchKernelFSRM(
     sourceterm::CellToPointSourcesMapping* __restrict mappingPtr,
     const seissol::memory::
         AlignedArray<real, tensor::mInvJInvPhisAtSources::size()>* __restrict mInvJInvPhisAtSources,
-    const unsigned* __restrict fusedOriginalIndex,
+    const unsigned* __restrict simulationIndex,
     const seissol::memory::AlignedArray<real,
                                         sourceterm::PointSources::TensorSize>* __restrict tensor,
     const real* __restrict a,
@@ -75,7 +75,7 @@ __launch_bounds__(Blocksize) __global__ void launchKernelFSRM(
                           to,
                           mappingPtr,
                           mInvJInvPhisAtSources,
-                          fusedOriginalIndex,
+                          simulationIndex,
                           tensor,
                           a,
                           stiffnessTensor,
@@ -114,7 +114,7 @@ void pointSourceKernel(sourceterm::ClusterMapping& clusterMapping,
     sample[1] = sources.sample[1].data();
     sample[2] = sources.sample[2].data();
 
-    const auto* __restrict fusedOriginalIndex = sources.fusedOriginalIndex.data();
+    const auto* __restrict simulationIndex = sources.simulationIndex.data();
 
 #ifdef __CUDACC__
     using StreamT = cudaStream_t;
@@ -138,7 +138,7 @@ void pointSourceKernel(sourceterm::ClusterMapping& clusterMapping,
                                                   to,
                                                   mappingPtr,
                                                   mInvJInvPhisAtSources,
-                                                  fusedOriginalIndex,
+                                                  simulationIndex,
                                                   tensor,
                                                   a,
                                                   stiffnessTensor,
@@ -152,7 +152,7 @@ void pointSourceKernel(sourceterm::ClusterMapping& clusterMapping,
                                                    to,
                                                    mappingPtr,
                                                    mInvJInvPhisAtSources,
-                                                   fusedOriginalIndex,
+                                                   simulationIndex,
                                                    tensor,
                                                    a,
                                                    stiffnessTensor,

--- a/src/Kernels/PointSourceClusterOnHost.cpp
+++ b/src/Kernels/PointSourceClusterOnHost.cpp
@@ -88,9 +88,9 @@ void PointSourceClusterOnHost::addTimeIntegratedPointSourceNRF(unsigned source,
   krnl.mArea = -sources_->A[source];
   krnl.momentToNRF = init::momentToNRF::Values;
 #ifdef MULTIPLE_SIMULATIONS
-  const auto originalIndex = sources_->fusedOriginalIndex[source];
+  const auto simulationIndex = sources_->simulationIndex[source];
   std::array<real, seissol::multisim::NumSimulations> sourceToMultSim{};
-  sourceToMultSim[originalIndex % seissol::multisim::NumSimulations] = 1.0;
+  sourceToMultSim[simulationIndex] = 1.0;
   krnl.oneSimToMultSim = sourceToMultSim.data();
 #endif
   krnl.execute();
@@ -114,9 +114,9 @@ void PointSourceClusterOnHost::addTimeIntegratedPointSourceFSRM(unsigned source,
   krnl.momentFSRM = sources_->tensor[source].data();
   krnl.stfIntegral = slip;
 #ifdef MULTIPLE_SIMULATIONS
-  const auto originalIndex = sources_->fusedOriginalIndex[source];
+  const auto simulationIndex = sources_->simulationIndex[source];
   std::array<real, seissol::multisim::NumSimulations> sourceToMultSim{};
-  sourceToMultSim[originalIndex % seissol::multisim::NumSimulations] = 1.0;
+  sourceToMultSim[simulationIndex] = 1.0;
   krnl.oneSimToMultSim = sourceToMultSim.data();
 #endif
   krnl.execute();

--- a/src/Kernels/PointSourceClusterSycl.cpp
+++ b/src/Kernels/PointSourceClusterSycl.cpp
@@ -37,7 +37,7 @@ void pointSourceKernel(sourceterm::ClusterMapping& clusterMapping,
     sample[1] = sources.sample[1].data();
     sample[2] = sources.sample[2].data();
 
-    const auto* __restrict fusedOriginalIndex = sources.fusedOriginalIndex.data();
+    const auto* __restrict simulationIndex = sources.simulationIndex.data();
 
     auto* queue = reinterpret_cast<sycl::queue*>(runtime.stream());
 
@@ -50,7 +50,7 @@ void pointSourceKernel(sourceterm::ClusterMapping& clusterMapping,
                                to,
                                mappingPtr,
                                mInvJInvPhisAtSources,
-                               fusedOriginalIndex,
+                               simulationIndex,
                                tensor,
                                a,
                                stiffnessTensor,
@@ -68,7 +68,7 @@ void pointSourceKernel(sourceterm::ClusterMapping& clusterMapping,
                                 to,
                                 mappingPtr,
                                 mInvJInvPhisAtSources,
-                                fusedOriginalIndex,
+                                simulationIndex,
                                 tensor,
                                 a,
                                 stiffnessTensor,

--- a/src/SourceTerm/Manager.cpp
+++ b/src/SourceTerm/Manager.cpp
@@ -343,12 +343,14 @@ auto loadSourcesFromFSRM(const char* fileName,
       sources.numberOfSources = numberOfSources;
       sources.mInvJInvPhisAtSources.resize(numberOfSources);
       sources.tensor.resize(numberOfSources);
-      sources.simulationIndex.resize(numberOfSources);
       sources.onsetTime.resize(numberOfSources);
       sources.samplingInterval.resize(numberOfSources);
       sources.sampleOffsets[0].resize(numberOfSources + 1);
       sources.sampleOffsets[0][0] = 0;
       sources.sample[0].resize(fsrm.numberOfSamples * numberOfSources);
+
+      // only actively used in the case of fused simulations
+      sources.simulationIndex.resize(numberOfSources);
 
       for (unsigned clusterSource = 0; clusterSource < numberOfSources; ++clusterSource) {
         const unsigned sourceIndex = clusterMappings[cluster].sources[clusterSource];
@@ -468,13 +470,15 @@ auto loadSourcesFromNRF(const char* fileName,
       sources.tensor.resize(numberOfSources);
       sources.A.resize(numberOfSources);
       sources.stiffnessTensor.resize(numberOfSources);
-      sources.simulationIndex.resize(numberOfSources);
       sources.onsetTime.resize(numberOfSources);
       sources.samplingInterval.resize(numberOfSources);
       for (auto& so : sources.sampleOffsets) {
         so.resize(numberOfSources + 1);
         so[0] = 0;
       }
+
+      // only actively used in the case of fused simulations
+      sources.simulationIndex.resize(numberOfSources);
 
       for (std::size_t i = 0; i < Offsets().size(); ++i) {
         std::size_t sampleSize = 0;

--- a/src/SourceTerm/Manager.cpp
+++ b/src/SourceTerm/Manager.cpp
@@ -32,6 +32,7 @@
 #include <Memory/Tree/Lut.h>
 #include <Model/CommonDatastructures.h>
 #include <Numerical/BasisFunction.h>
+#include <Solver/MultipleSimulations.h>
 #include <Solver/time_stepping/TimeManager.h>
 #include <SourceTerm/NRF.h>
 #include <SourceTerm/Typedefs.h>
@@ -342,7 +343,7 @@ auto loadSourcesFromFSRM(const char* fileName,
       sources.numberOfSources = numberOfSources;
       sources.mInvJInvPhisAtSources.resize(numberOfSources);
       sources.tensor.resize(numberOfSources);
-      sources.fusedOriginalIndex.resize(numberOfSources); // only used in case of fused simulations
+      sources.simulationIndex.resize(numberOfSources);
       sources.onsetTime.resize(numberOfSources);
       sources.samplingInterval.resize(numberOfSources);
       sources.sampleOffsets[0].resize(numberOfSources + 1);
@@ -352,8 +353,7 @@ auto loadSourcesFromFSRM(const char* fileName,
       for (unsigned clusterSource = 0; clusterSource < numberOfSources; ++clusterSource) {
         const unsigned sourceIndex = clusterMappings[cluster].sources[clusterSource];
         const unsigned fsrmIndex = originalIndex[sourceIndex];
-        sources.fusedOriginalIndex[clusterSource] =
-            fsrmIndex; // only used in case of fused simulations
+        sources.simulationIndex[clusterSource] = fsrmIndex % multisim::NumSimulations;
         computeMInvJInvPhisAtSources(fsrm.centers[fsrmIndex],
                                      sources.mInvJInvPhisAtSources[clusterSource],
                                      meshIds[sourceIndex],
@@ -468,7 +468,7 @@ auto loadSourcesFromNRF(const char* fileName,
       sources.tensor.resize(numberOfSources);
       sources.A.resize(numberOfSources);
       sources.stiffnessTensor.resize(numberOfSources);
-      sources.fusedOriginalIndex.resize(numberOfSources); // only used in case of fused simulations
+      sources.simulationIndex.resize(numberOfSources);
       sources.onsetTime.resize(numberOfSources);
       sources.samplingInterval.resize(numberOfSources);
       for (auto& so : sources.sampleOffsets) {
@@ -489,7 +489,7 @@ auto loadSourcesFromNRF(const char* fileName,
       for (unsigned clusterSource = 0; clusterSource < numberOfSources; ++clusterSource) {
         const unsigned sourceIndex = clusterMappings[cluster].sources[clusterSource];
         const unsigned nrfIndex = originalIndex[sourceIndex];
-        sources.fusedOriginalIndex[clusterSource] = nrfIndex;
+        sources.simulationIndex[clusterSource] = nrfIndex % multisim::NumSimulations;
         transformNRFSourceToInternalSource(
             nrf.centres[nrfIndex],
             meshIds[sourceIndex],

--- a/src/SourceTerm/Typedefs.h
+++ b/src/SourceTerm/Typedefs.h
@@ -41,7 +41,7 @@ struct PointSources {
       seissol::memory::AlignedArray<real, tensor::mInvJInvPhisAtSources::size()>>
       mInvJInvPhisAtSources;
 
-  seissol::memory::MemkindArray<unsigned> fusedOriginalIndex;
+  seissol::memory::MemkindArray<unsigned> simulationIndex;
 
   /** NRF: Basis vectors of the fault.
    * 0-2: Tan1X-Z   = first fault tangent (main slip direction in most cases)
@@ -78,7 +78,7 @@ struct PointSources {
   unsigned numberOfSources = 0;
 
   PointSources(seissol::memory::Memkind memkind)
-      : mInvJInvPhisAtSources(memkind), fusedOriginalIndex(memkind), tensor(memkind), A(memkind),
+      : mInvJInvPhisAtSources(memkind), simulationIndex(memkind), tensor(memkind), A(memkind),
         stiffnessTensor(memkind), onsetTime(memkind), samplingInterval(memkind),
         sampleOffsets{seissol::memory::MemkindArray<std::size_t>(memkind),
                       seissol::memory::MemkindArray<std::size_t>(memkind),
@@ -88,7 +88,7 @@ struct PointSources {
                seissol::memory::MemkindArray<real>(memkind)} {}
   PointSources(const PointSources& source, seissol::memory::Memkind memkind)
       : mInvJInvPhisAtSources(source.mInvJInvPhisAtSources, memkind),
-        fusedOriginalIndex(source.fusedOriginalIndex, memkind), tensor(source.tensor, memkind),
+        simulationIndex(source.simulationIndex, memkind), tensor(source.tensor, memkind),
         A(source.A, memkind), stiffnessTensor(source.stiffnessTensor, memkind),
         onsetTime(source.onsetTime, memkind), samplingInterval(source.samplingInterval, memkind),
         sampleOffsets{seissol::memory::MemkindArray<std::size_t>(source.sampleOffsets[0], memkind),


### PR DESCRIPTION
Instead of storing the original point source index, store the simulation it is used in—that's all we need.

Reason: we can avoid one modulo.

(still, IMO the fused way of point source distribution is pretty inconsistent with running a single simulation tbh)
