### PR TITLE
Add an `avoidic` flag

### DIFF
--- a/Documentation/parameters.par
+++ b/Documentation/parameters.par
@@ -51,6 +51,8 @@ ampField = 2 0 0 0 0 0 0 1 0 ! Amplification of the different wave modes
 
 filename = ''  ! file name for the easi initial condition file
 hastime = 1    ! indicates the required support of a time dimension in the easi file. Requires easi 1.5.0 or higher.
+
+avoidic = 0    ! 1 iff use the IC only for analytical boundary conditions
 /
 
 &DynamicRupture

--- a/src/Initializer/InitProcedure/InitSideConditions.cpp
+++ b/src/Initializer/InitProcedure/InitSideConditions.cpp
@@ -165,7 +165,8 @@ void initInitialCondition(seissol::SeisSol& seissolInstance) {
                                                   initConditionParams.hasTime);
   } else {
     auto initConditions = buildInitialConditionList(seissolInstance);
-    if (initConditionParams.type != seissol::initializer::parameters::InitializationType::Zero) {
+    if (initConditionParams.type != seissol::initializer::parameters::InitializationType::Zero &&
+        !initConditionParams.avoidIC) {
       seissol::initializer::projectInitialField(initConditions,
                                                 *memoryManager.getGlobalDataOnHost(),
                                                 seissolInstance.meshReader(),

--- a/src/Initializer/Parameters/InitializationParameters.cpp
+++ b/src/Initializer/Parameters/InitializationParameters.cpp
@@ -57,7 +57,9 @@ InitializationParameters readInitializationParameters(ParameterReader* baseReade
   const auto filename = reader->readPath("filename").value_or("");
   const auto hasTime = reader->read<bool>("hastime").value_or(true);
 
+  const auto avoidIC = reader->read<bool>("avoidic").value_or(false);
+
   return InitializationParameters{
-      type, origin, kVec, ampField, magnitude, width, k, filename, hasTime};
+      type, origin, kVec, ampField, magnitude, width, k, filename, hasTime, avoidIC};
 }
 } // namespace seissol::initializer::parameters

--- a/src/Initializer/Parameters/InitializationParameters.h
+++ b/src/Initializer/Parameters/InitializationParameters.h
@@ -41,6 +41,7 @@ struct InitializationParameters {
   double k;
   std::string filename;
   bool hasTime;
+  bool avoidIC;
 };
 
 InitializationParameters readInitializationParameters(ParameterReader* baseReader);


### PR DESCRIPTION
Add a flag to use the initial conditions only for the analytical boundary conditions, and not the initial field.
