### PR TITLE
Renaming of loop indices in DR output manager and Receiver output

### DIFF
--- a/src/DynamicRupture/Output/OutputManager.cpp
+++ b/src/DynamicRupture/Output/OutputManager.cpp
@@ -327,8 +327,8 @@ void OutputManager::initPickpointOutput() {
           const auto* initialStressVar = layer->var(drDescr->initialStressInFaultCS);
           const auto* initialStress = initialStressVar[face];
           std::array<real, 6> unrotatedInitialStress{};
-          for (std::size_t i = 0; i < unrotatedInitialStress.size(); ++i) {
-            unrotatedInitialStress[i] = initialStress[i][receiver.nearestGpIndex];
+          for (std::size_t stressVar = 0; stressVar < unrotatedInitialStress.size(); ++stressVar) {
+            unrotatedInitialStress[stressVar] = initialStress[stressVar][receiver.nearestGpIndex];
           }
 
           seissol::dynamicRupture::kernel::rotateInitStress alignAlongDipAndStrikeKernel;

--- a/src/DynamicRupture/Output/ReceiverBasedOutput.cpp
+++ b/src/DynamicRupture/Output/ReceiverBasedOutput.cpp
@@ -250,8 +250,8 @@ void ReceiverOutput::calcFaultOutput(
     if (totalTractions.isActive) {
       std::array<real, tensor::initialStress::size()> unrotatedInitStress{};
       std::array<real, tensor::rotatedStress::size()> rotatedInitStress{};
-      for (std::size_t i = 0; i < unrotatedInitStress.size(); ++i) {
-        unrotatedInitStress[i] = initStresses[i][local.nearestGpIndex];
+      for (std::size_t stressVar = 0; stressVar < unrotatedInitStress.size(); ++stressVar) {
+        unrotatedInitStress[stressVar] = initStresses[stressVar][local.nearestGpIndex];
       }
       alignAlongDipAndStrikeKernel.initialStress = unrotatedInitStress.data();
       alignAlongDipAndStrikeKernel.rotatedStress = rotatedInitStress.data();


### PR DESCRIPTION
Simple renaming of loop variables as the same loop variable is used as a variable for the outer loop and inner loop. Just creates a small confusion when debugging things. 