### PR TITLE
Update SeisSol after updating the Device Submodules

### DIFF
--- a/auto-tuning/proxy/src/Main.cpp
+++ b/auto-tuning/proxy/src/Main.cpp
@@ -80,7 +80,6 @@ auto main(int argc, char* argv[]) -> int {
   auto& device = DeviceType::getInstance();
   device.api->setDevice(0);
   device.api->initialize();
-  device.api->allocateStackMem();
 #endif
   print_hostname();
 

--- a/src/Equations/elastic/Kernels/Local.cpp
+++ b/src/Equations/elastic/Kernels/Local.cpp
@@ -275,15 +275,15 @@ void Local::computeBatchedIntegral(ConditionalPointersToRealsTable& dataTable,
 
   const auto maxTmpMem = yateto::getMaxTmpMemRequired(volKrnl, localFluxKrnl);
 
-  real* tmpMem = nullptr;
+  // volume kernel always contains more elements than any local one
+  const auto maxNumElements = dataTable.find(key) != dataTable.end()
+                                  ? (dataTable[key].get(inner_keys::Wp::Id::Dofs))->getSize()
+                                  : 0;
+  auto tmpMem = runtime.memoryHandle<real>((maxTmpMem * maxNumElements) / sizeof(real));
   if (dataTable.find(key) != dataTable.end()) {
     auto& entry = dataTable[key];
 
-    unsigned maxNumElements = (entry.get(inner_keys::Wp::Id::Dofs))->getSize();
     volKrnl.numElements = maxNumElements;
-
-    // volume kernel always contains more elements than any local one
-    tmpMem = (real*)(device.api->getStackMemory(maxTmpMem * maxNumElements));
 
     volKrnl.Q = (entry.get(inner_keys::Wp::Id::Dofs))->getDeviceDataPtr();
     volKrnl.I =
@@ -296,7 +296,7 @@ void Local::computeBatchedIntegral(ConditionalPointersToRealsTable& dataTable,
       volKrnl.extraOffset_star(i) = starOffset;
       starOffset += tensor::star::size(i);
     }
-    volKrnl.linearAllocator.initialize(tmpMem);
+    volKrnl.linearAllocator.initialize(tmpMem.get());
     volKrnl.streamPtr = runtime.stream();
     volKrnl.execute();
   }
@@ -313,7 +313,7 @@ void Local::computeBatchedIntegral(ConditionalPointersToRealsTable& dataTable,
           const_cast<const real**>((entry.get(inner_keys::Wp::Id::Idofs))->getDeviceDataPtr());
       localFluxKrnl.AplusT =
           const_cast<const real**>(entry.get(inner_keys::Wp::Id::AplusT)->getDeviceDataPtr());
-      localFluxKrnl.linearAllocator.initialize(tmpMem);
+      localFluxKrnl.linearAllocator.initialize(tmpMem.get());
       localFluxKrnl.streamPtr = runtime.stream();
       localFluxKrnl.execute(face);
     }
@@ -359,9 +359,6 @@ void Local::computeBatchedIntegral(ConditionalPointersToRealsTable& dataTable,
                                          device,
                                          runtime);
     }
-  }
-  if (tmpMem != nullptr) {
-    device.api->popStackMemory();
   }
 #else
   logError() << "No GPU implementation provided";

--- a/src/Equations/elastic/Kernels/Time.cpp
+++ b/src/Equations/elastic/Kernels/Time.cpp
@@ -226,16 +226,15 @@ void Time::computeBatchedAder(double timeStepWidth,
         runtime.stream());
 
     const auto maxTmpMem = yateto::getMaxTmpMemRequired(derivativesKrnl);
-    real* tmpMem = reinterpret_cast<real*>(device.api->getStackMemory(maxTmpMem * numElements));
+    auto tmpMem = runtime.memoryHandle<real>((maxTmpMem * numElements) / sizeof(real));
 
     derivativesKrnl.power(0) = timeStepWidth;
     for (std::size_t Der = 1; Der < ConvergenceOrder; ++Der) {
       derivativesKrnl.power(Der) = derivativesKrnl.power(Der - 1) * timeStepWidth / real(Der + 1);
     }
-    derivativesKrnl.linearAllocator.initialize(tmpMem);
+    derivativesKrnl.linearAllocator.initialize(tmpMem.get());
     derivativesKrnl.streamPtr = runtime.stream();
     derivativesKrnl.execute();
-    device.api->popStackMemory();
   }
 
   if (updateDisplacement) {
@@ -348,8 +347,8 @@ void Time::computeBatchedIntegral(double expansionPoint,
 
   kernel::gpu_derivativeTaylorExpansion intKrnl;
   intKrnl.numElements = numElements;
-  real* tmpMem = reinterpret_cast<real*>(
-      device.api->getStackMemory(intKrnl.TmpMaxMemRequiredInBytes * numElements));
+  auto tmpMem =
+      runtime.memoryHandle<real>((intKrnl.TmpMaxMemRequiredInBytes * numElements) / sizeof(real));
 
   intKrnl.I = timeIntegratedDofs;
 
@@ -369,10 +368,9 @@ void Time::computeBatchedIntegral(double expansionPoint,
     intKrnl.power(der) = firstTerm - secondTerm;
     intKrnl.power(der) /= factorial;
   }
-  intKrnl.linearAllocator.initialize(tmpMem);
+  intKrnl.linearAllocator.initialize(tmpMem.get());
   intKrnl.streamPtr = runtime.stream();
   intKrnl.execute();
-  device.api->popStackMemory();
 #else
   seissol::kernels::time::aux::taylorSum(true,
                                          numElements,

--- a/src/Equations/elastic/Kernels/Time.cpp
+++ b/src/Equations/elastic/Kernels/Time.cpp
@@ -219,7 +219,7 @@ void Time::computeBatchedAder(double timeStepWidth,
 
     // stream dofs to the zero derivative
     device.algorithms.streamBatchedData(
-        (entry.get(inner_keys::Wp::Id::Dofs))->getDeviceDataPtr(),
+        const_cast<const real**>((entry.get(inner_keys::Wp::Id::Dofs))->getDeviceDataPtr()),
         (entry.get(inner_keys::Wp::Id::Derivatives))->getDeviceDataPtr(),
         tensor::Q::Size,
         derivativesKrnl.numElements,

--- a/src/Initializer/BatchRecorders/DataTypes/Table.h
+++ b/src/Initializer/BatchRecorders/DataTypes/Table.h
@@ -51,7 +51,7 @@ class GenericTableEntry {
 
   virtual ~GenericTableEntry() {
     if (deviceDataPtr != nullptr) {
-      device.api->freeMem(deviceDataPtr);
+      device.api->freeGlobMem(deviceDataPtr);
       deviceDataPtr = nullptr;
     }
   }

--- a/src/Kernels/Plasticity.cpp
+++ b/src/Kernels/Plasticity.cpp
@@ -265,8 +265,12 @@ void Plasticity::computePlasticityBatched(
     auto prevDofs = runtime.memoryHandle<real>(prevDofsSize);
 
     real** dofsPtrs = (entry.get(inner_keys::Wp::Id::Dofs))->getDeviceDataPtr();
-    device.algorithms.copyScatterToUniform(
-        dofsPtrs, prevDofs.get(), DofsSize, DofsSize, numElements, defaultStream);
+    device.algorithms.copyScatterToUniform(const_cast<const real**>(dofsPtrs),
+                                           prevDofs.get(),
+                                           DofsSize,
+                                           DofsSize,
+                                           numElements,
+                                           defaultStream);
 
     // Convert modal to nodal
     real** modalStressTensors = (entry.get(inner_keys::Wp::Id::Dofs))->getDeviceDataPtr();

--- a/src/Kernels/Plasticity.cpp
+++ b/src/Kernels/Plasticity.cpp
@@ -236,13 +236,14 @@ unsigned Plasticity::computePlasticity(double oneMinusIntegratingFactor,
   return 0;
 }
 
-unsigned Plasticity::computePlasticityBatched(
+void Plasticity::computePlasticityBatched(
     double oneMinusIntegratingFactor,
     double timeStepWidth,
     double tV,
     const GlobalData* global,
     initializer::recording::ConditionalPointersToRealsTable& table,
     seissol::model::PlasticityData* plasticityData,
+    unsigned* yieldCounter,
     seissol::parallel::runtime::StreamRuntime& runtime) {
 #ifdef ACL_DEVICE
   static_assert(tensor::Q::Shape[0] == tensor::QStressNodal::Shape[0],
@@ -255,19 +256,17 @@ unsigned Plasticity::computePlasticityBatched(
   auto defaultStream = runtime.stream();
 
   if (table.find(key) != table.end()) {
-    unsigned stackMemCounter{0};
     auto& entry = table[key];
     const size_t numElements = (entry.get(inner_keys::Wp::Id::Dofs))->getSize();
 
     // copy dofs for later comparison, only first dof of stresses required
     constexpr unsigned DofsSize = tensor::Q::Size;
-    const size_t prevDofsSize = DofsSize * numElements * sizeof(real);
-    real* prevDofs = reinterpret_cast<real*>(device.api->getStackMemory(prevDofsSize));
-    ++stackMemCounter;
+    const size_t prevDofsSize = DofsSize * numElements;
+    auto prevDofs = runtime.memoryHandle<real>(prevDofsSize);
 
     real** dofsPtrs = (entry.get(inner_keys::Wp::Id::Dofs))->getDeviceDataPtr();
     device.algorithms.copyScatterToUniform(
-        dofsPtrs, prevDofs, DofsSize, DofsSize, numElements, defaultStream);
+        dofsPtrs, prevDofs.get(), DofsSize, DofsSize, numElements, defaultStream);
 
     // Convert modal to nodal
     real** modalStressTensors = (entry.get(inner_keys::Wp::Id::Dofs))->getDeviceDataPtr();
@@ -288,20 +287,22 @@ unsigned Plasticity::computePlasticityBatched(
     m2nKrnl.execute();
 
     // adjust deviatoric tensors
-    auto* isAdjustableVector =
-        reinterpret_cast<unsigned*>(device.api->getStackMemory(numElements * sizeof(unsigned)));
-    ++stackMemCounter;
+    auto isAdjustableVector = runtime.memoryHandle<unsigned>(numElements);
 
     device::aux::plasticity::adjustDeviatoricTensors(nodalStressTensors,
-                                                     isAdjustableVector,
+                                                     isAdjustableVector.get(),
                                                      plasticityData,
                                                      oneMinusIntegratingFactor,
                                                      numElements,
                                                      defaultStream);
 
     // count how many elements needs to be adjusted
-    unsigned numAdjustedElements = device.algorithms.reduceVector(
-        isAdjustableVector, numElements, ::device::ReductionType::Add, defaultStream);
+    device.algorithms.reduceVector(yieldCounter,
+                                   isAdjustableVector.get(),
+                                   true,
+                                   numElements,
+                                   ::device::ReductionType::Add,
+                                   defaultStream);
 
     // convert back to modal (taking into account the adjustment)
     static_assert(kernel::gpu_plConvertToModal::TmpMaxMemRequiredInBytes == 0);
@@ -310,35 +311,27 @@ unsigned Plasticity::computePlasticityBatched(
     n2mKrnl.QStressNodal = const_cast<const real**>(nodalStressTensors);
     n2mKrnl.QStress = modalStressTensors;
     n2mKrnl.streamPtr = defaultStream;
-    n2mKrnl.flags = isAdjustableVector;
+    n2mKrnl.flags = isAdjustableVector.get();
     n2mKrnl.numElements = numElements;
     n2mKrnl.execute();
 
     // prepare memory
-    const size_t qEtaNodalSize = tensor::QEtaNodal::Size * numElements * sizeof(real);
-    real* qEtaNodal = reinterpret_cast<real*>(device.api->getStackMemory(qEtaNodalSize));
-    real** qEtaNodalPtrs =
-        reinterpret_cast<real**>(device.api->getStackMemory(numElements * sizeof(real*)));
+    auto qEtaNodal = runtime.memoryHandle<real>(tensor::QEtaNodal::Size * numElements);
+    auto qEtaNodalPtrs = runtime.memoryHandle<real*>(numElements);
 
-    const size_t qEtaModalSize = tensor::QEtaModal::Size * numElements * sizeof(real);
-    real* qEtaModal = reinterpret_cast<real*>(device.api->getStackMemory(qEtaModalSize));
-    real** qEtaModalPtrs =
-        reinterpret_cast<real**>(device.api->getStackMemory(numElements * sizeof(real*)));
+    auto qEtaModal = runtime.memoryHandle<real>(tensor::QEtaModal::Size * numElements);
+    auto qEtaModalPtrs = runtime.memoryHandle<real*>(numElements);
 
     static_assert(tensor::QStress::Size == tensor::QStressNodal::Size);
-    const size_t dUdTpstrainSize = tensor::QStressNodal::Size * numElements * sizeof(real);
-    real* dUdTpstrain = reinterpret_cast<real*>(device.api->getStackMemory(dUdTpstrainSize));
-    real** dUdTpstrainPtrs =
-        reinterpret_cast<real**>(device.api->getStackMemory(numElements * sizeof(real*)));
+    auto dUdTpstrain = runtime.memoryHandle<real>(tensor::QStressNodal::Size * numElements);
+    auto dUdTpstrainPtrs = runtime.memoryHandle<real*>(numElements);
 
-    stackMemCounter += 6;
-
-    device::aux::plasticity::adjustPointers(qEtaNodal,
-                                            qEtaNodalPtrs,
-                                            qEtaModal,
-                                            qEtaModalPtrs,
-                                            dUdTpstrain,
-                                            dUdTpstrainPtrs,
+    device::aux::plasticity::adjustPointers(qEtaNodal.get(),
+                                            qEtaNodalPtrs.get(),
+                                            qEtaModal.get(),
+                                            qEtaModalPtrs.get(),
+                                            dUdTpstrain.get(),
+                                            dUdTpstrainPtrs.get(),
                                             numElements,
                                             defaultStream);
 
@@ -348,12 +341,12 @@ unsigned Plasticity::computePlasticityBatched(
     device::aux::plasticity::computePstrains(pstrains,
                                              plasticityData,
                                              dofs,
-                                             prevDofs,
-                                             dUdTpstrainPtrs,
+                                             prevDofs.get(),
+                                             dUdTpstrainPtrs.get(),
                                              tV,
                                              oneMinusIntegratingFactor,
                                              timeStepWidth,
-                                             isAdjustableVector,
+                                             isAdjustableVector.get(),
                                              numElements,
                                              defaultStream);
 
@@ -361,32 +354,32 @@ unsigned Plasticity::computePlasticityBatched(
     static_assert(kernel::gpu_plConvertToNodalNoLoading::TmpMaxMemRequiredInBytes == 0);
     kernel::gpu_plConvertToNodalNoLoading m2nKrnlDudtPstrain;
     m2nKrnlDudtPstrain.v = global->vandermondeMatrix;
-    m2nKrnlDudtPstrain.QStress = const_cast<const real**>(dUdTpstrainPtrs);
+    m2nKrnlDudtPstrain.QStress = const_cast<const real**>(dUdTpstrainPtrs.get());
     m2nKrnlDudtPstrain.QStressNodal = nodalStressTensors;
     m2nKrnlDudtPstrain.streamPtr = defaultStream;
-    m2nKrnlDudtPstrain.flags = isAdjustableVector;
+    m2nKrnlDudtPstrain.flags = isAdjustableVector.get();
     m2nKrnlDudtPstrain.numElements = numElements;
     m2nKrnlDudtPstrain.execute();
 
     device::aux::plasticity::pstrainToQEtaModal(
-        pstrains, qEtaModalPtrs, isAdjustableVector, numElements, defaultStream);
+        pstrains, qEtaModalPtrs.get(), isAdjustableVector.get(), numElements, defaultStream);
 
     // Convert modal to nodal
     static_assert(kernel::gpu_plConvertEtaModal2Nodal::TmpMaxMemRequiredInBytes == 0);
     kernel::gpu_plConvertEtaModal2Nodal m2nEtaKrnl;
     m2nEtaKrnl.v = global->vandermondeMatrix;
-    m2nEtaKrnl.QEtaModal = const_cast<const real**>(qEtaModalPtrs);
-    m2nEtaKrnl.QEtaNodal = qEtaNodalPtrs;
+    m2nEtaKrnl.QEtaModal = const_cast<const real**>(qEtaModalPtrs.get());
+    m2nEtaKrnl.QEtaNodal = qEtaNodalPtrs.get();
     m2nEtaKrnl.streamPtr = defaultStream;
-    m2nEtaKrnl.flags = isAdjustableVector;
+    m2nEtaKrnl.flags = isAdjustableVector.get();
     m2nEtaKrnl.numElements = numElements;
     m2nEtaKrnl.execute();
 
     // adjust: QEtaNodal
-    device::aux::plasticity::updateQEtaNodal(qEtaNodalPtrs,
+    device::aux::plasticity::updateQEtaNodal(qEtaNodalPtrs.get(),
                                              nodalStressTensors,
                                              timeStepWidth,
-                                             isAdjustableVector,
+                                             isAdjustableVector.get(),
                                              numElements,
                                              defaultStream);
 
@@ -394,35 +387,19 @@ unsigned Plasticity::computePlasticityBatched(
     static_assert(kernel::gpu_plConvertEtaNodal2Modal::TmpMaxMemRequiredInBytes == 0);
     kernel::gpu_plConvertEtaNodal2Modal n2mEtaKrnl;
     n2mEtaKrnl.vInv = global->vandermondeMatrixInverse;
-    n2mEtaKrnl.QEtaNodal = const_cast<const real**>(qEtaNodalPtrs);
-    n2mEtaKrnl.QEtaModal = qEtaModalPtrs;
+    n2mEtaKrnl.QEtaNodal = const_cast<const real**>(qEtaNodalPtrs.get());
+    n2mEtaKrnl.QEtaModal = qEtaModalPtrs.get();
     n2mEtaKrnl.streamPtr = defaultStream;
-    n2mEtaKrnl.flags = isAdjustableVector;
+    n2mEtaKrnl.flags = isAdjustableVector.get();
     n2mEtaKrnl.numElements = numElements;
     n2mEtaKrnl.execute();
 
     // copy: QEtaModal -> pstrain
     device::aux::plasticity::qEtaModalToPstrain(
-        qEtaModalPtrs, pstrains, isAdjustableVector, numElements, defaultStream);
-
-    // NOTE: Temp memory must be properly clean after using negative signed integers
-    // This kind of memory is mainly used for floating-point numbers. Negative signed ints might
-    // corrupt the most significant bits. We came to this conclusion by our first-hand experience
-    device.algorithms.fillArray(reinterpret_cast<char*>(isAdjustableVector),
-                                static_cast<char>(0),
-                                numElements * sizeof(int),
-                                defaultStream);
-
-    for (unsigned i = 0; i < stackMemCounter; ++i) {
-      device.api->popStackMemory();
-    }
-    return numAdjustedElements;
-  } else {
-    return 0;
+        qEtaModalPtrs.get(), pstrains, isAdjustableVector.get(), numElements, defaultStream);
   }
 #else
   logError() << "No GPU implementation provided";
-  return 0;
 #endif // ACL_DEVICE
 }
 

--- a/src/Kernels/Plasticity.h
+++ b/src/Kernels/Plasticity.h
@@ -31,13 +31,14 @@ class Plasticity {
                                     real degreesOfFreedom[tensor::Q::size()],
                                     real* pstrain);
 
-  static unsigned
+  static void
       computePlasticityBatched(double oneMinusIntegratingFactor,
                                double timeStepWidth,
                                double tV,
                                const GlobalData* global,
                                initializer::recording::ConditionalPointersToRealsTable& table,
                                seissol::model::PlasticityData* plasticityData,
+                               unsigned* yieldCounter,
                                seissol::parallel::runtime::StreamRuntime& runtime);
 
   static void flopsPlasticity(long long& nonZeroFlopsCheck,

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -65,7 +65,6 @@ int main(int argc, char* argv[]) {
 #endif // USE_MPI
   device::DeviceInstance& device = device::DeviceInstance::getInstance();
   device.api->initialize();
-  device.api->allocateStackMem();
 #endif // ACL_DEVICE
 
   utils::Env env("SEISSOL_");

--- a/src/Memory/MemoryAllocator.cpp
+++ b/src/Memory/MemoryAllocator.cpp
@@ -90,8 +90,10 @@ void free(void* pointer, enum Memkind memkind) {
 #endif
 
 #ifdef ACL_DEVICE
-  } else if ((memkind == DeviceGlobalMemory) || (memkind == DeviceUnifiedMemory)) {
-    device::DeviceInstance::getInstance().api->freeMem(pointer);
+  } else if (memkind == DeviceGlobalMemory) {
+    device::DeviceInstance::getInstance().api->freeGlobMem(pointer);
+  } else if (memkind == DeviceUnifiedMemory) {
+    device::DeviceInstance::getInstance().api->freeUnifiedMem(pointer);
   } else if (memkind == PinnedMemory) {
     device::DeviceInstance::getInstance().api->freePinnedMem(pointer);
 #endif

--- a/src/Parallel/DataCollector.h
+++ b/src/Parallel/DataCollector.h
@@ -62,7 +62,12 @@ class DataCollector {
     if (!hostAccessible && indexCount > 0) {
 #ifdef ACL_DEVICE
       device::DeviceInstance::getInstance().algorithms.copyScatterToUniform(
-          indexDataDevice, copiedDataDevice, elemSize, elemSize, indexCount, stream);
+          const_cast<const real**>(indexDataDevice),
+          copiedDataDevice,
+          elemSize,
+          elemSize,
+          indexCount,
+          stream);
 #endif
     }
   }
@@ -72,7 +77,12 @@ class DataCollector {
     if (!hostAccessible && indexCount > 0) {
 #ifdef ACL_DEVICE
       device::DeviceInstance::getInstance().algorithms.copyUniformToScatter(
-          copiedDataDevice, indexDataDevice, elemSize, elemSize, indexCount, stream);
+          const_cast<const real*>(copiedDataDevice),
+          indexDataDevice,
+          elemSize,
+          elemSize,
+          indexCount,
+          stream);
 #endif
     }
   }

--- a/src/Parallel/DataCollector.h
+++ b/src/Parallel/DataCollector.h
@@ -51,7 +51,7 @@ class DataCollector {
   ~DataCollector() {
     if (!hostAccessible && indexCount > 0) {
 #ifdef ACL_DEVICE
-      device::DeviceInstance::getInstance().api->freeMem(indexDataDevice);
+      device::DeviceInstance::getInstance().api->freeGlobMem(indexDataDevice);
       device::DeviceInstance::getInstance().api->freePinnedMem(copiedData);
 #endif
     }

--- a/src/ResultWriter/EnergyOutput.cpp
+++ b/src/ResultWriter/EnergyOutput.cpp
@@ -296,10 +296,10 @@ void EnergyOutput::computeDynamicRuptureEnergies() {
       auto& table = layer.getConditionalTable<inner_keys::Dr>();
       if (table.find(timeIntegrationKey) != table.end()) {
         auto& entry = table[timeIntegrationKey];
-        real** timeDerivativePlusDevice =
-            (entry.get(inner_keys::Dr::Id::DerivativesPlus))->getDeviceDataPtr();
-        real** timeDerivativeMinusDevice =
-            (entry.get(inner_keys::Dr::Id::DerivativesMinus))->getDeviceDataPtr();
+        const real** timeDerivativePlusDevice = const_cast<const real**>(
+            (entry.get(inner_keys::Dr::Id::DerivativesPlus))->getDeviceDataPtr());
+        const real** timeDerivativeMinusDevice = const_cast<const real**>(
+            (entry.get(inner_keys::Dr::Id::DerivativesMinus))->getDeviceDataPtr());
         device::DeviceInstance::getInstance().algorithms.copyScatterToUniform(
             timeDerivativePlusDevice,
             timeDerivativePlusHostMapped,

--- a/src/Solver/time_stepping/AbstractTimeCluster.cpp
+++ b/src/Solver/time_stepping/AbstractTimeCluster.cpp
@@ -286,5 +286,8 @@ bool AbstractTimeCluster::hasDifferentExecutorNeighbor() {
   });
 }
 
+void AbstractTimeCluster::finishPhase() {
+}
+
 } // namespace seissol::time_stepping
 

--- a/src/Solver/time_stepping/AbstractTimeCluster.h
+++ b/src/Solver/time_stepping/AbstractTimeCluster.h
@@ -76,6 +76,8 @@ public:
   void setPredictionTime(double time);
   void setCorrectionTime(double time);
 
+  virtual void finishPhase();
+
   long getTimeStepRate();
 
   /**

--- a/src/Solver/time_stepping/TimeCluster.cpp
+++ b/src/Solver/time_stepping/TimeCluster.cpp
@@ -453,14 +453,14 @@ void seissol::time_stepping::TimeCluster::computeLocalIntegrationDevice(
 
       if (resetBuffers) {
         device.algorithms.streamBatchedData(
-            (entry.get(inner_keys::Wp::Id::Idofs))->getDeviceDataPtr(),
+            const_cast<const real**>((entry.get(inner_keys::Wp::Id::Idofs))->getDeviceDataPtr()),
             (entry.get(inner_keys::Wp::Id::Buffers))->getDeviceDataPtr(),
             tensor::I::Size,
             (entry.get(inner_keys::Wp::Id::Idofs))->getSize(),
             streamRuntime.stream());
       } else {
         device.algorithms.accumulateBatchedData(
-            (entry.get(inner_keys::Wp::Id::Idofs))->getDeviceDataPtr(),
+            const_cast<const real**>((entry.get(inner_keys::Wp::Id::Idofs))->getDeviceDataPtr()),
             (entry.get(inner_keys::Wp::Id::Buffers))->getDeviceDataPtr(),
             tensor::I::Size,
             (entry.get(inner_keys::Wp::Id::Idofs))->getSize(),

--- a/src/Solver/time_stepping/TimeCluster.h
+++ b/src/Solver/time_stepping/TimeCluster.h
@@ -143,6 +143,8 @@ private:
 
     kernels::ReceiverCluster* m_receiverCluster;
 
+    seissol::memory::MemkindArray<unsigned> yieldCells;
+
     /**
      * Writes the receiver output if applicable (receivers present, receivers have to be written).
      **/
@@ -322,6 +324,8 @@ public:
   std::vector<NeighborCluster>* getNeighborClusters();
 
   void synchronizeTo(seissol::initializer::AllocationPlace place, void* stream);
+
+  void finishPhase();
 };
 
 

--- a/src/Solver/time_stepping/TimeManager.cpp
+++ b/src/Solver/time_stepping/TimeManager.cpp
@@ -308,6 +308,9 @@ void seissol::time_stepping::TimeManager::advanceInTime(const double &synchroniz
 #ifdef ACL_DEVICE
   device.api->popLastProfilingMark();
 #endif
+  for (auto& cluster : clusters) {
+    cluster->finishPhase();
+  }
 }
 
 void seissol::time_stepping::TimeManager::printComputationTime(


### PR DESCRIPTION
Update the device interop after the latest Device module changes from

* https://github.com/SeisSol/Device/pull/45
* https://github.com/SeisSol/Device/pull/46

Besides, it fixes the plasticity FLOP/s counting (in fact: so far, no FLOP/s for plasticity were accounted for on the CPU).
