### PR TITLE
Always assume MPI

### DIFF
--- a/src/DynamicRupture/Output/OutputManager.cpp
+++ b/src/DynamicRupture/Output/OutputManager.cpp
@@ -93,12 +93,8 @@ std::string buildIndexedMPIFileName(const std::string& namePrefix,
                                     const std::string& nameSuffix,
                                     const std::string& fileExtension = std::string()) {
   std::stringstream suffix;
-#ifdef PARALLEL
   suffix << nameSuffix << '-' << makeFormatted<int, WideFormat>(index) << '-'
          << makeFormatted<int, WideFormat>(seissol::MPI::mpi.rank());
-#else
-  suffix << nameSuffix << '-' << makeFormatted<int, WideFormat>(index);
-#endif
   return buildFileName(namePrefix, suffix.str(), fileExtension);
 }
 

--- a/src/Geometry/CubeGenerator.cpp
+++ b/src/Geometry/CubeGenerator.cpp
@@ -222,10 +222,8 @@ void CubeGenerator::cubeGenerator(const std::array<unsigned int, 4> numCubes,
   logInfo() << "Using" << omp_get_max_threads() << "threads";
 
   // Setup MPI Communicator
-#ifdef USE_MPI
   MPI_Comm commMaster = MPI_COMM_NULL;
   MPI_Comm_split(seissol::MPI::mpi.comm(), rank % 1 == 0 ? 1 : MPI_UNDEFINED, rank, &commMaster);
-#endif // USE_MPI
 
   size_t bndSize = -1;
   size_t bndElemSize = -1;
@@ -1557,9 +1555,7 @@ void CubeGenerator::cubeGenerator(const std::array<unsigned int, 4> numCubes,
   delete[] elemMPIIndicesPtr;
 
   // Close MPI communicator
-#ifdef USE_MPI
   MPI_Comm_free(&commMaster);
-#endif // USE_MPI
 
   // Recompute additional information
   findElementsPerVertex();

--- a/src/Geometry/MeshReader.cpp
+++ b/src/Geometry/MeshReader.cpp
@@ -20,12 +20,10 @@
 #include <algorithm>
 #include <cstddef>
 #include <map>
+#include <mpi.h>
 #include <unordered_map>
 #include <utility>
 #include <vector>
-#ifdef USE_MPI
-#include <mpi.h>
-#endif
 
 namespace seissol::geometry {
 
@@ -250,7 +248,6 @@ void MeshReader::extractFaultInformation(
 }
 
 void MeshReader::exchangeGhostlayerMetadata() {
-#ifdef USE_MPI
   std::unordered_map<int, std::vector<GhostElementMetadata>> sendData;
   std::unordered_map<int, std::vector<GhostElementMetadata>> recvData;
 
@@ -334,7 +331,6 @@ void MeshReader::exchangeGhostlayerMetadata() {
   m_ghostlayerMetadata = std::move(recvData);
 
   MPI_Type_free(&ghostElementType);
-#endif
 }
 
 void MeshReader::computeTimestepIfNecessary(const seissol::SeisSol& seissolInstance) {

--- a/src/Geometry/PUMLReader.cpp
+++ b/src/Geometry/PUMLReader.cpp
@@ -195,9 +195,7 @@ void PUMLReader::read(PUML::TETPUML& puml, const char* meshFile) {
   const size_t localCells = puml.numOriginalCells();
   size_t localStart = 0;
 
-#ifdef USE_MPI
   MPI_Exscan(&localCells, &localStart, 1, PUML::MPITypeInfer<size_t>::type(), MPI_SUM, puml.comm());
-#endif
 
   std::vector<size_t> cellIdsAsInFile(localCells);
   std::iota(cellIdsAsInFile.begin(), cellIdsAsInFile.end(), localStart);
@@ -224,7 +222,6 @@ void PUMLReader::partition(PUML::TETPUML& puml,
   auto graph = PUML::TETPartitionGraph(puml);
   graph.setVertexWeights(ltsWeights->vertexWeights(), ltsWeights->nWeightsPerVertex());
 
-#ifdef USE_MPI
   auto nodeWeights = std::vector<double>(MPI::mpi.size());
   MPI_Allgather(&tpwgt, 1, MPI_DOUBLE, nodeWeights.data(), 1, MPI_DOUBLE, seissol::MPI::mpi.comm());
   double sum = 0.0;
@@ -234,9 +231,6 @@ void PUMLReader::partition(PUML::TETPUML& puml,
   for (auto& w : nodeWeights) {
     w /= sum;
   }
-#else
-  auto nodeWeights = std::vector<double>{1.0};
-#endif
 
   auto target = PUML::PartitionTarget{};
   target.setVertexWeights(nodeWeights);

--- a/src/IO/Reader/File/Hdf5Reader.cpp
+++ b/src/IO/Reader/File/Hdf5Reader.cpp
@@ -116,9 +116,7 @@ void Hdf5Reader::readDataRaw(void* data,
   checkExistence(name, "dataset");
   const hid_t h5alist = H5Pcreate(H5P_DATASET_XFER);
   _eh(h5alist);
-#ifdef USE_MPI
   _eh(H5Pset_dxpl_mpio(h5alist, H5FD_MPIO_COLLECTIVE));
-#endif // USE_MPI
 
   const hid_t dataset = _eh(H5Dopen(handles.top(), name.c_str(), H5P_DEFAULT));
   const hid_t dataspace = _eh(H5Dget_space(dataset));

--- a/src/IO/Writer/File/Hdf5Writer.cpp
+++ b/src/IO/Writer/File/Hdf5Writer.cpp
@@ -174,9 +174,7 @@ void Hdf5File::writeData(const async::ExecInfo& info,
 
   const hid_t h5dxlist = H5Pcreate(H5P_DATASET_XFER);
   _eh(h5dxlist);
-#ifdef USE_MPI
   _eh(H5Pset_dxpl_mpio(h5dxlist, H5FD_MPIO_COLLECTIVE));
-#endif
 
   const hid_t h5memtype = datatype::convertToHdf5(source->datatype());
 

--- a/src/Initializer/InitProcedure/InitMesh.cpp
+++ b/src/Initializer/InitProcedure/InitMesh.cpp
@@ -27,10 +27,10 @@
 #include "Geometry/CubeGenerator.h"
 #include "Geometry/NetcdfReader.h"
 #endif // USE_NETCDF
-#if defined(USE_HDF) && defined(USE_MPI)
+#if defined(USE_HDF)
 #include "Geometry/PUMLReader.h"
 #include <hdf5.h>
-#endif // defined(USE_HDF) && defined(USE_MPI)
+#endif // defined(USE_HDF)
 #include "Initializer/TimeStepping/LtsWeights/WeightsFactory.h"
 #include "Modules/Modules.h"
 #include "Monitoring/Stopwatch.h"
@@ -94,10 +94,8 @@ void postMeshread(seissol::geometry::MeshReader& meshReader,
     }
   }
 
-#ifdef USE_MPI
   MPI_Allreduce(MPI_IN_PLACE, maxPointValue, 3, MPI_DOUBLE, MPI_MAX, seissol::MPI::mpi.comm());
   MPI_Allreduce(MPI_IN_PLACE, minPointValue, 3, MPI_DOUBLE, MPI_MIN, seissol::MPI::mpi.comm());
-#endif
 
   logInfo() << "Smallest bounding box around the mesh: <" << minPointValue[0] << minPointValue[1]
             << minPointValue[2] << "> to <" << maxPointValue[0] << maxPointValue[1]
@@ -106,7 +104,7 @@ void postMeshread(seissol::geometry::MeshReader& meshReader,
 
 void readMeshPUML(const seissol::initializer::parameters::SeisSolParameters& seissolParams,
                   seissol::SeisSol& seissolInstance) {
-#if defined(USE_HDF) && defined(USE_MPI)
+#if defined(USE_HDF)
   double nodeWeight = 1.0;
 
   if (seissolInstance.env().get<bool>("MINISEISSOL", true)) {
@@ -237,15 +235,9 @@ void readMeshPUML(const seissol::initializer::parameters::SeisSolParameters& sei
   watch.pause();
   watch.printTime("PUML mesh read in:");
 
-#else // defined(USE_HDF) && defined(USE_MPI)
-#ifndef USE_MPI
-  logError() << "Tried to load a PUML mesh. However, PUML is currently only supported with MPI "
-                "(and this build of SeisSol does not use MPI).";
-#endif
-#ifndef USE_HDF
+#else  // defined(USE_HDF)
   logError() << "Tried to load a PUML mesh. However, PUML needs SeisSol to be linked against HDF5.";
-#endif
-#endif // defined(USE_HDF) && defined(USE_MPI)
+#endif // defined(USE_HDF)
 }
 
 size_t getNumOutgoingEdges(seissol::geometry::MeshReader& meshReader) {

--- a/src/Initializer/MemoryManager.cpp
+++ b/src/Initializer/MemoryManager.cpp
@@ -82,7 +82,6 @@ void seissol::initializer::MemoryManager::correctGhostRegionSetups()
 
 void seissol::initializer::MemoryManager::deriveLayerLayouts() {
   // initialize memory
-#ifdef USE_MPI
   m_numberOfGhostBuffers           = (unsigned int*)  m_memoryAllocator.allocateMemory( m_ltsTree.numChildren() * sizeof( unsigned int  ), 1 );
   m_numberOfGhostRegionBuffers     = (unsigned int**) m_memoryAllocator.allocateMemory( m_ltsTree.numChildren() * sizeof( unsigned int* ), 1 );
   m_numberOfGhostDerivatives       = (unsigned int*)  m_memoryAllocator.allocateMemory( m_ltsTree.numChildren() * sizeof( unsigned int  ), 1 );
@@ -92,19 +91,16 @@ void seissol::initializer::MemoryManager::deriveLayerLayouts() {
   m_numberOfCopyRegionBuffers      = (unsigned int**) m_memoryAllocator.allocateMemory( m_ltsTree.numChildren() * sizeof( unsigned int* ), 1 );
   m_numberOfCopyDerivatives        = (unsigned int*)  m_memoryAllocator.allocateMemory( m_ltsTree.numChildren() * sizeof( unsigned int  ), 1 );
   m_numberOfCopyRegionDerivatives  = (unsigned int**) m_memoryAllocator.allocateMemory( m_ltsTree.numChildren() * sizeof( unsigned int* ), 1 );
-#endif // USE_MPI
 
   m_numberOfInteriorBuffers        = (unsigned int*)  m_memoryAllocator.allocateMemory( m_ltsTree.numChildren() * sizeof( unsigned int  ), 1 );
   m_numberOfInteriorDerivatives    = (unsigned int*)  m_memoryAllocator.allocateMemory( m_ltsTree.numChildren() * sizeof( unsigned int  ), 1 );
 
   for (unsigned tc = 0; tc < m_ltsTree.numChildren(); ++tc) {
     TimeCluster& cluster = m_ltsTree.child(tc);
-#ifdef USE_MPI
     CellLocalInformation* ghostCellInformation    = cluster.child<Ghost>().var(m_lts.cellInformation);
     CellLocalInformation* copyCellInformation     = cluster.child<Copy>().var(m_lts.cellInformation);
-#endif
     CellLocalInformation* interiorCellInformation = cluster.child<Interior>().var(m_lts.cellInformation);
-#ifdef USE_MPI
+
     m_numberOfGhostBuffers[             tc] = 0;
     m_numberOfGhostRegionBuffers[       tc] = (unsigned int*)  m_memoryAllocator.allocateMemory( m_meshStructure[tc].numberOfRegions * sizeof( unsigned int ), 1 );
     m_numberOfGhostDerivatives[         tc] = 0;
@@ -114,12 +110,10 @@ void seissol::initializer::MemoryManager::deriveLayerLayouts() {
     m_numberOfCopyRegionBuffers[        tc] = (unsigned int*)  m_memoryAllocator.allocateMemory( m_meshStructure[tc].numberOfRegions * sizeof( unsigned int ), 1 );
     m_numberOfCopyDerivatives[          tc] = 0;
     m_numberOfCopyRegionDerivatives[    tc] = (unsigned int*)  m_memoryAllocator.allocateMemory( m_meshStructure[tc].numberOfRegions * sizeof( unsigned int ), 1 );
-#endif // USE_MPI
 
     m_numberOfInteriorBuffers[          tc]       = 0;
     m_numberOfInteriorDerivatives[      tc]       = 0;
 
-#ifdef USE_MPI
     unsigned int l_ghostOffset = 0;
     unsigned int l_copyOffset  = 0;
     for( unsigned int l_region = 0; l_region < m_meshStructure[tc].numberOfRegions; l_region++ ) {
@@ -162,7 +156,6 @@ void seissol::initializer::MemoryManager::deriveLayerLayouts() {
       m_numberOfCopyBuffers[      tc ]  += m_numberOfCopyRegionBuffers[      tc][l_region];
       m_numberOfCopyDerivatives[  tc ]  += m_numberOfCopyRegionDerivatives[  tc][l_region];
     }
-#endif // USE_MPI
 
     // iterate over all cells of this clusters interior
     for( unsigned int l_cell = 0; l_cell < m_meshStructure[tc].numberOfInteriorCells; l_cell++ ) {
@@ -173,7 +166,6 @@ void seissol::initializer::MemoryManager::deriveLayerLayouts() {
   }
 }
 
-#ifdef USE_MPI
 void seissol::initializer::MemoryManager::initializeCommunicationStructure() {
 #ifdef ACL_DEVICE
   const auto allocationPlace = seissol::initializer::AllocationPlace::Device;
@@ -247,16 +239,11 @@ void seissol::initializer::MemoryManager::initializeCommunicationStructure() {
     }
   }
 }
-#endif
 
 void seissol::initializer::MemoryManager::initializeFaceNeighbors( unsigned    cluster,
                                                                     Layer&      layer )
 {
-#ifdef USE_MPI
   assert(layer.getLayerType() == Copy || layer.getLayerType() == Interior);
-#else
-  assert(layer.getLayerType() == Interior);
-#endif
 
   // iterate over clusters
 
@@ -332,7 +319,6 @@ void seissol::initializer::MemoryManager::initializeBuffersDerivatives() {
   for (unsigned tc = 0; tc < m_ltsTree.numChildren(); ++tc) {
     TimeCluster& cluster = m_ltsTree.child(tc);
 
-#ifdef USE_MPI
     /*
      * ghost layer
      */
@@ -356,7 +342,6 @@ void seissol::initializer::MemoryManager::initializeBuffersDerivatives() {
                                        static_cast<real*>(cluster.child<Copy>().bucket(m_lts.buffersDerivatives)),
                                        cluster.child<Copy>().var(m_lts.buffers),
                                        cluster.child<Copy>().var(m_lts.derivatives) );
-#endif
 
     /*
      * Interior
@@ -370,7 +355,6 @@ void seissol::initializer::MemoryManager::initializeBuffersDerivatives() {
                                           cluster.child<Interior>().var(m_lts.derivatives)  );
 
 #ifdef ACL_DEVICE
-    #ifdef USE_MPI
     /*
      * ghost layer
      */
@@ -406,7 +390,6 @@ void seissol::initializer::MemoryManager::initializeBuffersDerivatives() {
                                           static_cast<real*>(cluster.child<Interior>().bucket(m_lts.buffersDerivatives, seissol::initializer::AllocationPlace::Device)),
                                           cluster.child<Interior>().var(m_lts.buffersDevice),
                                           cluster.child<Interior>().var(m_lts.derivativesDevice)  );
-#endif
   }
 }
 
@@ -712,7 +695,7 @@ void seissol::initializer::MemoryManager::initializeMemoryLayout()
     size_t l_ghostSize = 0;
     size_t l_copySize = 0;
     size_t l_interiorSize = 0;
-#ifdef USE_MPI
+
     for( unsigned int l_region = 0; l_region < m_meshStructure[tc].numberOfRegions; l_region++ ) {
       l_ghostSize    += sizeof(real) * tensor::Q::size() * m_numberOfGhostRegionBuffers[tc][l_region];
       l_ghostSize    += sizeof(real) * yateto::computeFamilySize<tensor::dQ>() * m_numberOfGhostRegionDerivatives[tc][l_region];
@@ -720,7 +703,7 @@ void seissol::initializer::MemoryManager::initializeMemoryLayout()
       l_copySize     += sizeof(real) * tensor::Q::size() * m_numberOfCopyRegionBuffers[tc][l_region];
       l_copySize     += sizeof(real) * yateto::computeFamilySize<tensor::dQ>() * m_numberOfCopyRegionDerivatives[tc][l_region];
     }
-#endif // USE_MPI
+
     l_interiorSize += sizeof(real) * tensor::Q::size() * m_numberOfInteriorBuffers[tc];
     l_interiorSize += sizeof(real) * yateto::computeFamilySize<tensor::dQ>() * m_numberOfInteriorDerivatives[tc];
 
@@ -739,9 +722,7 @@ void seissol::initializer::MemoryManager::initializeMemoryLayout()
   // initialize face neighbors
   for (unsigned tc = 0; tc < m_ltsTree.numChildren(); ++tc) {
     TimeCluster& cluster = m_ltsTree.child(tc);
-#ifdef USE_MPI
     initializeFaceNeighbors(tc, cluster.child<Copy>());
-#endif
     initializeFaceNeighbors(tc, cluster.child<Interior>());
   }
 
@@ -764,10 +745,8 @@ void seissol::initializer::MemoryManager::initializeMemoryLayout()
     kernels::touchBuffersDerivatives(buffers, derivatives, layer.getNumberOfCells());
   }
 
-#ifdef USE_MPI
   // initialize the communication structure
   initializeCommunicationStructure();
-#endif
 
   initializeFaceDisplacements();
 

--- a/src/Initializer/MemoryManager.h
+++ b/src/Initializer/MemoryManager.h
@@ -13,9 +13,7 @@
 
 #include "Memory/Tree/Layer.h"
 #include "Initializer/Parameters/SeisSolParameters.h"
-#ifdef USE_MPI
 #include <mpi.h>
-#endif
 
 #include <utils/logger.h>
 
@@ -66,7 +64,6 @@ class MemoryManager {
     //! number of derivatives in the interior per cluster
     unsigned int *m_numberOfInteriorDerivatives;
 
-#ifdef USE_MPI
     /*
      * Ghost layer
      */
@@ -96,7 +93,6 @@ class MemoryManager {
 
     //! number of derivatives in the copy regionsper cluster
     unsigned int **m_numberOfCopyRegionDerivatives;
-#endif
 
     /*
      * Cross-cluster
@@ -164,14 +160,12 @@ class MemoryManager {
     /**
      * Initializes the displacement accumulation buffer.
      */
-  void initializeFaceDisplacements();
+    void initializeFaceDisplacements();
 
-#ifdef USE_MPI
     /**
      * Initializes the communication structure.
      **/
     void initializeCommunicationStructure();
-#endif
 
   public:
     /**

--- a/src/Initializer/PointMapper.cpp
+++ b/src/Initializer/PointMapper.cpp
@@ -106,7 +106,6 @@ void findMeshIds(const Eigen::Vector3d* points,
   }
 }
 
-#ifdef USE_MPI
 void cleanDoubles(short* contained, std::size_t numPoints) {
   const auto myrank = seissol::MPI::mpi.rank();
   const auto size = seissol::MPI::mpi.size();
@@ -137,6 +136,5 @@ void cleanDoubles(short* contained, std::size_t numPoints) {
     logInfo() << "Cleaned " << cleaned << " double occurring points on rank " << myrank << ".";
   }
 }
-#endif
 
 } // namespace seissol::initializer

--- a/src/Initializer/PointMapper.h
+++ b/src/Initializer/PointMapper.h
@@ -31,9 +31,9 @@ void findMeshIds(const Eigen::Vector3d* points,
                  short* contained,
                  unsigned* meshIds,
                  double tolerance = 0);
-#ifdef USE_MPI
+
 void cleanDoubles(short* contained, std::size_t numPoints);
-#endif
+
 } // namespace seissol::initializer
 
 #endif // SEISSOL_SRC_INITIALIZER_POINTMAPPER_H_

--- a/src/Initializer/TimeStepping/Common.h
+++ b/src/Initializer/TimeStepping/Common.h
@@ -211,7 +211,6 @@ static void normalizeLtsSetup( unsigned short  i_neighboringLtsSetups[4],
  * @param io_cellLocalInformation cell local information which lts setup will be written using present face and cluster.
  domain.
  */
-#ifdef USE_MPI
 static void synchronizeLtsSetups( unsigned int                 i_numberOfClusters,
                                   struct MeshStructure        *io_meshStructure,
                                   struct CellLocalInformation *io_cellLocalInformation ) {
@@ -319,7 +318,6 @@ static void synchronizeLtsSetups( unsigned int                 i_numberOfCluster
   delete[] l_sendBuffer;
   delete[] l_receiveBuffer;
 }
-#endif
 
 /**
  * Derives the lts setups of all given cells.
@@ -378,11 +376,9 @@ inline void deriveLtsSetups( unsigned int                 i_numberOfClusters,
   }
 
 // exchange ltsSetup of the ghost layer for the normalization step
-#ifdef USE_MPI
   synchronizeLtsSetups( i_numberOfClusters,
                         io_meshStructure,
                         io_cellLocalInformation );
-#endif
 
   // iterate over cells and normalize the setups
   l_cell = 0;
@@ -426,11 +422,9 @@ inline void deriveLtsSetups( unsigned int                 i_numberOfClusters,
   }
 
 // get final setup in the ghost layer (after normalization)
-#ifdef USE_MPI
   synchronizeLtsSetups( i_numberOfClusters,
                         io_meshStructure,
                         io_cellLocalInformation );
-#endif
 }
 
 }}}

--- a/src/Initializer/TimeStepping/GlobalTimestep.cpp
+++ b/src/Initializer/TimeStepping/GlobalTimestep.cpp
@@ -84,7 +84,6 @@ GlobalTimestep
   double localMinTimestep = *minmaxCellPosition.first;
   double localMaxTimestep = *minmaxCellPosition.second;
 
-#ifdef USE_MPI
   MPI_Allreduce(&localMinTimestep,
                 &timestep.globalMinTimeStep,
                 1,
@@ -97,10 +96,6 @@ GlobalTimestep
                 MPI_DOUBLE,
                 MPI_MAX,
                 seissol::MPI::mpi.comm());
-#else
-  timestep.globalMinTimeStep = localMinTimestep;
-  timestep.globalMaxTimeStep = localMaxTimestep;
-#endif
   return timestep;
 }
 } // namespace seissol::initializer

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -59,9 +59,7 @@ std::shared_ptr<YAML::Node> readYamlParams(const std::string& parameterFile) {
 
 int main(int argc, char* argv[]) {
 #ifdef ACL_DEVICE
-#ifdef USE_MPI
   seissol::MPI::mpi.bindAcceleratorDevice();
-#endif // USE_MPI
   device::DeviceInstance& device = device::DeviceInstance::getInstance();
   device.api->initialize();
 #endif // ACL_DEVICE

--- a/src/Monitoring/FlopCounter.cpp
+++ b/src/Monitoring/FlopCounter.cpp
@@ -131,12 +131,8 @@ void FlopCounter::printPerformanceSummary(double wallTime) const {
   flops[PLNonZeroFlops] = nonZeroFlopsPlasticity;
   flops[PLHardwareFlops] = hardwareFlopsPlasticity;
 
-#ifdef USE_MPI
   double totalFlops[NumCounters];
   MPI_Reduce(&flops, &totalFlops, NumCounters, MPI_DOUBLE, MPI_SUM, 0, seissol::MPI::mpi.comm());
-#else
-  double* totalFlops = &flops[0];
-#endif
 
 #ifndef NDEBUG
   logInfo() << "Total    libxsmm HW-FLOP: " << UnitFlop.formatPrefix(totalFlops[Libxsmm]).c_str();

--- a/src/Monitoring/Stopwatch.cpp
+++ b/src/Monitoring/Stopwatch.cpp
@@ -76,7 +76,6 @@ void Stopwatch::print(const char* text, double time, MPI_Comm comm) {
   int rank = 0;
   double avg = time;
 
-#ifdef USE_MPI
   double min = time;
   double max = time;
 
@@ -99,14 +98,10 @@ void Stopwatch::print(const char* text, double time, MPI_Comm comm) {
     MPI_Reduce(&min, nullptr, 1, MPI_DOUBLE, MPI_MIN, 0, comm);
     MPI_Reduce(&max, nullptr, 1, MPI_DOUBLE, MPI_MAX, 0, comm);
   }
-#endif // USE_MPI
 
-  logInfo() << text << UnitTime.formatTime(avg).c_str()
-#ifdef USE_MPI
-            << "(min:" << utils::nospace << UnitTime.formatTime(min).c_str()
-            << ", max: " << UnitTime.formatTime(max).c_str() << ')'
-#endif // USE_MPI
-      ;
+  logInfo() << text << UnitTime.formatTime(avg).c_str() << "(min:" << utils::nospace
+            << UnitTime.formatTime(min).c_str() << ", max: " << UnitTime.formatTime(max).c_str()
+            << ')';
 }
 
 } // namespace seissol

--- a/src/Numerical/Statistics.cpp
+++ b/src/Numerical/Statistics.cpp
@@ -50,14 +50,10 @@ seissol::statistics::Summary::Summary(const std::vector<double>& values) : media
 }
 
 auto seissol::statistics::parallelSummary(double value) -> Summary {
-#ifdef USE_MPI
   auto collect = seissol::MPI::mpi.collect(value);
   const int rank = seissol::MPI::mpi.rank();
   if (rank == 0) {
     return Summary(collect);
   }
   return Summary();
-#else
-  return Summary(value);
-#endif
 }

--- a/src/Parallel/MPI.h
+++ b/src/Parallel/MPI.h
@@ -29,7 +29,7 @@
 namespace seissol {
 
 #ifndef USE_MPI
-typedef MPIDummy MPI;
+using MPI = MPIDummy;
 #else // USE_MPI
 
 /**

--- a/src/Reader/AsagiModule.cpp
+++ b/src/Reader/AsagiModule.cpp
@@ -41,6 +41,7 @@ AsagiModule::AsagiModule(utils::Env& env)
 }
 
 AsagiMPIMode AsagiModule::getMPIMode(utils::Env& env) {
+  // USE_MPI kept on purpose
 #ifdef USE_MPI
   const std::string mpiModeName = env.get(EnvMpiMode, "WINDOWS");
   if (mpiModeName == "WINDOWS") {
@@ -95,17 +96,13 @@ void AsagiModule::postMPIInit() {
 }
 
 void AsagiModule::preModel() {
-#ifdef USE_MPI
   // TODO check if ASAGI is required for model setup
   ::asagi::Grid::startCommThread();
-#endif // USE_MPI
 }
 
 void AsagiModule::postModel() {
-#ifdef USE_MPI
   // TODO check if ASAGI is required for model setup
   ::asagi::Grid::stopCommThread();
-#endif // USE_MPI
 }
 
 void AsagiModule::initInstance(utils::Env& env) {

--- a/src/Reader/AsagiReader.cpp
+++ b/src/Reader/AsagiReader.cpp
@@ -35,12 +35,12 @@ namespace seissol::asagi {
 
   // Set MPI mode
   if (AsagiModule::mpiMode() != AsagiMPIMode::Off) {
+    // USE_MPI kept on purpose
 #ifdef USE_MPI
     ::asagi::Grid::Error const err = grid->setComm(comm);
     if (err != ::asagi::Grid::SUCCESS) {
       logError() << "Could not set ASAGI communicator:" << err;
     }
-
 #endif // USE_MPI
 
     if (AsagiModule::mpiMode() == AsagiMPIMode::CommThread) {

--- a/src/ResultWriter/AnalysisWriter.cpp
+++ b/src/ResultWriter/AnalysisWriter.cpp
@@ -268,7 +268,6 @@ void AnalysisWriter::printAnalysis(double simulationTime) {
       MeshTools::center(elements[elemLInfLocal[i]], vertices, center);
     }
 
-#ifdef USE_MPI
     const auto& comm = mpi.comm();
 
     // Reduce error over all MPI ranks.
@@ -358,28 +357,6 @@ void AnalysisWriter::printAnalysis(double simulationTime) {
         csvWriter.addObservation(std::to_string(i), "LInf_rel", errLInfRel);
       }
     }
-#else
-    for (unsigned int i = 0; i < numberOfQuantities; ++i) {
-      VrtxCoords center;
-      MeshTools::center(elements[elemLInfLocal[i]], vertices, center);
-      const auto errL1 = errL1Local[i];
-      const auto errL2 = std::sqrt(errL2Local[i]);
-      const auto errLInf = errLInfLocal[i];
-      const auto errL1Rel = errL1 / analyticalL1Local[i];
-      const auto errL2Rel = std::sqrt(errL2Local[i] / analyticalL2Local[i]);
-      const auto errLInfRel = errLInf / analyticalLInfLocal[i];
-      logInfo() << "L1  , var[" << i << "] =\t" << errL1 << "\t" << errL1Rel;
-      logInfo() << "L2  , var[" << i << "] =\t" << errL2 << "\t" << errL2Rel;
-      logInfo() << "LInf, var[" << i << "] =\t" << errLInf << "\t" << errLInfRel << "\tat ["
-                << center[0] << ",\t" << center[1] << ",\t" << center[2] << "\t]";
-      csvWriter.addObservation(std::to_string(i), "L1", errL1);
-      csvWriter.addObservation(std::to_string(i), "L2", errL2);
-      csvWriter.addObservation(std::to_string(i), "LInf", errLInf);
-      csvWriter.addObservation(std::to_string(i), "L1_rel", errL1Rel);
-      csvWriter.addObservation(std::to_string(i), "L2_rel", errL2Rel);
-      csvWriter.addObservation(std::to_string(i), "LInf_rel", errLInfRel);
-    }
-#endif // USE_MPI
   }
 }
 } // namespace seissol::writer

--- a/src/ResultWriter/AsyncCellIDs.h
+++ b/src/ResultWriter/AsyncCellIDs.h
@@ -9,9 +9,7 @@
 #ifndef SEISSOL_SRC_RESULTWRITER_ASYNCCELLIDS_H_
 #define SEISSOL_SRC_RESULTWRITER_ASYNCCELLIDS_H_
 
-#ifdef USE_MPI
 #include <mpi.h>
-#endif // USE_MPI
 
 #include "SeisSol.h"
 
@@ -38,7 +36,6 @@ class AsyncCellIDs {
                unsigned int nVertices,
                const unsigned int* cells,
                seissol::SeisSol& seissolInstance) {
-#ifdef USE_MPI
     // Add the offset to the cells
     MPI_Comm groupComm = seissolInstance.asyncIO().groupComm();
     unsigned int offset = nVertices;
@@ -51,9 +48,6 @@ class AsyncCellIDs {
       localCells[i] = cells[i] + offset;
     }
     constCells = localCells.data();
-#else  // USE_MPI
-    constCells = cells;
-#endif // USE_MPI
   }
 
   [[nodiscard]] const unsigned int* cells() const { return constCells; }

--- a/src/ResultWriter/AsyncIO.cpp
+++ b/src/ResultWriter/AsyncIO.cpp
@@ -18,9 +18,7 @@ namespace seissol::io {
 bool AsyncIO::init() {
   async::Dispatcher::init();
 
-#ifdef USE_MPI
   seissol::MPI::mpi.setComm(commWorld());
-#endif // USE_MPI
 
   return dispatch();
 }
@@ -29,10 +27,8 @@ void AsyncIO::finalize() {
   // Call parent class
   async::Dispatcher::finalize();
 
-#ifdef USE_MPI
   // Reset the MPI communicator
   seissol::MPI::mpi.setComm(MPI_COMM_WORLD);
-#endif // USE_MPI
 }
 
 } // namespace seissol::io

--- a/src/ResultWriter/EnergyOutput.cpp
+++ b/src/ResultWriter/EnergyOutput.cpp
@@ -599,7 +599,6 @@ void EnergyOutput::computeEnergies() {
 }
 
 void EnergyOutput::reduceEnergies() {
-#ifdef USE_MPI
   const auto& comm = MPI::mpi.comm();
   MPI_Allreduce(MPI_IN_PLACE,
                 energiesStorage.energies.data(),
@@ -607,11 +606,9 @@ void EnergyOutput::reduceEnergies() {
                 MPI_DOUBLE,
                 MPI_SUM,
                 comm);
-#endif
 }
 
 void EnergyOutput::reduceMinTimeSinceSlipRateBelowThreshold() {
-#ifdef USE_MPI
   const auto& comm = MPI::mpi.comm();
   MPI_Allreduce(MPI_IN_PLACE,
                 minTimeSinceSlipRateBelowThreshold.data(),
@@ -619,7 +616,6 @@ void EnergyOutput::reduceMinTimeSinceSlipRateBelowThreshold() {
                 MPI::castToMpiType<double>(),
                 MPI_MIN,
                 comm);
-#endif
 }
 
 void EnergyOutput::printEnergies() {
@@ -730,10 +726,8 @@ void EnergyOutput::checkAbortCriterion(
   }
 
   bool abort = abortCount == multisim::NumSimulations;
-#ifdef USE_MPI
   const auto& comm = MPI::mpi.comm();
   MPI_Bcast(reinterpret_cast<void*>(&abort), 1, MPI_CXX_BOOL, 0, comm);
-#endif
   if (abort) {
     seissolInstance.simulator().abort();
   }

--- a/src/ResultWriter/FaultWriterExecutor.cpp
+++ b/src/ResultWriter/FaultWriterExecutor.cpp
@@ -31,15 +31,11 @@ void seissol::writer::FaultWriterExecutor::execInit(const async::ExecInfo& info,
   const unsigned int nCells = info.bufferSize(Cells) / (3 * sizeof(int));
   const unsigned int nVertices = info.bufferSize(Vertices) / (3 * sizeof(double));
 
-#ifdef USE_MPI
   MPI_Comm_split(seissol::MPI::mpi.comm(), (nCells > 0 ? 0 : MPI_UNDEFINED), 0, &m_comm);
-#endif // USE_MPI
 
   if (nCells > 0) {
     int rank = 0;
-#ifdef USE_MPI
     MPI_Comm_rank(m_comm, &rank);
-#endif // USE_MPI
 
     std::string outputName(static_cast<const char*>(info.buffer(OutputPrefix)));
     outputName += "-fault";
@@ -56,9 +52,7 @@ void seissol::writer::FaultWriterExecutor::execInit(const async::ExecInfo& info,
     m_xdmfWriter = new xdmfwriter::XdmfWriter<xdmfwriter::TRIANGLE, double, real>(
         param.backend, outputName.c_str(), param.timestep);
 
-#ifdef USE_MPI
     m_xdmfWriter->setComm(m_comm);
-#endif // USE_MPI
     m_xdmfWriter->setBackupTimeStamp(param.backupTimeStamp);
     const auto vertexFilter = utils::Env("").get<bool>("SEISSOL_VERTEXFILTER", true);
     m_xdmfWriter->init(variables, std::vector<const char*>(), "fault-tag", vertexFilter, true);

--- a/src/ResultWriter/FaultWriterExecutor.h
+++ b/src/ResultWriter/FaultWriterExecutor.h
@@ -9,9 +9,7 @@
 #ifndef SEISSOL_SRC_RESULTWRITER_FAULTWRITEREXECUTOR_H_
 #define SEISSOL_SRC_RESULTWRITER_FAULTWRITEREXECUTOR_H_
 
-#ifdef USE_MPI
 #include <mpi.h>
-#endif // USE_MPI
 
 #include "Kernels/Precision.h"
 #include "Monitoring/Stopwatch.h"
@@ -40,10 +38,8 @@ class FaultWriterExecutor {
   private:
   xdmfwriter::XdmfWriter<xdmfwriter::TRIANGLE, double, real>* m_xdmfWriter{nullptr};
 
-#ifdef USE_MPI
   /** The MPI communicator for the writer */
   MPI_Comm m_comm;
-#endif // USE_MPI
 
   /** The number of variables that should be written */
   unsigned int m_numVariables{0};
@@ -53,13 +49,9 @@ class FaultWriterExecutor {
 
   public:
   FaultWriterExecutor()
-      :
-#ifdef USE_MPI
-        m_comm(MPI_COMM_NULL)
-#endif // USE_MPI
+      : m_comm(MPI_COMM_NULL)
 
-  {
-  }
+  {}
 
   /**
    * Initialize the XDMF writer
@@ -90,20 +82,13 @@ class FaultWriterExecutor {
 
   void finalize() {
     if (m_xdmfWriter != nullptr) {
-      m_stopwatch.printTime("Time fault writer backend:"
-#ifdef USE_MPI
-                            ,
-                            m_comm
-#endif // USE_MPI
-      );
+      m_stopwatch.printTime("Time fault writer backend:", m_comm);
     }
 
-#ifdef USE_MPI
     if (m_comm != MPI_COMM_NULL) {
       MPI_Comm_free(&m_comm);
       m_comm = MPI_COMM_NULL;
     }
-#endif // USE_MPI
 
     delete m_xdmfWriter;
     m_xdmfWriter = nullptr;

--- a/src/ResultWriter/FreeSurfaceWriterExecutor.cpp
+++ b/src/ResultWriter/FreeSurfaceWriterExecutor.cpp
@@ -31,15 +31,11 @@ void seissol::writer::FreeSurfaceWriterExecutor::execInit(
   const unsigned int nCells = info.bufferSize(Cells) / (3 * sizeof(int));
   const unsigned int nVertices = info.bufferSize(Vertices) / (3 * sizeof(double));
 
-#ifdef USE_MPI
   MPI_Comm_split(seissol::MPI::mpi.comm(), (nCells > 0 ? 0 : MPI_UNDEFINED), 0, &m_comm);
-#endif // USE_MPI
 
   if (nCells > 0) {
     int rank = 0;
-#ifdef USE_MPI
     MPI_Comm_rank(m_comm, &rank);
-#endif // USE_MPI
 
     std::string outputName(static_cast<const char*>(info.buffer(OutputPrefix)));
     outputName += "-surface";
@@ -55,9 +51,7 @@ void seissol::writer::FreeSurfaceWriterExecutor::execInit(
     m_xdmfWriter = new xdmfwriter::XdmfWriter<xdmfwriter::TRIANGLE, double, real>(
         param.backend, outputName.c_str(), param.timestep);
 
-#ifdef USE_MPI
     m_xdmfWriter->setComm(m_comm);
-#endif // USE_MPI
     m_xdmfWriter->setBackupTimeStamp(param.backupTimeStamp);
     const std::string extraIntVarName = "locationFlag";
     const auto vertexFilter = utils::Env("").get<bool>("SEISSOL_VERTEXFILTER", true);

--- a/src/ResultWriter/FreeSurfaceWriterExecutor.h
+++ b/src/ResultWriter/FreeSurfaceWriterExecutor.h
@@ -37,10 +37,8 @@ class FreeSurfaceWriterExecutor {
   };
 
   private:
-#ifdef USE_MPI
   /** The MPI communicator for the writer */
   MPI_Comm m_comm{MPI_COMM_NULL};
-#endif // USE_MPI
 
   xdmfwriter::XdmfWriter<xdmfwriter::TRIANGLE, double, real>* m_xdmfWriter{nullptr};
   unsigned m_numVariables{0};
@@ -80,20 +78,13 @@ class FreeSurfaceWriterExecutor {
 
   void finalize() {
     if (m_xdmfWriter != nullptr) {
-      m_stopwatch.printTime("Time free surface writer backend:"
-#ifdef USE_MPI
-                            ,
-                            m_comm
-#endif // USE_MPI
-      );
+      m_stopwatch.printTime("Time free surface writer backend:", m_comm);
     }
 
-#ifdef USE_MPI
     if (m_comm != MPI_COMM_NULL) {
       MPI_Comm_free(&m_comm);
       m_comm = MPI_COMM_NULL;
     }
-#endif // USE_MPI
 
     delete m_xdmfWriter;
     m_xdmfWriter = nullptr;

--- a/src/ResultWriter/ReceiverWriter.cpp
+++ b/src/ResultWriter/ReceiverWriter.cpp
@@ -202,8 +202,8 @@ void ReceiverWriter::addPoints(const seissol::geometry::MeshReader& mesh,
   initializer::findMeshIds(
       points.data(), mesh, numberOfPoints, contained.data(), meshIds.data(), 1e-3);
   std::vector<short> globalContained(contained.begin(), contained.end());
-#ifdef USE_MPI
-  logInfo() << "Cleaning possible double occurring receivers for MPI...";
+
+  logInfo() << "Cleaning possible double occurring receivers for multi-rank setups...";
   initializer::cleanDoubles(contained.data(), numberOfPoints);
   MPI_Allreduce(MPI_IN_PLACE,
                 globalContained.data(),
@@ -211,7 +211,6 @@ void ReceiverWriter::addPoints(const seissol::geometry::MeshReader& mesh,
                 MPI_SHORT,
                 MPI_MAX,
                 seissol::MPI::mpi.comm());
-#endif
 
   bool receiversMissing = false;
   for (std::size_t i = 0; i < numberOfPoints; ++i) {

--- a/src/ResultWriter/ReceiverWriter.cpp
+++ b/src/ResultWriter/ReceiverWriter.cpp
@@ -80,9 +80,7 @@ std::vector<Eigen::Vector3d> parseReceiverFile(const std::string& receiverFileNa
 std::string ReceiverWriter::fileName(unsigned pointId) const {
   std::stringstream fns;
   fns << std::setfill('0') << m_fileNamePrefix << "-receiver-" << std::setw(5) << (pointId + 1);
-#ifdef PARALLEL
   fns << "-" << std::setw(5) << seissol::MPI::mpi.rank();
-#endif
   fns << ".dat";
   return fns.str();
 }

--- a/src/ResultWriter/WaveFieldWriter.cpp
+++ b/src/ResultWriter/WaveFieldWriter.cpp
@@ -86,9 +86,9 @@ seissol::refinement::TetrahedronRefiner<double>*
 const unsigned*
     seissol::writer::WaveFieldWriter::adjustOffsets(refinement::MeshRefiner<double>* meshRefiner) {
   const unsigned* constCells = nullptr;
-// Cells are a bit complicated because the vertex filter will now longer work if we just use the
-// buffer We will add the offset later
-#ifdef USE_MPI
+  // Cells are a bit complicated because the vertex filter will now longer work if we just use the
+  // buffer We will add the offset later
+
   // Add the offset to the cells
   MPI_Comm groupComm = seissolInstance.asyncIO().groupComm();
   unsigned int offset = meshRefiner->getNumVertices();
@@ -101,9 +101,6 @@ const unsigned*
     cells[i] = meshRefiner->getCellData()[i] + offset;
   }
   constCells = cells;
-#else  // USE_MPI
-  const_cells = meshRefiner->getCellData();
-#endif // USE_MPI
   return constCells;
 }
 
@@ -409,10 +406,8 @@ void seissol::writer::WaveFieldWriter::init(
   // Remove the low mesh refiner if it was setup
   delete pLowMeshRefiner;
 
-#ifdef USE_MPI
   delete[] constCells;
   delete[] constLowCells;
-#endif // USE_MPI
 
   // Save dof/map pointer
   m_dofs = dofs;

--- a/src/SeisSol.cpp
+++ b/src/SeisSol.cpp
@@ -37,7 +37,6 @@ bool SeisSol::init(int argc, char* argv[]) {
     logInfo() << "Running on (rank=0):" << hostNames.front();
   }
 
-#ifdef USE_MPI
   logInfo() << "Using MPI with #ranks:" << seissol::MPI::mpi.size();
   logInfo() << "Node-wide (shared memory) MPI with #ranks/node:"
             << seissol::MPI::mpi.sharedMemMpiSize();
@@ -46,7 +45,6 @@ bool SeisSol::init(int argc, char* argv[]) {
   seissol::MPI::mpi.setDataTransferModeFromEnv();
 
   printPersistentMpiInfo(m_env);
-#endif
 #ifdef ACL_DEVICE
   printUSMInfo(m_env);
   printMPIUSMInfo(m_env);

--- a/src/Solver/time_stepping/TimeCluster.cpp
+++ b/src/Solver/time_stepping/TimeCluster.cpp
@@ -758,13 +758,11 @@ void TimeCluster::correct() {
 
   // TODO(Lukas) Adjust with time step rate? Relevant is maximum cluster is not on this node
   const auto nextCorrectionSteps = ct.nextCorrectionSteps();
-  if constexpr (USE_MPI) {
-    if (printProgress && (((nextCorrectionSteps / timeStepRate) % 100) == 0)) {
-      logInfo() << "#max-updates since sync: " << nextCorrectionSteps
-                    << " @ " << ct.nextCorrectionTime(syncTime);
+  if (printProgress && (((nextCorrectionSteps / timeStepRate) % 100) == 0)) {
+    logInfo() << "#max-updates since sync: " << nextCorrectionSteps
+                  << " @ " << ct.nextCorrectionTime(syncTime);
 
-      }
-  }
+    }
 }
 
 void TimeCluster::reset() {

--- a/src/Solver/time_stepping/TimeCluster.h
+++ b/src/Solver/time_stepping/TimeCluster.h
@@ -11,10 +11,8 @@
 #ifndef SEISSOL_SRC_SOLVER_TIME_STEPPING_TIMECLUSTER_H_
 #define SEISSOL_SRC_SOLVER_TIME_STEPPING_TIMECLUSTER_H_
 
-#ifdef USE_MPI
 #include <mpi.h>
 #include <list>
-#endif
 
 #include "Initializer/Typedefs.h"
 #include "SourceTerm/Typedefs.h"

--- a/src/Solver/time_stepping/TimeManager.cpp
+++ b/src/Solver/time_stepping/TimeManager.cpp
@@ -147,7 +147,7 @@ void seissol::time_stepping::TimeManager::addClusters(TimeStepping& timeStepping
 
     increaseManager.setTimeClusterVector(&clusters);
     decreaseManager.setTimeClusterVector(&clusters);
-#ifdef USE_MPI
+
     // Create ghost time clusters for MPI
     const auto preferredDataTransferMode = MPI::mpi.getPreferredDataTransferMode();
     const auto persistent = usePersistentMpi(seissolInstance.env());
@@ -181,7 +181,6 @@ void seissol::time_stepping::TimeManager::addClusters(TimeStepping& timeStepping
         ghostClusters.back()->connect(*copy);
       }
     }
-#endif
   }
 
   clusteringWriter.write();

--- a/src/SourceTerm/Manager.cpp
+++ b/src/SourceTerm/Manager.cpp
@@ -314,10 +314,8 @@ auto loadSourcesFromFSRM(const char* fileName,
   initializer::findMeshIds(
       fsrm.centers.data(), mesh, fsrm.numberOfSources, contained.data(), meshIds.data());
 
-#ifdef USE_MPI
-  logInfo() << "Cleaning possible double occurring point sources for MPI...";
+  logInfo() << "Cleaning possible double occurring point sources in multi-rank setups...";
   initializer::cleanDoubles(contained.data(), fsrm.numberOfSources);
-#endif
 
   auto originalIndex = std::vector<unsigned>(fsrm.numberOfSources);
   unsigned numSources = 0;
@@ -426,10 +424,8 @@ auto loadSourcesFromNRF(const char* fileName,
   logInfo() << "Finding meshIds for point sources...";
   initializer::findMeshIds(nrf.centres.data(), mesh, nrf.size(), contained.data(), meshIds.data());
 
-#ifdef USE_MPI
-  logInfo() << "Cleaning possible double occurring point sources for MPI...";
+  logInfo() << "Cleaning possible double occurring point sources for multi-rank setups...";
   initializer::cleanDoubles(contained.data(), nrf.size());
-#endif
 
   auto originalIndex = std::vector<unsigned>(nrf.size());
   unsigned numSources = 0;
@@ -441,9 +437,7 @@ auto loadSourcesFromNRF(const char* fileName,
 
   // Checking that all sources are within the domain
   unsigned globalnumSources = numSources;
-#ifdef USE_MPI
   MPI_Reduce(&numSources, &globalnumSources, 1, MPI_UNSIGNED, MPI_SUM, 0, seissol::MPI::mpi.comm());
-#endif
 
   if (rank == 0) {
     const int numSourceOutside = nrf.size() - globalnumSources;

--- a/src/tests/Initializer/time_stepping/LTSWeights.t.h
+++ b/src/tests/Initializer/time_stepping/LTSWeights.t.h
@@ -19,8 +19,6 @@
 namespace seissol::unit_test {
 
 TEST_CASE("LTS Weights") {
-// PUMLReader is only available with MPI
-#ifdef USE_MPI
   std::cout.setstate(std::ios_base::failbit);
   using namespace seissol::initializer::time_stepping;
   const LtsWeightsConfig config{seissol::initializer::parameters::BoundaryFormat::I32, 2, 1, 1, 1};
@@ -60,7 +58,6 @@ TEST_CASE("LTS Weights") {
       std::vector<unsigned>{2, 2, 1, 1, 1, 1, 1, 2, 1, 1, 2, 2, 2, 1, 1, 1, 1, 2, 2, 2, 1, 1, 2, 1};
 
   REQUIRE(givenWeights == expectedWeights);
-#endif
 }
 
 TEST_CASE("Cost function for LTS") {


### PR DESCRIPTION
The MPI-less build of SeisSol is not that well supported; and MPI is present pretty much on almost every system. Plus, distinguishing between an MPI-less and MPI-using version creates a lot of extra code paths which are not really worth the maintenance given the setups that we have.

Hence, we remove most of the `USE_MPI` checks. If we really want an MPI-less build, it would probably be better to create a one-rank fake MPI implementation (i.e. which implements all MPI calls, but runs them only locally). We'll still need the `USE_MPI` flag nonetheless; for the submodules. The only two MPI-related checks that are left in are for ASAGI which is built separately and may need MPI on its own.

Petsc does the same thing; cf. https://gitlab.com/petsc/petsc/-/tree/main/include/petsc/mpiuni .
