### PR TITLE
Allow Ninja Multi-Config Builds (Debug+Release)

### DIFF
--- a/.github/workflows/build-seissol-cpu.yml
+++ b/.github/workflows/build-seissol-cpu.yml
@@ -21,8 +21,7 @@ jobs:
     env:
       EXENAME: |
         ${{
-          format('{0}_{1}{2}_{3}_{4}{5}',
-            matrix.build_type,
+          format('{0}{1}_{2}_{3}{4}',
             matrix.precision == 'single' && 's' || 'd',
             matrix.arch,
             matrix.order,
@@ -178,8 +177,7 @@ jobs:
     env:
       EXENAME: |
         ${{
-          format('{0}_{1}{2}_{3}_{4}{5}',
-            matrix.build_type,
+          format('{0}{1}_{2}_{3}{4}',
             matrix.precision == 'single' && 's' || 'd',
             matrix.arch,
             matrix.order,

--- a/.github/workflows/build-seissol-gpu.yml
+++ b/.github/workflows/build-seissol-gpu.yml
@@ -21,8 +21,7 @@ jobs:
     env:
       EXENAME: |
         ${{
-          format('{0}_{1}{2}_{3}_{4}_{5}{6}',
-            matrix.build_type,
+          format('{0}{1}_{2}_{3}_{4}{5}',
             matrix.precision == 'single' && 's' || 'd',
             matrix.setup.arch,
             matrix.setup.backend,
@@ -197,8 +196,7 @@ jobs:
     env:
       EXENAME: |
         ${{
-          format('{0}_{1}{2}_{3}_{4}_{5}{6}',
-            matrix.build_type,
+          format('{0}{1}_{2}_{3}_{4}{5}',
             matrix.precision == 'single' && 's' || 'd',
             matrix.setup.arch,
             matrix.setup.backend,

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,12 +77,12 @@ endif()
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
-set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS
-        "Debug" "Release" "RelWithDebInfo") # MinSizeRel is useless for us
 if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Release CACHE STRING "" FORCE)
   message(STATUS "Set build type to Release as none was supplied.")
 endif()
+set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS
+        "Debug" "Release" "RelWithDebInfo") # MinSizeRel is useless for us
 
 if (NOT (DEVICE_BACKEND STREQUAL "hip" AND DEVICE_ARCH MATCHES "sm_*"))
   # Note: hip 4.x has a bug during setting rpath while compiling

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -458,9 +458,9 @@ endif()
 
 # adjust prefix name of executables
 if ("${DEVICE_ARCH_STR}" STREQUAL "none")
-  set(EXE_NAME_PREFIX "${CMAKE_BUILD_TYPE}_${HOST_ARCH_STR}_${ORDER}_${EQUATIONS}")
+  set(EXE_NAME_PREFIX "${HOST_ARCH_STR}_${ORDER}_${EQUATIONS}")
 else()
-  set(EXE_NAME_PREFIX "${CMAKE_BUILD_TYPE}_${DEVICE_ARCH_STR}_${DEVICE_BACKEND}_${ORDER}_${EQUATIONS}")
+  set(EXE_NAME_PREFIX "${DEVICE_ARCH_STR}_${DEVICE_BACKEND}_${ORDER}_${EQUATIONS}")
 endif()
 
 if(${NUMBER_OF_FUSED_SIMULATIONS} GREATER 1)
@@ -495,7 +495,7 @@ if (WITH_GPU)
   target_link_libraries(seissol-common-properties INTERFACE seissol-device-lib)
 
   set_target_properties(seissol-device-lib PROPERTIES OUTPUT_NAME "SeisSol_gpucodegen_${EXE_NAME_PREFIX}")
-  set_target_properties(device PROPERTIES OUTPUT_NAME "device_${CMAKE_BUILD_TYPE}_${DEVICE_BACKEND}")
+  set_target_properties(device PROPERTIES OUTPUT_NAME "device_${DEVICE_BACKEND}")
 
   # set up GPU install targets
   install(TARGETS seissol-device-lib LIBRARY)


### PR DESCRIPTION
Refers to https://cmake.org/cmake/help/latest/generator/Ninja%20Multi-Config.html . All new builds are put into `$BUILD_ROOT/Release`, `$BUILD_ROOT/Debug` and so on—if you configure with `cmake -G "Ninja Multi-Build`.

It needed one operation to be moved.

Moreover, I've removed the `Release` and `Debug` etc. from the Seissol exe name because of that—you can now build both without regenerating your CMake files each time.
Feel free to disagree with that change.

(and yes, this PR's _only_ about the build type, nothing SeisSol specific)
