### PR TITLE
Fix the CI once more; add issue types to the issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,9 +1,10 @@
 ---
 name: Bug report
-about: Create a report to help us improve
+about: Report a problem with SeisSol that should not appear
 title: ''
 labels: 'bug'
 assignees: ''
+type: 'Bug'
 ---
 <!-- markdownlint-disable MD041 -->
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,7 +1,8 @@
 ---
 name: Feature request
 about: Suggest adding a feature that is not yet in SeisSol  
-labels: feature
+labels: 'feature-request'
+type: 'Feature'
 ---
 <!-- markdownlint-disable MD041 -->
 

--- a/postprocessing/validation/compare-energies.py
+++ b/postprocessing/validation/compare-energies.py
@@ -33,11 +33,8 @@ def get_number_of_fused_sims(df):
 
 def get_sub_simulation(df, fused_index):
     if "simulation_index" not in df.columns:
-        sub_df = pd.DataFrame()
-        for c in df.columns:
-            if int(c[-1]) == fused_index:
-                sub_df[c[:-1]] = df[c]
-        return sub_df
+        # if there's no simulation_index, we're not fused
+        return 0
     else:
         is_subsim = df["simulation_index"] == fused_index
         return df.loc[is_subsim, :].reset_index()


### PR DESCRIPTION
* fix the CI again, by just assuming that every energy file that's without `simulation_index` is not fused. (by now, all of them contain the index; but the `precomputed-seissol` comparison ones usually don't)
* add issue types to the issue template
