### PR TITLE
Add MPI resize to struct types

### DIFF
--- a/src/Geometry/MeshReader.cpp
+++ b/src/Geometry/MeshReader.cpp
@@ -259,6 +259,7 @@ void MeshReader::exchangeGhostlayerMetadata() {
   // TODO(David): Once a generic MPI type inference module is ready, replace this part here ...
   // Maybe.
   MPI_Datatype ghostElementType = MPI_DATATYPE_NULL;
+  MPI_Datatype ghostElementTypePre = MPI_DATATYPE_NULL;
 
   // assume that all vertices are stored contiguously
   const int datatypeCount = 6;
@@ -280,7 +281,8 @@ void MeshReader::exchangeGhostlayerMetadata() {
                          datatypeBlocklen.data(),
                          datatypeDisplacement.data(),
                          datatypeDatatype.data(),
-                         &ghostElementType);
+                         &ghostElementTypePre);
+  MPI_Type_create_resized(ghostElementTypePre, 0, sizeof(GhostElementMetadata), &ghostElementType);
   MPI_Type_commit(&ghostElementType);
 
   size_t counter = 0;

--- a/src/IO/Datatype/MPIType.cpp
+++ b/src/IO/Datatype/MPIType.cpp
@@ -46,6 +46,7 @@ MPI_Datatype convertArray(const seissol::io::datatype::ArrayDatatype& datatype) 
 }
 
 MPI_Datatype convertStruct(const seissol::io::datatype::StructDatatype& datatype) {
+  MPI_Datatype pretype = MPI_DATATYPE_NULL;
   MPI_Datatype type = MPI_DATATYPE_NULL;
   std::vector<MPI_Datatype> subtypes;
   std::vector<MPI_Aint> suboffsets;
@@ -56,7 +57,8 @@ MPI_Datatype convertStruct(const seissol::io::datatype::StructDatatype& datatype
     subtypes.push_back(seissol::io::datatype::convertToMPI(member.datatype, false));
   }
   MPI_Type_create_struct(
-      subtypes.size(), subsizes.data(), suboffsets.data(), subtypes.data(), &type);
+      subtypes.size(), subsizes.data(), suboffsets.data(), subtypes.data(), &pretype);
+  MPI_Type_create_resized(pretype, 0, datatype.size(), &type);
   return type;
 }
 


### PR DESCRIPTION
Types may be sized differently than the elements they store; it can be fixed by resizing the datatype explicitly—cf. https://stackoverflow.com/a/33624425 .
