### PR TITLE
Adjust the CPU DR Implementation to the GPU DR Implementation

### DIFF
--- a/src/DynamicRupture/FrictionLaws/CpuImpl/LinearSlipWeakening.h
+++ b/src/DynamicRupture/FrictionLaws/CpuImpl/LinearSlipWeakening.h
@@ -179,7 +179,7 @@ class LinearSlipWeakeningLaw : public BaseFrictionLaw<LinearSlipWeakeningLaw<Spe
     specialization.resampleSlipRate(resampledSlipRate, this->slipRateMagnitude[ltsFace]);
 
     real time = this->mFullUpdateTime;
-    for (int i = 0; i <= timeIndex; ++i) {
+    for (unsigned i = 0; i <= timeIndex; ++i) {
       time += this->deltaT[i];
     }
 #pragma omp simd

--- a/src/DynamicRupture/FrictionLaws/GpuImpl/FastVelocityWeakeningLaw.h
+++ b/src/DynamicRupture/FrictionLaws/GpuImpl/FastVelocityWeakeningLaw.h
@@ -77,16 +77,16 @@ class FastVelocityWeakeningLaw
   }
 
   SEISSOL_DEVICE static double
-      updateMu(FrictionLawContext& ctx, double localSlipRateMagnitude, MuDetails& details) {
+      updateMu(FrictionLawContext& ctx, double localSlipRateMagnitude, const MuDetails& details) {
     const double x = details.c * localSlipRateMagnitude;
     return details.a * std::asinh(x);
   }
 
   SEISSOL_DEVICE static double updateMuDerivative(FrictionLawContext& ctx,
                                                   double localSlipRateMagnitude,
-                                                  MuDetails& details) {
+                                                  const MuDetails& details) {
     const double x = details.c * localSlipRateMagnitude;
-    return details.ac / std::sqrt(std::pow(x, 2) + 1.0);
+    return details.ac / std::sqrt(x * x + 1.0);
   }
 
   SEISSOL_DEVICE static void resampleStateVar(FrictionLawContext& ctx) {

--- a/src/DynamicRupture/FrictionLaws/GpuImpl/ImposedSlipRates.h
+++ b/src/DynamicRupture/FrictionLaws/GpuImpl/ImposedSlipRates.h
@@ -35,7 +35,7 @@ class ImposedSlipRates : public BaseFrictionSolver<ImposedSlipRates<STF>> {
   SEISSOL_DEVICE static void updateFrictionAndSlip(FrictionLawContext& ctx, unsigned timeIndex) {
     const real timeIncrement = ctx.data->deltaT[timeIndex];
     real currentTime = ctx.fullUpdateTime;
-    for (int i = 0; i <= timeIndex; i++) {
+    for (unsigned i = 0; i <= timeIndex; i++) {
       currentTime += ctx.data->deltaT[i];
     }
 

--- a/src/DynamicRupture/FrictionLaws/GpuImpl/LinearSlipWeakening.h
+++ b/src/DynamicRupture/FrictionLaws/GpuImpl/LinearSlipWeakening.h
@@ -187,7 +187,7 @@ class LinearSlipWeakeningLaw
     const auto tpProxyExponent{ctx.data->drParameters.tpProxyExponent};
 
     real tn = ctx.fullUpdateTime;
-    for (int i = 0; i <= timeIndex; ++i) {
+    for (unsigned i = 0; i <= timeIndex; ++i) {
       tn += ctx.data->deltaT[i];
     }
 

--- a/src/DynamicRupture/FrictionLaws/GpuImpl/SevereVelocityWeakeningLaw.h
+++ b/src/DynamicRupture/FrictionLaws/GpuImpl/SevereVelocityWeakeningLaw.h
@@ -85,7 +85,7 @@ class SevereVelocityWeakeningLaw
   }
 
   SEISSOL_DEVICE static double
-      updateMu(FrictionLawContext& ctx, double localSlipRateMagnitude, MuDetails& details) {
+      updateMu(FrictionLawContext& ctx, double localSlipRateMagnitude, const MuDetails& details) {
     return ctx.data->drParameters.rsF0 +
            details.a * localSlipRateMagnitude /
                (localSlipRateMagnitude + ctx.data->drParameters.rsSr0) -
@@ -94,7 +94,7 @@ class SevereVelocityWeakeningLaw
 
   SEISSOL_DEVICE static double updateMuDerivative(FrictionLawContext& ctx,
                                                   double localSlipRateMagnitude,
-                                                  MuDetails& details) {
+                                                  const MuDetails& details) {
     // note that: d/dx (x/(x+c)) = ((x+c)-x)/(x+c)**2 = c/(x+c)**2
     const double divisor = (localSlipRateMagnitude + ctx.data->drParameters.rsSr0);
     return details.a * ctx.data->drParameters.rsSr0 / (divisor * divisor);

--- a/src/DynamicRupture/FrictionLaws/GpuImpl/SlowVelocityWeakeningLaw.h
+++ b/src/DynamicRupture/FrictionLaws/GpuImpl/SlowVelocityWeakeningLaw.h
@@ -47,16 +47,16 @@ class SlowVelocityWeakeningLaw
   }
 
   SEISSOL_DEVICE static double
-      updateMu(FrictionLawContext& ctx, double localSlipRateMagnitude, MuDetails& details) {
+      updateMu(FrictionLawContext& ctx, double localSlipRateMagnitude, const MuDetails& details) {
     const double x = localSlipRateMagnitude * details.c;
     return details.a * std::asinh(x);
   }
 
   SEISSOL_DEVICE static double updateMuDerivative(FrictionLawContext& ctx,
                                                   double localSlipRateMagnitude,
-                                                  MuDetails& details) {
+                                                  const MuDetails& details) {
     const double x = localSlipRateMagnitude * details.c;
-    return details.ac / std::sqrt(std::pow(x, 2) + 1.0);
+    return details.ac / std::sqrt(x * x + 1.0);
   }
 
   /**


### PR DESCRIPTION
Effectively, port some of the smaller R+S optimizations from GPU to CPU; especially moving out the constant computations.
Also effectively work around the ICX 2025 compile bug.
