### PR TITLE
Modify the `simulationStart` hook for checkpointing

### DIFF
--- a/src/IO/Writer/Module/WriterModule.cpp
+++ b/src/IO/Writer/Module/WriterModule.cpp
@@ -17,6 +17,7 @@
 #include <cassert>
 #include <cmath>
 #include <cstring>
+#include <optional>
 #include <string>
 #include <unordered_set>
 #include <vector>
@@ -61,7 +62,11 @@ void WriterModule::startup() {
   setSyncInterval(settings.interval);
 }
 
-void WriterModule::simulationStart() { syncPoint(0); }
+void WriterModule::simulationStart(std::optional<double> checkpointTime) {
+  if (checkpointTime.value_or(0) == 0) {
+    syncPoint(0);
+  }
+}
 
 void WriterModule::syncPoint(double time) {
   if (lastWrite >= 0) {

--- a/src/IO/Writer/Module/WriterModule.h
+++ b/src/IO/Writer/Module/WriterModule.h
@@ -30,7 +30,7 @@ class WriterModule : public seissol::Module, private AsyncWriterModule {
                const parallel::Pinning& pinning);
   void startup();
   void setUp() override;
-  void simulationStart() override;
+  void simulationStart(std::optional<double> checkpointTime) override;
   void syncPoint(double time) override;
   void simulationEnd() override;
   void shutdown() override;

--- a/src/Modules/Module.h
+++ b/src/Modules/Module.h
@@ -9,6 +9,7 @@
 #ifndef SEISSOL_SRC_MODULES_MODULE_H_
 #define SEISSOL_SRC_MODULES_MODULE_H_
 
+#include <optional>
 namespace seissol {
 
 /**
@@ -96,7 +97,7 @@ class Module {
    *
    * Only called when the simulation is not started from a checkpoint
    */
-  virtual void simulationStart() {}
+  virtual void simulationStart(std::optional<double> checkpointTime) {}
 
   virtual void simulationEnd() {}
 

--- a/src/Modules/Modules.cpp
+++ b/src/Modules/Modules.cpp
@@ -11,6 +11,7 @@
 #include <cassert>
 #include <cstddef>
 #include <limits>
+#include <optional>
 #include <utility>
 #include <utils/logger.h>
 
@@ -77,6 +78,12 @@ double Modules::_callSyncHook(double currentTime, double timeTolerance, bool for
   return nextSyncTime;
 }
 
+void Modules::_callSimulationStartHook(std::optional<double> checkpointTime) {
+  for (auto& [_, module] : hooks[static_cast<size_t>(ModuleHook::SimulationStart)]) {
+    module->simulationStart(checkpointTime);
+  }
+}
+
 void Modules::_setSimulationStartTime(double time) {
   assert(static_cast<int>(nextHook) <= static_cast<int>(ModuleHook::SynchronizationPoint));
 
@@ -99,6 +106,10 @@ double Modules::callSyncHook(double currentTime, double timeTolerance, bool forc
   return instance()._callSyncHook(currentTime, timeTolerance, forceSyncPoint);
 }
 
+void Modules::callSimulationStartHook(std::optional<double> checkpointTime) {
+  instance()._callSimulationStartHook(checkpointTime);
+}
+
 void Modules::setSimulationStartTime(double time) { instance()._setSimulationStartTime(time); }
 
 // Create all template instances for call
@@ -116,7 +127,6 @@ MODULES_CALL_INSTANCE(ModuleHook::PreLtsInit, preLtsInit)
 MODULES_CALL_INSTANCE(ModuleHook::PostLtsInit, postLtsInit)
 MODULES_CALL_INSTANCE(ModuleHook::PreModel, preModel)
 MODULES_CALL_INSTANCE(ModuleHook::PostModel, postModel)
-MODULES_CALL_INSTANCE(ModuleHook::SimulationStart, simulationStart)
 MODULES_CALL_INSTANCE(ModuleHook::SimulationEnd, simulationEnd)
 MODULES_CALL_INSTANCE(ModuleHook::Shutdown, shutdown)
 

--- a/src/Modules/Modules.h
+++ b/src/Modules/Modules.h
@@ -15,6 +15,7 @@
 #include <array>
 #include <limits>
 #include <map>
+#include <optional>
 
 namespace seissol {
 
@@ -99,6 +100,8 @@ class Modules {
 
   double _callSyncHook(double currentTime, double timeTolerance, bool forceSyncPoint);
 
+  void _callSimulationStartHook(std::optional<double> checkpointTime);
+
   /**
    * Set the simulation start time.
    *
@@ -139,11 +142,18 @@ class Modules {
    */
   static double callSyncHook(double currentTime, double timeTolerance, bool forceSyncPoint = false);
 
+  static void callSimulationStartHook(std::optional<double> checkpointTime);
+
   /**
    * Set the simulation start time
    */
   static void setSimulationStartTime(double time);
 };
+
+template <>
+inline void seissol::Modules::_callHook<ModuleHook::SimulationStart>() {
+  logError() << "Simulation start hooks have to be called with \"callSimulationStartHook\"";
+}
 
 template <>
 inline void seissol::Modules::_callHook<ModuleHook::SynchronizationPoint>() {

--- a/src/ResultWriter/EnergyOutput.cpp
+++ b/src/ResultWriter/EnergyOutput.cpp
@@ -39,6 +39,7 @@
 #include <kernel.h>
 #include <limits>
 #include <mpi.h>
+#include <optional>
 #include <ostream>
 #include <string>
 #include <tensor.h>
@@ -181,14 +182,14 @@ void EnergyOutput::syncPoint(double time) {
   logInfo() << "Writing energy output at time" << time << "Done.";
 }
 
-void EnergyOutput::simulationStart() {
+void EnergyOutput::simulationStart(std::optional<double> checkpointTime) {
   if (isFileOutputEnabled) {
     out.open(outputFileName);
     out << std::scientific;
     out << std::setprecision(std::numeric_limits<real>::max_digits10);
     writeHeader();
   }
-  syncPoint(0.0);
+  syncPoint(checkpointTime.value_or(0));
 }
 
 EnergyOutput::~EnergyOutput() {

--- a/src/ResultWriter/EnergyOutput.h
+++ b/src/ResultWriter/EnergyOutput.h
@@ -73,7 +73,7 @@ class EnergyOutput : public Module {
 
   void syncPoint(double time) override;
 
-  void simulationStart() override;
+  void simulationStart(std::optional<double> checkpointTime) override;
 
   EnergyOutput(seissol::SeisSol& seissolInstance) : seissolInstance(seissolInstance) {}
 

--- a/src/ResultWriter/FaultWriter.cpp
+++ b/src/ResultWriter/FaultWriter.cpp
@@ -13,6 +13,7 @@
 #include <async/Module.h>
 #include <cassert>
 #include <cstring>
+#include <optional>
 #include <string>
 #include <utils/logger.h>
 
@@ -150,7 +151,11 @@ void seissol::writer::FaultWriter::init(const unsigned int* cells,
   setSyncInterval(interval);
 }
 
-void seissol::writer::FaultWriter::simulationStart() { syncPoint(0.0); }
+void seissol::writer::FaultWriter::simulationStart(std::optional<double> checkpointTime) {
+  if (checkpointTime.value_or(0) == 0) {
+    syncPoint(0.0);
+  }
+}
 
 void seissol::writer::FaultWriter::syncPoint(double currentTime) {
   SCOREP_USER_REGION("faultoutput_elementwise", SCOREP_USER_REGION_TYPE_FUNCTION)

--- a/src/ResultWriter/FaultWriter.h
+++ b/src/ResultWriter/FaultWriter.h
@@ -135,7 +135,7 @@ class FaultWriter : private async::Module<FaultWriterExecutor, FaultInitParam, F
   //
   // Hooks
   //
-  void simulationStart() override;
+  void simulationStart(std::optional<double> checkpointTime) override;
 
   void syncPoint(double currentTime) override;
 };

--- a/src/ResultWriter/FreeSurfaceWriter.cpp
+++ b/src/ResultWriter/FreeSurfaceWriter.cpp
@@ -19,6 +19,7 @@
 #include <async/Module.h>
 #include <cassert>
 #include <cstring>
+#include <optional>
 #include <string>
 #include <utils/logger.h>
 #include <vector>
@@ -207,7 +208,11 @@ void seissol::writer::FreeSurfaceWriter::write(double time) {
   logInfo() << "Writing free surface at time" << utils::nospace << time << ". Done.";
 }
 
-void seissol::writer::FreeSurfaceWriter::simulationStart() { syncPoint(0.0); }
+void seissol::writer::FreeSurfaceWriter::simulationStart(std::optional<double> checkpointTime) {
+  if (checkpointTime.value_or(0) == 0) {
+    syncPoint(0.0);
+  }
+}
 
 void seissol::writer::FreeSurfaceWriter::syncPoint(double currentTime) {
   SCOREP_USER_REGION("freesurfaceoutput", SCOREP_USER_REGION_TYPE_FUNCTION)

--- a/src/ResultWriter/FreeSurfaceWriter.h
+++ b/src/ResultWriter/FreeSurfaceWriter.h
@@ -87,7 +87,7 @@ class FreeSurfaceWriter
   //
   // Hooks
   //
-  void simulationStart() override;
+  void simulationStart(std::optional<double> checkpointTime) override;
 
   void syncPoint(double currentTime) override;
 };

--- a/src/ResultWriter/ReceiverWriter.cpp
+++ b/src/ResultWriter/ReceiverWriter.cpp
@@ -27,6 +27,7 @@
 #include <memory>
 #include <mpi.h>
 #include <numeric>
+#include <optional>
 #include <ostream>
 #include <regex>
 #include <sstream>
@@ -252,7 +253,7 @@ void ReceiverWriter::addPoints(const seissol::geometry::MeshReader& mesh,
   }
 }
 
-void ReceiverWriter::simulationStart() {
+void ReceiverWriter::simulationStart(std::optional<double> checkpointTime) {
   for (auto& [layer, clusters] : m_receiverClusters) {
     for (auto& cluster : clusters) {
       cluster.allocateData();

--- a/src/ResultWriter/ReceiverWriter.h
+++ b/src/ResultWriter/ReceiverWriter.h
@@ -54,7 +54,7 @@ class ReceiverWriter : public seissol::Module {
   // Hooks
   //
   void syncPoint(double /*currentTime*/) override;
-  void simulationStart() override;
+  void simulationStart(std::optional<double> checkpointTime) override;
   void shutdown() override;
 
   private:

--- a/src/ResultWriter/WaveFieldWriter.cpp
+++ b/src/ResultWriter/WaveFieldWriter.cpp
@@ -20,6 +20,7 @@
 #include <map>
 #include <memory>
 #include <mpi.h>
+#include <optional>
 #include <ostream>
 #include <string>
 #include <utility>
@@ -498,6 +499,10 @@ void seissol::writer::WaveFieldWriter::write(double time) {
   logInfo() << "Writing wave field at time" << utils::nospace << time << ". Done.";
 }
 
-void seissol::writer::WaveFieldWriter::simulationStart() { syncPoint(0.0); }
+void seissol::writer::WaveFieldWriter::simulationStart(std::optional<double> checkpointTime) {
+  if (checkpointTime.value_or(0) == 0) {
+    syncPoint(0.0);
+  }
+}
 
 void seissol::writer::WaveFieldWriter::syncPoint(double currentTime) { write(currentTime); }

--- a/src/ResultWriter/WaveFieldWriter.h
+++ b/src/ResultWriter/WaveFieldWriter.h
@@ -194,7 +194,7 @@ class WaveFieldWriter
   //
   // Hooks
   //
-  void simulationStart() override;
+  void simulationStart(std::optional<double> checkpointTime) override;
 
   void syncPoint(double currentTime) override;
 };

--- a/src/Solver/Simulator.cpp
+++ b/src/Solver/Simulator.cpp
@@ -37,6 +37,7 @@ void seissol::Simulator::setUsePlasticity( bool plasticity ) {
 void seissol::Simulator::setCurrentTime( double i_currentTime ) {
 	assert( i_currentTime >= 0 );
 	m_currentTime = i_currentTime;
+  checkpoint = true;
 }
 
 void seissol::Simulator::abort() {
@@ -64,8 +65,11 @@ void seissol::Simulator::simulate(seissol::SeisSol& seissolInstance) {
   double timeTolerance = seissolInstance.timeManager().getTimeTolerance();
 
   // Write initial wave field snapshot
-  if (m_currentTime == 0.0) {
-    Modules::callHook<ModuleHook::SimulationStart>();
+  if (checkpoint) {
+    Modules::callSimulationStartHook(m_currentTime);
+  }
+  else {
+    Modules::callSimulationStartHook(std::optional<double>{});
   }
 
   // intialize wave field and checkpoint time

--- a/src/Solver/Simulator.h
+++ b/src/Solver/Simulator.h
@@ -31,6 +31,8 @@ class seissol::Simulator {
 
     //! If true, the while loop of the simulation will be aborted (see terminator)
     bool m_abort;
+
+    bool checkpoint{false};
   public:
     /**
      * Constructor, which initializes all values.


### PR DESCRIPTION
Mainly e.g. due to the energy output file not being written out after a checkpoint restart.
