### PR TITLE
Update the validation scripts, pipelines

### DIFF
--- a/.github/workflows/build-seissol-cpu.yml
+++ b/.github/workflows/build-seissol-cpu.yml
@@ -212,7 +212,7 @@ jobs:
           - name: tpv5-poro
             equation: poroelastic
             multisim: 1
-            energies: true
+            energies: false # incomplete, hence disabled
             receivers: true
             fault: true
           - name: tpv6
@@ -231,7 +231,7 @@ jobs:
             equation: elastic
             multisim: 1
             energies: true
-            receivers: false # FIXME: do not work right now; disabled in the Gitlab CI
+            receivers: true
             fault: true
           #- name: tpv33
           #  equation: elastic

--- a/.github/workflows/build-seissol-gpu.yml
+++ b/.github/workflows/build-seissol-gpu.yml
@@ -208,7 +208,7 @@ jobs:
           #- name: tpv5-poro
           #  equation: poroelastic
           #  multisim: 1
-          #  energies: true
+          #  energies: false # incomplete, hence disabled
           #  receivers: true
           #  fault: true
           - name: tpv6
@@ -227,8 +227,8 @@ jobs:
             equation: elastic
             multisim: 1
             energies: true
-            receivers: false # FIXME: does not work right now; disabled in the Gitlab CI
-            fault: false
+            receivers: true
+            fault: true
           - name: tpv101
             equation: elastic
             multisim: 1


### PR DESCRIPTION
Rework the validation scripts a bit:

* disable the poroelastic energy comparison (broken since #1304, as the volume energies are now computed for isotropic elastic)
* fix and robustify the energy comparison for fused simulations
* start correcting some bugs in the receiver comparison
