### PR TITLE
Use larger yield accumulators

### DIFF
--- a/src/Kernels/Plasticity.h
+++ b/src/Kernels/Plasticity.h
@@ -28,13 +28,13 @@ class Plasticity {
 
   /** Returns 1 if there was plastic yielding otherwise 0.
    */
-  static unsigned computePlasticity(double oneMinusIntegratingFactor,
-                                    double timeStepWidth,
-                                    double tV,
-                                    const GlobalData* global,
-                                    const seissol::model::PlasticityData* plasticityData,
-                                    real degreesOfFreedom[tensor::Q::size()],
-                                    real* pstrain);
+  static std::size_t computePlasticity(double oneMinusIntegratingFactor,
+                                       double timeStepWidth,
+                                       double tV,
+                                       const GlobalData* global,
+                                       const seissol::model::PlasticityData* plasticityData,
+                                       real degreesOfFreedom[tensor::Q::size()],
+                                       real* pstrain);
 
   static void
       computePlasticityBatched(double timeStepWidth,
@@ -42,7 +42,7 @@ class Plasticity {
                                const GlobalData* global,
                                initializer::recording::ConditionalPointersToRealsTable& table,
                                seissol::model::PlasticityData* plasticityData,
-                               unsigned* yieldCounter,
+                               std::size_t* yieldCounter,
                                seissol::parallel::runtime::StreamRuntime& runtime);
 
   static void flopsPlasticity(long long& nonZeroFlopsCheck,

--- a/src/Solver/time_stepping/TimeCluster.h
+++ b/src/Solver/time_stepping/TimeCluster.h
@@ -139,7 +139,7 @@ private:
 
     kernels::ReceiverCluster* m_receiverCluster;
 
-    seissol::memory::MemkindArray<unsigned> yieldCells;
+    seissol::memory::MemkindArray<std::size_t> yieldCells;
 
     /**
      * Writes the receiver output if applicable (receivers present, receivers have to be written).


### PR DESCRIPTION
Includes the latest `Device` updates (NVTX package finding; fix the reduction on CDNA).
Also now uses a 64-bit accumulator for plasticity FLOP during a phase.
