### PR TITLE
A an `etahack` stopping mechanic

### DIFF
--- a/src/DynamicRupture/FrictionLaws/CpuImpl/BaseFrictionLaw.h
+++ b/src/DynamicRupture/FrictionLaws/CpuImpl/BaseFrictionLaw.h
@@ -52,8 +52,10 @@ class BaseFrictionLaw : public FrictionSolver {
       SCOREP_USER_REGION_BEGIN(
           myRegionHandle, "computeDynamicRupturePrecomputeStress", SCOREP_USER_REGION_TYPE_COMMON)
       LIKWID_MARKER_START("computeDynamicRupturePrecomputeStress");
+      auto modIE = impAndEta[ltsFace];
+      modIE.etaP *= drParameters->etaStop > this->mFullUpdateTime ? drParameters->etaHack : 1.0;
       common::precomputeStressFromQInterpolated(faultStresses,
-                                                impAndEta[ltsFace],
+                                                modIE,
                                                 impedanceMatrices[ltsFace],
                                                 qInterpolatedPlus[ltsFace],
                                                 qInterpolatedMinus[ltsFace]);

--- a/src/Initializer/CellLocalMatrices.cpp
+++ b/src/Initializer/CellLocalMatrices.cpp
@@ -676,7 +676,7 @@ void initializeDynamicRuptureMatrices(const seissol::geometry::MeshReader& meshR
       impAndEta[ltsFace].invZsNeig = 1 / impAndEta[ltsFace].zsNeig;
 
       impAndEta[ltsFace].etaP =
-          etaHack / (1.0 / impAndEta[ltsFace].zp + 1.0 / impAndEta[ltsFace].zpNeig);
+          1.0 / (1.0 / impAndEta[ltsFace].zp + 1.0 / impAndEta[ltsFace].zpNeig);
       impAndEta[ltsFace].invEtaS = 1.0 / impAndEta[ltsFace].zs + 1.0 / impAndEta[ltsFace].zsNeig;
       impAndEta[ltsFace].etaS =
           1.0 / (1.0 / impAndEta[ltsFace].zs + 1.0 / impAndEta[ltsFace].zsNeig);

--- a/src/Initializer/Parameters/DRParameters.cpp
+++ b/src/Initializer/Parameters/DRParameters.cpp
@@ -154,6 +154,9 @@ DRParameters readDRParameters(ParameterReader* baseReader) {
     }
   }();
 
+  const auto hackStop =
+      reader->read<double>("etastop").value_or(std::numeric_limits<double>::infinity());
+
   reader->warnDeprecated({"rf_output_on", "backgroundtype"});
 
   return DRParameters{isDynamicRuptureEnabled,
@@ -185,6 +188,7 @@ DRParameters readDRParameters(ParameterReader* baseReader) {
                       faultFileNames,
                       referencePoint,
                       terminatorSlipRateThreshold,
-                      etaHack};
+                      etaHack,
+                      hackStop};
 }
 } // namespace seissol::initializer::parameters

--- a/src/Initializer/Parameters/DRParameters.h
+++ b/src/Initializer/Parameters/DRParameters.h
@@ -84,6 +84,7 @@ struct DRParameters {
   Eigen::Vector3d referencePoint;
   real terminatorSlipRateThreshold{0.0};
   double etaHack{1.0};
+  double etaStop{0.0};
 };
 
 DRParameters readDRParameters(ParameterReader* baseReader);


### PR DESCRIPTION
A mechanic to disable the `etahack`, as soon as we've exceeded a certain duration in the simulation.

Still needs a slightly better implementation, but it seems to already do its job right now.
