### PR TITLE
Fix build for ICX 2025.0

### DIFF
--- a/src/DynamicRupture/FrictionLaws/CpuImpl/RateAndState.h
+++ b/src/DynamicRupture/FrictionLaws/CpuImpl/RateAndState.h
@@ -11,6 +11,12 @@
 #include "BaseFrictionLaw.h"
 #include "DynamicRupture/FrictionLaws/RateAndStateCommon.h"
 
+#ifdef __INTEL_LLVM_COMPILER
+#if __INTEL_LLVM_COMPILER >= 20250000
+#define SEISSOL_INTEL_SIMD_EXCEPTION
+#endif
+#endif // __INTEL_LLVM_COMPILER
+
 namespace seissol::dr::friction_law::cpu {
 /**
  * General implementation of a rate and state solver
@@ -330,7 +336,9 @@ class RateAndStateBase : public BaseFrictionLaw<RateAndStateBase<Derived, TPMeth
       if (hasConverged) {
         return hasConverged;
       }
+#ifndef SEISSOL_INTEL_SIMD_EXCEPTION
 #pragma omp simd
+#endif
       for (unsigned pointIndex = 0; pointIndex < misc::NumPaddedPoints; pointIndex++) {
 
         // derivative of g


### PR DESCRIPTION
If the `omp simd` is enabled, ICX/ICPX (tested with 2025.0.4) fails compiling with an internal clang error. Hence, insert a workaround for now, if we have ICX >= 2025.0.0 at hand.
(the CI tests against 2024.2; there the build still works without this workaround)

[NOTE: might be mitigated by PR #1383 ; but the problem in the compiler is probably still not absolved by that]

Stack dump, for completeness:
```
Stack dump:
0.      Program arguments: /opt/intel/oneapi/compiler/2025.0/bin/compiler/clang++ @/tmp/icpx0366395912KtjBCE/icpxargM8vvok
1.      <eof> parser at end of file
2.      Optimizer
3.      Running pass "function(pragma-omp-simd-if,inject-tli-mappings,hir-ssa-deconstruction,hir-temp-cleanup,hir-normalize-casts,hir-propagate-casted-iv,hir-loop-concatenation,hir-pm-symbolic-tripcount-completeunroll,hir-array-transpose,hir-conditional-temp-sinking,hir-early-opt-predicate,hir-lmm,hir-store-result-into-temp-array,hir-aos-to-soa,hir-runtime-dd,hir-mv-const-ub,hir-sinking-for-perfect-loopnest,hir-non-zero-sinking-for-perfect-loopnest,hir-pragma-loop-blocking,hir-loop-distribute-loopnest,hir-loop-interchange,hir-generate-mkl-call,hir-loop-blocking,hir-undo-sinking-for-perfect-loopnest,hir-dead-store-elimination,hir-minmax-recognition,hir-identity-matrix-idiom-recognition,hir-lower-small-memset-memcpy,hir-pre-vec-complete-unroll,hir-cond-ldst-motion,hir-memory-reduction-sinking,hir-loop-peeling,hir-lmm,hir-min-max-blob-to-select,hir-dead-store-elimination,hir-last-value-computation,hir-loop-reroll,hir-loop-collapse,hir-loop-fusion,hir-dead-store-elimination,hir-loop-independent-scalar-repl,hir-opt-var-predicate,hir-temp-array-transpose,hir-loop-distribute-memrec,hir-loop-reversal,hir-loop-rematerialize,hir-multi-exit-loop-reroll,hir-idiom,hir-if-reversal,hir-unroll-and-jam,hir-mv-variable-stride,hir-opt-predicate,hir-special-opt-predicate,hir-lmm,hir-memory-reduction-sinking,hir-loop-independent-scalar-repl,hir-vec-dir-insert,hir-vplan-vec,hir-vplan-vec,hir-post-vec-complete-unroll,hir-general-unroll,hir-scalarrepl-array,hir-nontemporal-marking,hir-prefetching,hir-cg,vpo-cfg-restructuring,vpo-rename-operands,simplifycfg<bonus-inst-threshold=1;no-forward-switch-cond;no-switch-range-to-icmp;no-switch-to-lookup;keep-loops;no-hoist-common-insts;no-hoist-loads-stores-with-cond-faulting;no-sink-common-insts;speculate-blocks;simplify-cond-branch;no-invalidate-anders-res>,lower-subscript,sroa<modify-cfg>,nary-reassociate,gvn<>,sroa<modify-cfg>,simplifycfg<bonus-inst-threshold=1;no-forward-switch-cond;no-switch-range-to-icmp;no-switch-to-lookup;keep-loops;no-hoist-common-insts;no-hoist-loads-stores-with-cond-faulting;no-sink-common-insts;speculate-blocks;simplify-cond-branch;no-invalidate-anders-res>,vpo-cfg-restructuring,instcombine<max-iterations=1;no-use-loop-info;no-verify-fixpoint>,loop-carried-cse,dse,addsub-reassoc,vpo-restore-operands,loop-simplify,lower-switch,loop(loop-simplifycfg),vpo-cfg-restructuring)" on module "/home/david/Dokumente/uni/phd/software/seissol/seissol20/src/DynamicRupture/Factory.cpp"
4.      Running pass "simplifycfg<bonus-inst-threshold=1;no-forward-switch-cond;no-switch-range-to-icmp;no-switch-to-lookup;keep-loops;no-hoist-common-insts;no-hoist-loads-stores-with-cond-faulting;no-sink-common-insts;speculate-blocks;simplify-cond-branch;no-invalidate-anders-res>" on function "_ZN7seissol2dr12friction_law3cpu16RateAndStateBaseINS2_24SlowVelocityWeakeningLawINS2_8AgingLawINS2_21ThermalPressurizationEEES6_EES6_E28updateStateVariableIterativeERbRKSt5arrayIfLm64EERSC_SF_SF_SE_RKNS0_13FaultStressesILNS_8ExecutorE0EEEjj"
 #0 0x000055e788f10e37 llvm::sys::PrintStackTrace(llvm::raw_ostream&, int) (/opt/intel/oneapi/compiler/2025.0/bin/compiler/clang+++0x606ee37)
 #1 0x000055e788f0fb94 llvm::sys::RunSignalHandlers() (/opt/intel/oneapi/compiler/2025.0/bin/compiler/clang+++0x606db94)
 #2 0x000055e788ebc865 (anonymous namespace)::CrashRecoveryContextImpl::HandleCrash(int, unsigned long) CrashRecoveryContext.cpp:0:0
 #3 0x000055e788ebca7d CrashRecoverySignalHandler(int) CrashRecoveryContext.cpp:0:0
 #4 0x00007f5b6d64def0 (/usr/lib/libc.so.6+0x3def0)
 #5 0x000055e786e5d1c4 llvm::removeUnreachableBlocks(llvm::Function&, llvm::DomTreeUpdater*, llvm::MemorySSAUpdater*) (/opt/intel/oneapi/compiler/2025.0/bin/compiler/clang+++0x3fbb1c4)
 #6 0x000055e786e1a9c2 simplifyFunctionCFG(llvm::Function&, llvm::TargetTransformInfo const&, llvm::DominatorTree*, llvm::SimplifyCFGOptions const&, llvm::AndersensAAResult*) SimplifyCFGPass.cpp:0:0
 #7 0x000055e7871c15ae llvm::SimplifyCFGPass::run(llvm::Function&, llvm::AnalysisManager<llvm::Function>&) (/opt/intel/oneapi/compiler/2025.0/bin/compiler/clang+++0x431f5ae)
 #8 0x000055e7871c1501 llvm::detail::PassModel<llvm::Function, llvm::SimplifyCFGPass, llvm::AnalysisManager<llvm::Function>>::run(llvm::Function&, llvm::AnalysisManager<llvm::Function>&) VPODirectiveCleanup.cpp:0:0
 #9 0x000055e787338a01 llvm::PassManager<llvm::Function, llvm::AnalysisManager<llvm::Function>>::run(llvm::Function&, llvm::AnalysisManager<llvm::Function>&) (/opt/intel/oneapi/compiler/2025.0/bin/compiler/clang+++0x4496a01)
#10 0x000055e787338731 llvm::detail::PassModel<llvm::Function, llvm::PassManager<llvm::Function, llvm::AnalysisManager<llvm::Function>>, llvm::AnalysisManager<llvm::Function>>::run(llvm::Function&, llvm::AnalysisManager<llvm::Function>&) X86CodeGenPassBuilder.cpp:0:0
#11 0x000055e7872c836a llvm::ModuleToFunctionPassAdaptor::run(llvm::Module&, llvm::AnalysisManager<llvm::Module>&) (/opt/intel/oneapi/compiler/2025.0/bin/compiler/clang+++0x442636a)
#12 0x000055e7872c8141 llvm::detail::PassModel<llvm::Module, llvm::ModuleToFunctionPassAdaptor, llvm::AnalysisManager<llvm::Module>>::run(llvm::Module&, llvm::AnalysisManager<llvm::Module>&) X86CodeGenPassBuilder.cpp:0:0
#13 0x000055e787334c99 llvm::PassManager<llvm::Module, llvm::AnalysisManager<llvm::Module>>::run(llvm::Module&, llvm::AnalysisManager<llvm::Module>&) (/opt/intel/oneapi/compiler/2025.0/bin/compiler/clang+++0x4492c99)
#14 0x000055e787b19b22 (anonymous namespace)::EmitAssemblyHelper::RunOptimizationPipeline(clang::BackendAction, std::__1::unique_ptr<llvm::raw_pwrite_stream, std::__1::default_delete<llvm::raw_pwrite_stream>>&, std::__1::unique_ptr<llvm::ToolOutputFile, std::__1::default_delete<llvm::ToolOutputFile>>&, clang::BackendConsumer*) BackendUtil.cpp:0:0
#15 0x000055e787796f03 clang::EmitBackendOutput(clang::DiagnosticsEngine&, clang::HeaderSearchOptions const&, clang::CodeGenOptions const&, clang::TargetOptions const&, clang::LangOptions const&, llvm::StringRef, llvm::Module*, clang::BackendAction, llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem>, std::__1::unique_ptr<llvm::raw_pwrite_stream, std::__1::default_delete<llvm::raw_pwrite_stream>>, clang::BackendConsumer*) (/opt/intel/oneapi/compiler/2025.0/bin/compiler/clang+++0x48f4f03)
#16 0x000055e78727ea02 clang::BackendConsumer::HandleTranslationUnit(clang::ASTContext&) (/opt/intel/oneapi/compiler/2025.0/bin/compiler/clang+++0x43dca02)
#17 0x000055e786fa926a clang::ParseAST(clang::Sema&, bool, bool) (/opt/intel/oneapi/compiler/2025.0/bin/compiler/clang+++0x410726a)
#18 0x000055e7872ffa7c clang::CodeGenAction::ExecuteAction() (/opt/intel/oneapi/compiler/2025.0/bin/compiler/clang+++0x445da7c)
#19 0x000055e787ccb07e clang::FrontendAction::Execute() (/opt/intel/oneapi/compiler/2025.0/bin/compiler/clang+++0x4e2907e)
#20 0x000055e787ccabc1 clang::CompilerInstance::ExecuteAction(clang::FrontendAction&) (/opt/intel/oneapi/compiler/2025.0/bin/compiler/clang+++0x4e28bc1)
#21 0x000055e78747c305 clang::ExecuteCompilerInvocation(clang::CompilerInstance*) (/opt/intel/oneapi/compiler/2025.0/bin/compiler/clang+++0x45da305)
#22 0x000055e787c09cab cc1_main(llvm::ArrayRef<char const*>, char const*, void*) (/opt/intel/oneapi/compiler/2025.0/bin/compiler/clang+++0x4d67cab)
#23 0x000055e7875148ac ExecuteCC1Tool(llvm::SmallVectorImpl<char const*>&, llvm::ToolContext const&) driver.cpp:0:0
#24 0x000055e7895d9bfd void llvm::function_ref<void ()>::callback_fn<clang::driver::CC1Command::Execute(llvm::ArrayRef<std::__1::optional<llvm::StringRef>>, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>*, bool*) const::$_0>(long) Job.cpp:0:0
#25 0x000055e787e25d56 llvm::CrashRecoveryContext::RunSafely(llvm::function_ref<void ()>) (/opt/intel/oneapi/compiler/2025.0/bin/compiler/clang+++0x4f83d56)
#26 0x000055e787e25e7e clang::driver::CC1Command::Execute(llvm::ArrayRef<std::__1::optional<llvm::StringRef>>, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>*, bool*) const (/opt/intel/oneapi/compiler/2025.0/bin/compiler/clang+++0x4f83e7e)
#27 0x000055e787e876ad clang::driver::Compilation::ExecuteCommand(clang::driver::Command const&, clang::driver::Command const*&, bool) const (/opt/intel/oneapi/compiler/2025.0/bin/compiler/clang+++0x4fe56ad)
#28 0x000055e787e872f7 clang::driver::Compilation::ExecuteJobs(clang::driver::JobList const&, llvm::SmallVectorImpl<std::__1::pair<int, clang::driver::Command const*>>&, bool) const (/opt/intel/oneapi/compiler/2025.0/bin/compiler/clang+++0x4fe52f7)
#29 0x000055e787e86670 clang::driver::Driver::ExecuteCompilation(clang::driver::Compilation&, llvm::SmallVectorImpl<std::__1::pair<int, clang::driver::Command const*>>&) (/opt/intel/oneapi/compiler/2025.0/bin/compiler/clang+++0x4fe4670)
#30 0x000055e787c0c690 clang_main(int, char**, llvm::ToolContext const&) (/opt/intel/oneapi/compiler/2025.0/bin/compiler/clang+++0x4d6a690)
#31 0x000055e787792049 main (/opt/intel/oneapi/compiler/2025.0/bin/compiler/clang+++0x48f0049)
#32 0x00007f5b6d6376b5 (/usr/lib/libc.so.6+0x276b5)
#33 0x00007f5b6d637769 __libc_start_main (/usr/lib/libc.so.6+0x27769)
#34 0x000055e78831e37e _start /export/project/tools-build/toolchain-cross/src/glibc/csu/../sysdeps/x86_64/start.S:122:0
icpx: error: clang frontend command failed with exit code 139 (use -v to see invocation)
Intel(R) oneAPI DPC++/C++ Compiler 2025.0.4 (2025.0.4.20241205)
Target: x86_64-unknown-linux-gnu
Thread model: posix
InstalledDir: /opt/intel/oneapi/compiler/2025.0/bin/compiler
Configuration file: /opt/intel/oneapi/compiler/2025.0/bin/compiler/../icpx.cfg
```