### PR TITLE
Modify pre-computed hases for ci

### DIFF
--- a/.github/workflows/build-seissol-cpu.yml
+++ b/.github/workflows/build-seissol-cpu.yml
@@ -10,7 +10,7 @@ on:
   - push
 
 env:
-  precomputed-hash: 0fe0a82d19d2452c213789a51bc1d65edcf3c1ee
+  precomputed-hash: cbcab3f832289de2412dd732304588c828b1e8b7
 
 jobs:
   seissol-build-test:

--- a/.github/workflows/build-seissol-gpu.yml
+++ b/.github/workflows/build-seissol-gpu.yml
@@ -10,7 +10,7 @@ on:
   - push
 
 env:
-  precomputed-hash: 0fe0a82d19d2452c213789a51bc1d65edcf3c1ee
+  precomputed-hash: cbcab3f832289de2412dd732304588c828b1e8b7
 
 jobs:
   seissol-build-test:


### PR DESCRIPTION
The current CI hash does not have tpv13 fused precomputed in it. Changing CI hashes such that it is available