### PR TITLE
Fix assert, fix #396

### DIFF
--- a/src/Initializer/ParameterDB.cpp
+++ b/src/Initializer/ParameterDB.cpp
@@ -630,7 +630,7 @@ std::shared_ptr<QueryGenerator> getBestQueryGenerator(bool plasticity,
   if (!useCellHomogenizedMaterial) {
     queryGen = std::make_shared<ElementBarycenterGenerator>(cellToVertex);
   } else {
-    if (MaterialT::Type != MaterialType::Viscoelastic || MaterialT::Type != MaterialType::Elastic) {
+    if (MaterialT::Type != MaterialType::Viscoelastic && MaterialT::Type != MaterialType::Elastic) {
       logWarning() << "Material Averaging is not implemented for " << MaterialT::Text
                    << " materials. Falling back to "
                       "material properties sampled from the element barycenters instead.";

--- a/src/Initializer/TimeStepping/LtsLayout.cpp
+++ b/src/Initializer/TimeStepping/LtsLayout.cpp
@@ -489,7 +489,7 @@ void seissol::initializer::time_stepping::LtsLayout::deriveClusteredCopyInterior
 
         // local id in the ghost region
         unsigned int l_localGhostCell = m_cells[l_cell].mpiIndices[l_face];
-        assert( l_localGhostCell < m_numberOfPlainGhostCells[l_plainRegion] );
+        assert( l_localGhostCell < m_mesh->getGhostlayerMetadata().at(m_cells[l_cell].neighborRanks[l_face]).size() );
 
         // neighboring cluster id
         unsigned int l_neighboringClusterId = m_mesh->getGhostlayerMetadata().at(m_cells[l_cell].neighborRanks[l_face])[l_localGhostCell].clusterId;

--- a/src/Solver/FreeSurfaceIntegrator.cpp
+++ b/src/Solver/FreeSurfaceIntegrator.cpp
@@ -49,10 +49,10 @@ seissol::solver::FreeSurfaceIntegrator::~FreeSurfaceIntegrator()
   for (unsigned dim = 0; dim < FREESURFACE_NUMBER_OF_COMPONENTS; ++dim) {
     seissol::memory::free(velocities[dim]);
     seissol::memory::free(displacements[dim]);
-
-    seissol::memory::free(projectionMatrixMemory);
-    seissol::memory::free(projectionMatrixFromFace);
   }
+
+  seissol::memory::free(projectionMatrixMemory);
+  seissol::memory::free(projectionMatrixFromFace);
 }
 
 

--- a/src/Solver/FreeSurfaceIntegrator.h
+++ b/src/Solver/FreeSurfaceIntegrator.h
@@ -42,15 +42,15 @@ private:
     void addTo(seissol::initializer::LTSTree& surfaceLtsTree);
   };
 
-  std::unique_ptr<real> projectionMatrixMemory;
-  real* projectionMatrix[4];
-  std::unique_ptr<real> projectionMatrixFromFace;
-  unsigned numberOfSubTriangles;
-  unsigned numberOfAlignedSubTriangles;
+  real* projectionMatrixMemory{nullptr};
+  real* projectionMatrix[4]{};
+  real* projectionMatrixFromFace{nullptr};
+  unsigned numberOfSubTriangles{0};
+  unsigned numberOfAlignedSubTriangles{0};
 
   static constexpr auto polyDegree = ConvergenceOrder-1;
   static constexpr auto numQuadraturePoints = polyDegree*polyDegree;
-  bool m_enabled;
+  bool m_enabled{false};
   
   void initializeProjectionMatrices(unsigned maxRefinementDepth);
   void computeSubTriangleAverages(real* projectionMatrixRow,
@@ -68,10 +68,9 @@ public:
   real* velocities[FREESURFACE_NUMBER_OF_COMPONENTS];
   real* displacements[FREESURFACE_NUMBER_OF_COMPONENTS];
 
-public:
   std::vector<unsigned int> locationFlags;
   unsigned totalNumberOfFreeSurfaces;
-  unsigned totalNumberOfTriangles;
+  unsigned totalNumberOfTriangles{0};
 
   SurfaceLTS surfaceLts;
   seissol::initializer::LTSTree surfaceLtsTree;


### PR DESCRIPTION
Transform #396 to utilizing the SeisSol memory allocator methods; which should fix the problems—as in all other cases (yes, we could modify the unique pointer with a C++-style allocator here—probably not yet worth the effort; maybe soon). The problem may have lied with using a C++ `delete` onto a `posix_memalign` allocation.

Fix #396

(further formatting of the `Solver` folder will be done by #1122)
