### PR TITLE
Fix a `ClusterLayout` typo

### DIFF
--- a/src/Initializer/TimeStepping/ClusterLayout.h
+++ b/src/Initializer/TimeStepping/ClusterLayout.h
@@ -7,16 +7,18 @@
 #ifndef SEISSOL_SRC_INITIALIZER_TIMESTEPPING_CLUSTERLAYOUT_H_
 #define SEISSOL_SRC_INITIALIZER_TIMESTEPPING_CLUSTERLAYOUT_H_
 
+#include <cstddef>
+#include <cstdint>
 #include <vector>
 
 namespace seissol::initializer {
 
 struct ClusterLayout {
-  std::vector<std::size_t> rates;
+  std::vector<std::uint64_t> rates;
   double minimumTimestep;
   std::size_t globalClusterCount;
 
-  ClusterLayout(const std::vector<std::size_t>& rates,
+  ClusterLayout(const std::vector<std::uint64_t>& rates,
                 double minimumTimestep,
                 std::size_t globalClusterCount)
       : rates(rates), minimumTimestep(minimumTimestep), globalClusterCount(globalClusterCount) {}
@@ -25,8 +27,8 @@ struct ClusterLayout {
     return clusterRate(id) * minimumTimestep;
   }
 
-  [[nodiscard]] long clusterRate(std::size_t id) const {
-    std::size_t value = 1;
+  [[nodiscard]] std::uint64_t clusterRate(std::size_t id) const {
+    std::uint64_t value = 1;
     for (std::size_t i = 0; i < id; ++i) {
       const auto rate = rates.size() > i ? rates[i] : rates.back();
       value *= rate;

--- a/src/Solver/TimeStepping/TimeManager.cpp
+++ b/src/Solver/TimeStepping/TimeManager.cpp
@@ -78,7 +78,7 @@ void TimeManager::addClusters(const initializer::ClusterLayout& clusterLayout,
     const int globalClusterId = static_cast<int>(localClusterId);
     // chop off at synchronization time
     const auto timeStepSize = clusterLayout.timestepRate(localClusterId);
-    const long timeStepRate = clusterLayout.clusterRate(localClusterId);
+    const auto timeStepRate = clusterLayout.clusterRate(localClusterId);
 
     // Dynamic rupture
     auto& dynRupTree = memoryManager.getDynamicRuptureTree()->child(localClusterId);
@@ -172,7 +172,7 @@ void TimeManager::addClusters(const initializer::ClusterLayout& clusterLayout,
         assert(static_cast<int>(otherGlobalClusterId) <
                std::min(globalClusterId + 2, static_cast<int>(clusterLayout.globalClusterCount)));
         const auto otherTimeStepSize = clusterLayout.timestepRate(otherGlobalClusterId);
-        const long otherTimeStepRate = clusterLayout.timestepRate(otherGlobalClusterId);
+        const auto otherTimeStepRate = clusterLayout.clusterRate(otherGlobalClusterId);
 
         auto ghostCluster = GhostTimeClusterFactory::get(otherTimeStepSize,
                                                          otherTimeStepRate,


### PR DESCRIPTION
Fix a typo that broke LTS+MPI.
Also, switch some datatypes to fixed-length ones.
