### PR TITLE
Add multi-varyrate clustering; refactor histogram printing

### DIFF
--- a/.ci/format.sh
+++ b/.ci/format.sh
@@ -57,6 +57,7 @@ format() {
         src/Initializer/PointMapper.cpp
         src/Initializer/PreProcessorMacros.h
         src/Initializer/TimeStepping/ClusterLayout.h
+        src/Initializer/TimeStepping/ClusterLayout.cpp
         src/Initializer/TimeStepping/GlobalTimestep.h
         src/Initializer/TimeStepping/GlobalTimestep.cpp
         src/SeisSol.h

--- a/.ci/tidy.sh
+++ b/.ci/tidy.sh
@@ -58,6 +58,7 @@ format() {
         src/Initializer/PointMapper.cpp
         src/Initializer/PreProcessorMacros.h
         src/Initializer/TimeStepping/ClusterLayout.h
+        src/Initializer/TimeStepping/ClusterLayout.cpp
         src/Initializer/TimeStepping/GlobalTimestep.h
         src/Initializer/TimeStepping/GlobalTimestep.cpp
         src/SeisSol.h

--- a/src/Initializer/InitProcedure/InitModel.cpp
+++ b/src/Initializer/InitProcedure/InitModel.cpp
@@ -299,10 +299,13 @@ void hostDeviceCoexecution(seissol::SeisSol& seissolInstance) {
 void initializeClusteredLts(LtsInfo& ltsInfo, seissol::SeisSol& seissolInstance) {
   const auto& seissolParams = seissolInstance.getSeisSolParameters();
 
-  seissolInstance.getLtsLayout().deriveLayout(seissolParams.timeStepping.lts.getRate());
+  seissolInstance.getLtsLayout().deriveLayout();
 
   seissolInstance.getLtsLayout().getMeshStructure(ltsInfo.meshStructure);
-  ltsInfo.clusterLayout = seissolInstance.getLtsLayout().clusterLayout();
+  ltsInfo.clusterLayout = ClusterLayout::fromMesh(seissolParams.timeStepping.lts.getRate(),
+                                                  seissolInstance.meshReader(),
+                                                  seissolParams.timeStepping.lts.getWiggleFactor(),
+                                                  true);
 
   seissolInstance.getMemoryManager().initializeFrictionLaw();
 

--- a/src/Initializer/InitProcedure/InitModel.cpp
+++ b/src/Initializer/InitProcedure/InitModel.cpp
@@ -299,10 +299,7 @@ void hostDeviceCoexecution(seissol::SeisSol& seissolInstance) {
 void initializeClusteredLts(LtsInfo& ltsInfo, seissol::SeisSol& seissolInstance) {
   const auto& seissolParams = seissolInstance.getSeisSolParameters();
 
-  assert(seissolParams.timeStepping.lts.getRate() > 0);
-
-  seissolInstance.getLtsLayout().deriveLayout(TimeClustering::MultiRate,
-                                              seissolParams.timeStepping.lts.getRate());
+  seissolInstance.getLtsLayout().deriveLayout(seissolParams.timeStepping.lts.getRate());
 
   seissolInstance.getLtsLayout().getMeshStructure(ltsInfo.meshStructure);
   ltsInfo.clusterLayout = seissolInstance.getLtsLayout().clusterLayout();

--- a/src/Initializer/Parameters/LtsParameters.cpp
+++ b/src/Initializer/Parameters/LtsParameters.cpp
@@ -18,8 +18,10 @@
 #include <math.h>
 #include <stdexcept>
 #include <string>
+#include <utility>
 #include <utils/logger.h>
 #include <utils/stringutils.h>
+#include <vector>
 
 namespace seissol::initializer::parameters {
 
@@ -134,7 +136,7 @@ AutoMergeCostBaseline LtsParameters::getAutoMergeCostBaseline() const {
 }
 
 void LtsParameters::setWiggleFactor(double factor) {
-  assert(factor >= 1.0 / static_cast<double>(rate));
+  assert(factor >= 1.0 / static_cast<double>(rate[0]));
   assert(factor <= 1.0);
   finalWiggleFactor = factor;
 }
@@ -150,7 +152,7 @@ TimeSteppingParameters::TimeSteppingParameters(VertexWeightParameters vertexWeig
                                                double endTime,
                                                LtsParameters lts)
     : vertexWeight(vertexWeight), cfl(cfl), maxTimestepWidth(maxTimestepWidth), endTime(endTime),
-      lts(lts) {}
+      lts(std::move(lts)) {}
 
 TimeSteppingParameters readTimeSteppingParameters(ParameterReader* baseReader) {
   auto* reader = baseReader->readSubNode("discretization");

--- a/src/Initializer/Parameters/LtsParameters.h
+++ b/src/Initializer/Parameters/LtsParameters.h
@@ -36,7 +36,7 @@ AutoMergeCostBaseline parseAutoMergeCostBaseline(std::string str);
 
 class LtsParameters {
   private:
-  unsigned int rate{};
+  std::vector<uint64_t> rate;
   double wiggleFactorMinimum{};
   double wiggleFactorStepsize{};
   bool wiggleFactorEnforceMaximumDifference{};
@@ -48,7 +48,7 @@ class LtsParameters {
   double finalWiggleFactor = 1.0;
 
   public:
-  [[nodiscard]] unsigned int getRate() const;
+  [[nodiscard]] std::vector<uint64_t> getRate() const;
   [[nodiscard]] bool isWiggleFactorUsed() const;
   [[nodiscard]] double getWiggleFactorMinimum() const;
   [[nodiscard]] double getWiggleFactorStepsize() const;
@@ -64,7 +64,7 @@ class LtsParameters {
 
   LtsParameters() = default;
 
-  LtsParameters(unsigned int rate,
+  LtsParameters(const std::vector<uint64_t>& rate,
                 double wiggleFactorMinimum,
                 double wiggleFactorStepsize,
                 bool wigleFactorEnforceMaximumDifference,

--- a/src/Initializer/TimeStepping/ClusterLayout.cpp
+++ b/src/Initializer/TimeStepping/ClusterLayout.cpp
@@ -9,8 +9,12 @@
 #include <Monitoring/Unit.h>
 #include <Numerical/StableSum.h>
 #include <Parallel/MPI.h>
+#include <algorithm>
+#include <array>
 #include <cstddef>
 #include <cstdint>
+#include <limits>
+#include <utils/logger.h>
 #include <vector>
 
 #include <mpi.h>

--- a/src/Initializer/TimeStepping/ClusterLayout.cpp
+++ b/src/Initializer/TimeStepping/ClusterLayout.cpp
@@ -1,0 +1,106 @@
+// SPDX-FileCopyrightText: 2025 SeisSol Group
+//
+// SPDX-License-Identifier: BSD-3-Clause
+// SPDX-LicenseComments: Full text under /LICENSE and /LICENSES/
+//
+// SPDX-FileContributor: Author lists in /AUTHORS and /CITATION.cff
+#include <Geometry/MeshReader.h>
+#include <Initializer/TimeStepping/ClusterLayout.h>
+#include <Monitoring/Unit.h>
+#include <Numerical/StableSum.h>
+#include <Parallel/MPI.h>
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+#include <mpi.h>
+
+namespace seissol::initializer {
+
+ClusterLayout ClusterLayout::fromMesh(const std::vector<std::uint64_t>& rates,
+                                      const geometry::MeshReader& mesh,
+                                      double wiggle,
+                                      bool infoprint) {
+  std::uint64_t maxLtsId = 0;
+  double minimumTimestep = std::numeric_limits<double>::max();
+  for (const auto& element : mesh.getElements()) {
+    maxLtsId = std::max(maxLtsId, static_cast<std::uint64_t>(element.clusterId));
+    minimumTimestep = std::min(minimumTimestep, element.timestep);
+  }
+  MPI_Allreduce(
+      MPI_IN_PLACE, &maxLtsId, 1, MPI::castToMpiType<std::uint64_t>(), MPI_MAX, MPI::mpi.comm());
+  MPI_Allreduce(MPI_IN_PLACE, &minimumTimestep, 1, MPI_DOUBLE, MPI_MIN, MPI::mpi.comm());
+  if (wiggle == 1) {
+    if (infoprint) {
+      logInfo() << "Minimum timestep:" << seissol::UnitTime.formatPrefix(minimumTimestep).c_str();
+    }
+  } else {
+    if (infoprint) {
+      logInfo() << "Minimum timestep (pre-wiggle):"
+                << seissol::UnitTime.formatPrefix(minimumTimestep).c_str();
+    }
+
+    // apply wiggle here
+    minimumTimestep *= wiggle;
+    if (infoprint) {
+      logInfo() << "Minimum timestep (with wiggle" << wiggle
+                << "):" << seissol::UnitTime.formatPrefix(minimumTimestep).c_str();
+    }
+  }
+  ClusterLayout layout(rates, minimumTimestep, maxLtsId + 1);
+
+  if (infoprint) {
+    std::vector<std::uint64_t> clusters(maxLtsId + 1);
+    std::vector<std::uint64_t> clustersDR(maxLtsId + 1);
+    const double timefactorGTS = minimumTimestep * mesh.getElements().size();
+    numerical::StableAccumulator<double> timefactorELTS;
+    numerical::StableAccumulator<double> timefactorCLTS;
+    for (const auto& element : mesh.getElements()) {
+      ++clusters[static_cast<std::size_t>(element.clusterId)];
+      for (int i = 0; i < 4; ++i) {
+        if (element.boundaries[i] == 3) {
+          ++clustersDR[static_cast<std::size_t>(element.clusterId)];
+        }
+      }
+
+      const auto elts = element.timestep * wiggle;
+      const auto clts = layout.timestepRate(static_cast<std::size_t>(element.clusterId));
+
+      timefactorELTS += elts;
+      timefactorCLTS += clts;
+    }
+    MPI_Allreduce(MPI_IN_PLACE,
+                  clusters.data(),
+                  clusters.size(),
+                  MPI::castToMpiType<std::uint64_t>(),
+                  MPI_SUM,
+                  MPI::mpi.comm());
+    MPI_Allreduce(MPI_IN_PLACE,
+                  clustersDR.data(),
+                  clustersDR.size(),
+                  MPI::castToMpiType<std::uint64_t>(),
+                  MPI_SUM,
+                  MPI::mpi.comm());
+    std::array<double, 3> timefactors{
+        timefactorGTS, timefactorELTS.result(), timefactorCLTS.result()};
+    MPI_Allreduce(
+        MPI_IN_PLACE, timefactors.data(), timefactors.size(), MPI_DOUBLE, MPI_SUM, MPI::mpi.comm());
+
+    const auto eltsSpeedup = timefactors[1] / timefactors[0];
+    const auto cltsSpeedup = timefactors[2] / timefactors[0];
+    logInfo() << "Theoretical speedup to GTS:" << eltsSpeedup << "elementwise LTS;" << cltsSpeedup
+              << "clustered LTS (current setup)";
+
+    logInfo() << "Cluster histogram (cell, DR):";
+    for (std::size_t i = 0; i <= maxLtsId; ++i) {
+      // NOTE: we count the DR faces twice; hence divide by 2 here
+      // (also we now ignore copy-layer DR faces in the histogram unlike @:1.3.2; see the actual
+      // clustering histogram for that instead)
+      logInfo() << i << ":" << clusters[i] << "," << (clustersDR[i] / 2);
+    }
+  }
+
+  return layout;
+}
+
+} // namespace seissol::initializer

--- a/src/Initializer/TimeStepping/ClusterLayout.h
+++ b/src/Initializer/TimeStepping/ClusterLayout.h
@@ -11,6 +11,10 @@
 #include <cstdint>
 #include <vector>
 
+namespace seissol::geometry {
+class MeshReader;
+} // namespace seissol::geometry
+
 namespace seissol::initializer {
 
 struct ClusterLayout {
@@ -35,6 +39,11 @@ struct ClusterLayout {
     }
     return value;
   }
+
+  static ClusterLayout fromMesh(const std::vector<std::uint64_t>& rates,
+                                const geometry::MeshReader& mesh,
+                                double wiggle,
+                                bool infoprint);
 };
 
 } // namespace seissol::initializer

--- a/src/Initializer/TimeStepping/LtsLayout.cpp
+++ b/src/Initializer/TimeStepping/LtsLayout.cpp
@@ -726,13 +726,12 @@ void seissol::initializer::time_stepping::LtsLayout::deriveClusteredGhost() {
   delete[] l_requests;
 }
 
-void seissol::initializer::time_stepping::LtsLayout::deriveLayout( TimeClustering i_timeClustering,
-                                                                    unsigned int        i_clusterRate ) {
-  m_globalTimeStepRates.resize(1);
-  m_globalTimeStepRates[0] = i_clusterRate;
+void seissol::initializer::time_stepping::LtsLayout::deriveLayout( const std::vector<uint64_t>& rates ) {
+  ClusterLayout layout(rates, m_globalTimeStepWidths[0], m_numberOfGlobalClusters);
+  m_globalTimeStepRates = rates;
   
   for (std::size_t i = 1; i < m_numberOfGlobalClusters; ++i) {
-    m_globalTimeStepWidths[i] = m_globalTimeStepWidths[i - 1] * i_clusterRate;
+    m_globalTimeStepWidths[i] = layout.timestepRate(i);
   }
 
   // derive plain copy and the interior
@@ -771,7 +770,7 @@ void seissol::initializer::time_stepping::LtsLayout::deriveLayout( TimeClusterin
 }
 
 seissol::initializer::ClusterLayout seissol::initializer::time_stepping::LtsLayout::clusterLayout() const {
-  return ClusterLayout({m_globalTimeStepRates[0]}, m_globalTimeStepWidths[0], m_numberOfGlobalClusters);
+  return ClusterLayout(m_globalTimeStepRates, m_globalTimeStepWidths[0], m_numberOfGlobalClusters);
 }
 
 void seissol::initializer::time_stepping::LtsLayout::getCellInformation( CellLocalInformation* io_cellLocalInformation,

--- a/src/Initializer/TimeStepping/LtsLayout.h
+++ b/src/Initializer/TimeStepping/LtsLayout.h
@@ -210,20 +210,6 @@ class seissol::initializer::time_stepping::LtsLayout {
     void normalizeMpiIndices();
 
     /**
-     * Normalizes the clustering.
-     **/
-    void normalizeClustering();
-
-    /**
-     * Gets the maximum possible speedups.
-     *
-     * @param o_perCellTimeStepWidths maximum possible speedup, when every cell is allowed to do an individual time step width.
-     * @param o_clustering maximum possible speedup with the derived clustering strategy.
-     **/
-    void getTheoreticalSpeedup( double &o_perCellTimeStepWidths,
-                                double &o_clustering );
-
-    /**
      * Sorts a clustered copy region neighboring to a copy region in GTS fashion.
      * Copy cells send either buffers or derivatives to neighboring cells, never both.
      * For a copy region with clusterd id $l$ neighboring to a cluster with clusterd $n$ the following holds:
@@ -403,9 +389,7 @@ class seissol::initializer::time_stepping::LtsLayout {
      * @param i_timeClustering clustering strategy.
      * @param i_clusterRate cluster rate in the case of a multi-rate scheme.
      **/
-    void deriveLayout( const std::vector<uint64_t>& rates );
-
-    [[nodiscard]] ClusterLayout clusterLayout() const;
+    void deriveLayout(  );
 
     /**
      * Initializes the data structures required for computation.

--- a/src/Initializer/TimeStepping/LtsLayout.h
+++ b/src/Initializer/TimeStepping/LtsLayout.h
@@ -52,7 +52,7 @@ class seissol::initializer::time_stepping::LtsLayout {
     std::vector<double> m_globalTimeStepWidths;
 
     //! time step rates of all clusters
-    std::vector<unsigned int> m_globalTimeStepRates;
+    std::vector<uint64_t> m_globalTimeStepRates;
 
     //! mpi tags used for communication
     enum mpiTag {
@@ -403,8 +403,7 @@ class seissol::initializer::time_stepping::LtsLayout {
      * @param i_timeClustering clustering strategy.
      * @param i_clusterRate cluster rate in the case of a multi-rate scheme.
      **/
-    void deriveLayout( enum TimeClustering i_timeClustering,
-                       unsigned int        i_clusterRate = std::numeric_limits<unsigned int>::max() );
+    void deriveLayout( const std::vector<uint64_t>& rates );
 
     [[nodiscard]] ClusterLayout clusterLayout() const;
 

--- a/src/Initializer/TimeStepping/LtsWeights/LtsWeights.cpp
+++ b/src/Initializer/TimeStepping/LtsWeights/LtsWeights.cpp
@@ -377,7 +377,7 @@ std::uint64_t LtsWeights::getCluster(double timestep,
 
   std::uint64_t cluster = 0;
   while (upper <= timestep) {
-    upper *= rate.size() > cluster ? rate[cluster] : rate.back();
+    upper *= rate.size() > (cluster + 1) ? rate[cluster + 1] : rate.back();
     ++cluster;
   }
   return cluster;

--- a/src/Initializer/TimeStepping/LtsWeights/LtsWeights.cpp
+++ b/src/Initializer/TimeStepping/LtsWeights/LtsWeights.cpp
@@ -18,6 +18,7 @@
 #include <cassert>
 #include <cmath>
 #include <cstddef>
+#include <cstdint>
 #include <limits>
 #include <map>
 #include <optional>

--- a/src/Initializer/TimeStepping/LtsWeights/LtsWeights.cpp
+++ b/src/Initializer/TimeStepping/LtsWeights/LtsWeights.cpp
@@ -41,7 +41,7 @@ namespace seissol::initializer::time_stepping {
 
 double computeLocalCostOfClustering(const std::vector<int>& clusterIds,
                                     const std::vector<int>& cellCosts,
-                                    unsigned int rate,
+                                    const std::vector<uint64_t>& rate,
                                     double wiggleFactor,
                                     double minimalTimestep) {
   assert(clusterIds.size() == cellCosts.size());
@@ -50,8 +50,8 @@ double computeLocalCostOfClustering(const std::vector<int>& clusterIds,
   for (auto i = 0U; i < clusterIds.size(); ++i) {
     const auto cluster = clusterIds[i];
     const auto cellCost = cellCosts[i];
-    const double updateFactor = 1.0 / (std::pow(rate, cluster));
-    cost += updateFactor * cellCost;
+    const auto invUpdateFactor = ratepow(rate, 0, cluster);
+    cost += cellCost / static_cast<double>(invUpdateFactor);
   }
 
   const auto minDtWithWiggle = minimalTimestep * wiggleFactor;
@@ -60,7 +60,7 @@ double computeLocalCostOfClustering(const std::vector<int>& clusterIds,
 
 double computeGlobalCostOfClustering(const std::vector<int>& clusterIds,
                                      const std::vector<int>& cellCosts,
-                                     unsigned int rate,
+                                     const std::vector<uint64_t>& rate,
                                      double wiggleFactor,
                                      double minimalTimestep,
                                      MPI_Comm comm) {
@@ -84,7 +84,7 @@ std::vector<int> enforceMaxClusterId(const std::vector<int>& clusterIds, int max
 // Merges clusters such that new cost is max oldCost * allowedPerformanceLossRatio
 int computeMaxClusterIdAfterAutoMerge(const std::vector<int>& clusterIds,
                                       const std::vector<int>& cellCosts,
-                                      unsigned int rate,
+                                      const std::vector<uint64_t>& rate,
                                       double maximalAdmissibleCost,
                                       double wiggleFactor,
                                       double minimalTimestep) {
@@ -92,7 +92,7 @@ int computeMaxClusterIdAfterAutoMerge(const std::vector<int>& clusterIds,
   MPI_Allreduce(MPI_IN_PLACE, &maxClusterId, 1, MPI_INT, MPI_MAX, MPI::mpi.comm());
 
   // We only have one cluster for rate = 1 and thus cannot merge.
-  if (rate == 1) {
+  if (rate.empty()) {
     return maxClusterId;
   }
 
@@ -125,7 +125,7 @@ void LtsWeights::computeWeights(PUML::TETPUML const& mesh) {
               << "does not support LTS. Switching to GTS.";
     continueComputation = false;
   }
-  if (m_rate == 1) {
+  if (m_rate.empty()) {
     logInfo() << "GTS has been selected.";
     continueComputation = false;
   }
@@ -365,19 +365,19 @@ int LtsWeights::nWeightsPerVertex() const {
   return m_ncon;
 }
 
-int LtsWeights::getCluster(double timestep,
-                           double globalMinTimestep,
-                           double ltsWiggleFactor,
-                           unsigned rate) {
-  if (rate == 1) {
+std::uint64_t LtsWeights::getCluster(double timestep,
+                                     double globalMinTimestep,
+                                     double ltsWiggleFactor,
+                                     const std::vector<uint64_t>& rate) {
+  if (rate.empty()) {
     return 0;
   }
 
-  double upper = ltsWiggleFactor * rate * globalMinTimestep;
+  double upper = ltsWiggleFactor * rate[0] * globalMinTimestep;
 
-  int cluster = 0;
+  std::uint64_t cluster = 0;
   while (upper <= timestep) {
-    upper *= rate;
+    upper *= rate.size() > cluster ? rate[cluster] : rate.back();
     ++cluster;
   }
   return cluster;
@@ -391,17 +391,12 @@ FaceType LtsWeights::getBoundaryCondition(const void* boundaryCond, size_t cell,
   return static_cast<FaceType>(bcCurrentFace);
 }
 
-int LtsWeights::ipow(int x, int y) {
-  assert(y >= 0);
-
-  if (y == 0) {
-    return 1;
+std::uint64_t ratepow(const std::vector<std::uint64_t>& rate, std::uint64_t a, std::uint64_t b) {
+  std::uint64_t factor = 1;
+  for (std::uint64_t i = a; i < b; ++i) {
+    factor *= i < rate.size() ? rate[i] : rate.back();
   }
-  int result = x;
-  while (--y != 0) {
-    result *= x;
-  }
-  return result;
+  return factor;
 }
 
 seissol::initializer::GlobalTimestep LtsWeights::collectGlobalTimeStepDetails() {

--- a/src/Initializer/TimeStepping/LtsWeights/LtsWeights.h
+++ b/src/Initializer/TimeStepping/LtsWeights/LtsWeights.h
@@ -30,7 +30,7 @@ class SeisSol;
 namespace initializer::time_stepping {
 struct LtsWeightsConfig {
   seissol::initializer::parameters::BoundaryFormat boundaryFormat;
-  unsigned rate{};
+  std::vector<uint64_t> rate;
   int vertexWeightElement{};
   int vertexWeightDynamicRupture{};
   int vertexWeightFreeSurfaceWithGravity{};
@@ -38,13 +38,13 @@ struct LtsWeightsConfig {
 
 double computeLocalCostOfClustering(const std::vector<int>& clusterIds,
                                     const std::vector<int>& cellCosts,
-                                    unsigned int rate,
+                                    const std::vector<uint64_t>& rate,
                                     double wiggleFactor,
                                     double minimalTimestep);
 
 double computeGlobalCostOfClustering(const std::vector<int>& clusterIds,
                                      const std::vector<int>& cellCosts,
-                                     unsigned int rate,
+                                     const std::vector<uint64_t>& rate,
                                      double wiggleFactor,
                                      double minimalTimestep,
                                      MPI_Comm comm);
@@ -53,10 +53,12 @@ std::vector<int> enforceMaxClusterId(const std::vector<int>& clusterIds, int max
 
 int computeMaxClusterIdAfterAutoMerge(const std::vector<int>& clusterIds,
                                       const std::vector<int>& cellCosts,
-                                      unsigned int rate,
+                                      const std::vector<uint64_t>& rate,
                                       double maximalAdmissibleCost,
                                       double wiggleFactor,
                                       double minimalTimestep);
+
+std::uint64_t ratepow(const std::vector<std::uint64_t>& rate, std::uint64_t a, std::uint64_t b);
 
 class LtsWeights {
   public:
@@ -78,7 +80,10 @@ class LtsWeights {
   seissol::initializer::GlobalTimestep m_details;
 
   seissol::initializer::GlobalTimestep collectGlobalTimeStepDetails();
-  int getCluster(double timestep, double globalMinTimestep, double wiggleFactor, unsigned rate);
+  std::uint64_t getCluster(double timestep,
+                           double globalMinTimestep,
+                           double wiggleFactor,
+                           const std::vector<uint64_t>& rate);
   FaceType getBoundaryCondition(const void* boundaryCond, size_t cell, unsigned face);
   std::vector<int> computeClusterIds(double curWiggleFactor);
   // returns number of reductions for maximum difference
@@ -87,13 +92,11 @@ class LtsWeights {
   int enforceMaximumDifferenceLocal(int maxDifference = 1);
   std::vector<int> computeCostsPerTimestep();
 
-  static int ipow(int x, int y);
-
   virtual void setVertexWeights() = 0;
   virtual void setAllowedImbalances() = 0;
   virtual int evaluateNumberOfConstraints() = 0;
 
-  unsigned m_rate{};
+  std::vector<uint64_t> m_rate;
   std::vector<int> m_vertexWeights;
   std::vector<double> m_imbalances;
   std::vector<int> m_cellCosts;

--- a/src/Initializer/TimeStepping/LtsWeights/WeightsModels.cpp
+++ b/src/Initializer/TimeStepping/LtsWeights/WeightsModels.cpp
@@ -19,7 +19,7 @@ void ExponentialWeights::setVertexWeights() {
       getCluster(m_details.globalMaxTimeStep, m_details.globalMinTimeStep, wiggleFactor, m_rate);
 
   for (unsigned cell = 0; cell < m_cellCosts.size(); ++cell) {
-    const int factor = LtsWeights::ipow(m_rate, maxCluster - m_clusterIds[cell]);
+    const int factor = ratepow(m_rate, m_clusterIds[cell], maxCluster);
     m_vertexWeights[m_ncon * cell] = factor * m_cellCosts[cell];
   }
 }
@@ -38,7 +38,7 @@ void ExponentialBalancedWeights::setVertexWeights() {
       getCluster(m_details.globalMaxTimeStep, m_details.globalMinTimeStep, wiggleFactor, m_rate);
 
   for (unsigned cell = 0; cell < m_cellCosts.size(); ++cell) {
-    const int factor = LtsWeights::ipow(m_rate, maxCluster - m_clusterIds[cell]);
+    const int factor = ratepow(m_rate, m_clusterIds[cell], maxCluster);
     m_vertexWeights[m_ncon * cell] = factor * m_cellCosts[cell];
 
     constexpr int MemoryWeight{1};

--- a/src/Numerical/StableSum.h
+++ b/src/Numerical/StableSum.h
@@ -18,8 +18,8 @@ struct StableAccumulator {
   auto operator+(RealT number) -> StableAccumulator<RealT> {
     StableAccumulator<RealT> newacc;
     const auto numberC = number - corr;
-    newacc.acc = acc + number;
-    newacc.corr = (newacc.acc - number) - numberC;
+    newacc.acc = acc + numberC;
+    newacc.corr = (newacc.acc - acc) - numberC;
     return newacc;
   }
 
@@ -29,6 +29,10 @@ struct StableAccumulator {
     this->corr = tempnew.corr;
     return *this;
   }
+
+  auto operator-(RealT number) -> StableAccumulator<RealT> { return (*this + (-number)); }
+
+  auto operator-=(RealT number) -> StableAccumulator<RealT> { return (*this += (-number)); }
 
   RealT result() const { return acc; }
 

--- a/src/Numerical/StableSum.h
+++ b/src/Numerical/StableSum.h
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: 2025 SeisSol Group
+//
+// SPDX-License-Identifier: BSD-3-Clause
+// SPDX-LicenseComments: Full text under /LICENSE and /LICENSES/
+//
+// SPDX-FileContributor: Author lists in /AUTHORS and /CITATION.cff
+
+#ifndef SEISSOL_SRC_NUMERICAL_STABLESUM_H_
+#define SEISSOL_SRC_NUMERICAL_STABLESUM_H_
+
+namespace seissol::numerical {
+
+template <typename RealT>
+struct StableAccumulator {
+  StableAccumulator() = default;
+  StableAccumulator(RealT start) : acc(start), corr(0) {}
+
+  auto operator+(RealT number) -> StableAccumulator<RealT> {
+    StableAccumulator<RealT> newacc;
+    const auto numberC = number - corr;
+    newacc.acc = acc + number;
+    newacc.corr = (newacc.acc - number) - numberC;
+    return newacc;
+  }
+
+  auto operator+=(RealT number) -> StableAccumulator<RealT>& {
+    const auto tempnew = *this + number;
+    this->acc = tempnew.acc;
+    this->corr = tempnew.corr;
+    return *this;
+  }
+
+  RealT result() const { return acc; }
+
+  private:
+  RealT acc{0};
+  RealT corr{0};
+};
+
+} // namespace seissol::numerical
+
+#endif // SEISSOL_SRC_NUMERICAL_STABLESUM_H_

--- a/src/ResultWriter/ClusteringWriter.cpp
+++ b/src/ResultWriter/ClusteringWriter.cpp
@@ -44,33 +44,32 @@ void ClusteringWriter::write() const {
   const auto sizes = mpi.collectContainer(clusteringInformation.sizes);
   const auto dynamicRuptureSizes = mpi.collectContainer(clusteringInformation.dynamicRuptureSizes);
 
-  logInfo() << "Cluster statistics:";
-  for (std::size_t i = 0; i < clusteringInformation.profilingIds.size(); ++i) {
-    std::vector<double> sizestat(mpi.size());
-    for (std::size_t j = 0; j < sizestat.size(); ++j) {
-      sizestat[j] = sizes[j][i];
-    }
-    const auto sizeSummary = statistics::Summary(sizestat);
-    const auto layerType = static_cast<LayerType>(clusteringInformation.layerTypes[i]);
-    const std::string layerTypeStr = layerType == Interior ? "interior" : "copy";
-    logInfo() << "cell" << layerTypeStr.c_str() << localClusterIds[0][i] << ":" << sizeSummary.sum
-              << "(per rank:" << sizeSummary.mean << "±" << sizeSummary.std << "; range: ["
-              << sizeSummary.min << ";" << sizeSummary.max << "])";
-  }
-  for (std::size_t i = 0; i < clusteringInformation.profilingIds.size(); ++i) {
-    std::vector<double> sizestat(mpi.size());
-    for (std::size_t j = 0; j < sizestat.size(); ++j) {
-      sizestat[j] = dynamicRuptureSizes[j][i];
-    }
-    const auto sizeSummary = statistics::Summary(sizestat);
-    const auto layerType = static_cast<LayerType>(clusteringInformation.layerTypes[i]);
-    const std::string layerTypeStr = layerType == Interior ? "interior" : "copy";
-    logInfo() << "DR" << layerTypeStr.c_str() << localClusterIds[0][i] << ":" << sizeSummary.sum
-              << "(per rank:" << sizeSummary.mean << "±" << sizeSummary.std << "; range: ["
-              << sizeSummary.min << ";" << sizeSummary.max << "])";
-  }
-
   if (mpi.rank() == 0) {
+    logInfo() << "Cluster statistics:";
+    for (std::size_t i = 0; i < clusteringInformation.profilingIds.size(); ++i) {
+      std::vector<double> sizestat(mpi.size());
+      for (std::size_t j = 0; j < sizestat.size(); ++j) {
+        sizestat[j] = sizes[j][i];
+      }
+      const auto sizeSummary = statistics::Summary(sizestat);
+      const auto layerType = static_cast<LayerType>(clusteringInformation.layerTypes[i]);
+      const std::string layerTypeStr = layerType == Interior ? "interior" : "copy";
+      logInfo() << "cell" << layerTypeStr.c_str() << localClusterIds[0][i] << ":" << sizeSummary.sum
+                << "(per rank:" << sizeSummary.mean << "±" << sizeSummary.std << "; range: ["
+                << sizeSummary.min << ";" << sizeSummary.max << "])";
+    }
+    for (std::size_t i = 0; i < clusteringInformation.profilingIds.size(); ++i) {
+      std::vector<double> sizestat(mpi.size());
+      for (std::size_t j = 0; j < sizestat.size(); ++j) {
+        sizestat[j] = dynamicRuptureSizes[j][i];
+      }
+      const auto sizeSummary = statistics::Summary(sizestat);
+      const auto layerType = static_cast<LayerType>(clusteringInformation.layerTypes[i]);
+      const std::string layerTypeStr = layerType == Interior ? "interior" : "copy";
+      logInfo() << "DR" << layerTypeStr.c_str() << localClusterIds[0][i] << ":" << sizeSummary.sum
+                << "(per rank:" << sizeSummary.mean << "±" << sizeSummary.std << "; range: ["
+                << sizeSummary.min << ";" << sizeSummary.max << "])";
+    }
 
     auto filepath = path(outputPrefix);
     filepath += path("-clustering.csv");

--- a/src/ResultWriter/ClusteringWriter.cpp
+++ b/src/ResultWriter/ClusteringWriter.cpp
@@ -9,6 +9,7 @@
 
 #include "Common/Filesystem.h"
 #include <Memory/Tree/Layer.h>
+#include <Numerical/Statistics.h>
 #include <cstddef>
 #include <fstream>
 #include <ios>
@@ -23,8 +24,8 @@ ClusteringWriter::ClusteringWriter(const std::string& outputPrefix) : outputPref
 void ClusteringWriter::addCluster(unsigned profilingId,
                                   unsigned localClusterId,
                                   LayerType layerType,
-                                  unsigned size,
-                                  unsigned dynRupSize) {
+                                  std::size_t size,
+                                  std::size_t dynRupSize) {
   clusteringInformation.profilingIds.push_back(profilingId);
   clusteringInformation.localClusterIds.push_back(localClusterId);
   clusteringInformation.layerTypes.push_back(layerType);
@@ -42,6 +43,32 @@ void ClusteringWriter::write() const {
   const auto layerTypes = mpi.collectContainer(clusteringInformation.layerTypes);
   const auto sizes = mpi.collectContainer(clusteringInformation.sizes);
   const auto dynamicRuptureSizes = mpi.collectContainer(clusteringInformation.dynamicRuptureSizes);
+
+  logInfo() << "Cluster statistics:";
+  for (std::size_t i = 0; i < clusteringInformation.profilingIds.size(); ++i) {
+    std::vector<double> sizestat(mpi.size());
+    for (std::size_t j = 0; j < sizestat.size(); ++j) {
+      sizestat[j] = sizes[j][i];
+    }
+    const auto sizeSummary = statistics::Summary(sizestat);
+    const auto layerType = static_cast<LayerType>(clusteringInformation.layerTypes[i]);
+    const std::string layerTypeStr = layerType == Interior ? "interior" : "copy";
+    logInfo() << "cell" << layerTypeStr.c_str() << localClusterIds[0][i] << ":" << sizeSummary.sum
+              << "(per rank:" << sizeSummary.mean << "±" << sizeSummary.std << "; range: ["
+              << sizeSummary.min << ";" << sizeSummary.max << "])";
+  }
+  for (std::size_t i = 0; i < clusteringInformation.profilingIds.size(); ++i) {
+    std::vector<double> sizestat(mpi.size());
+    for (std::size_t j = 0; j < sizestat.size(); ++j) {
+      sizestat[j] = dynamicRuptureSizes[j][i];
+    }
+    const auto sizeSummary = statistics::Summary(sizestat);
+    const auto layerType = static_cast<LayerType>(clusteringInformation.layerTypes[i]);
+    const std::string layerTypeStr = layerType == Interior ? "interior" : "copy";
+    logInfo() << "DR" << layerTypeStr.c_str() << localClusterIds[0][i] << ":" << sizeSummary.sum
+              << "(per rank:" << sizeSummary.mean << "±" << sizeSummary.std << "; range: ["
+              << sizeSummary.min << ";" << sizeSummary.max << "])";
+  }
 
   if (mpi.rank() == 0) {
 

--- a/src/ResultWriter/ClusteringWriter.cpp
+++ b/src/ResultWriter/ClusteringWriter.cpp
@@ -15,6 +15,7 @@
 #include <ios>
 #include <string>
 #include <utils/logger.h>
+#include <vector>
 
 #include "Parallel/MPI.h"
 namespace seissol::writer {

--- a/src/ResultWriter/ClusteringWriter.h
+++ b/src/ResultWriter/ClusteringWriter.h
@@ -21,8 +21,8 @@ class ClusteringWriter {
   void addCluster(unsigned profilingId,
                   unsigned localClusterId,
                   LayerType layerType,
-                  unsigned size,
-                  unsigned dynRupSize);
+                  std::size_t size,
+                  std::size_t dynRupSize);
   void write() const;
 
   // SoA that contains info about clusters
@@ -32,8 +32,8 @@ class ClusteringWriter {
     std::vector<int> profilingIds;
     std::vector<int> localClusterIds;
     std::vector<std::underlying_type_t<LayerType>> layerTypes;
-    std::vector<unsigned> sizes;
-    std::vector<unsigned> dynamicRuptureSizes;
+    std::vector<std::size_t> sizes;
+    std::vector<std::size_t> dynamicRuptureSizes;
   };
 
   private:

--- a/src/sources.cmake
+++ b/src/sources.cmake
@@ -82,6 +82,8 @@ src/SourceTerm/Manager.cpp
 src/Solver/Simulator.cpp
 src/ResultWriter/AnalysisWriter.cpp
 
+src/Initializer/TimeStepping/ClusterLayout.cpp
+
 ${CMAKE_CURRENT_SOURCE_DIR}/src/DynamicRupture/Factory.cpp
 ${CMAKE_CURRENT_SOURCE_DIR}/src/Parallel/MPI.cpp
 )

--- a/src/tests/Initializer/TimeStepping/LTSWeights.t.h
+++ b/src/tests/Initializer/TimeStepping/LTSWeights.t.h
@@ -21,10 +21,11 @@ namespace seissol::unit_test {
 TEST_CASE("LTS Weights") {
   std::cout.setstate(std::ios_base::failbit);
   using namespace seissol::initializer::time_stepping;
-  const LtsWeightsConfig config{seissol::initializer::parameters::BoundaryFormat::I32, 2, 1, 1, 1};
+  const LtsWeightsConfig config{
+      seissol::initializer::parameters::BoundaryFormat::I32, {2}, 1, 1, 1};
 
   const seissol::initializer::parameters::LtsParameters ltsParameters(
-      2,
+      {2},
       1.0,
       0.01,
       false,
@@ -67,7 +68,7 @@ TEST_CASE("Cost function for LTS") {
   SUBCASE("No clusters") {
     const std::vector<int> clusterIds = {};
     const std::vector<int> cellCosts = {};
-    const auto is = computeLocalCostOfClustering(clusterIds, cellCosts, 2, 1.0, 1.0);
+    const auto is = computeLocalCostOfClustering(clusterIds, cellCosts, {2}, 1.0, 1.0);
     const auto should = 0.0;
     REQUIRE(AbsApprox(is).epsilon(eps) == should);
   }
@@ -80,7 +81,7 @@ TEST_CASE("Cost function for LTS") {
       for (int j = 1; j <= 10; ++j) {
         const auto wiggleFactor = 1.0 / j;
 
-        const auto is = computeLocalCostOfClustering(clusterIds, cellCosts, 2, wiggleFactor, dt);
+        const auto is = computeLocalCostOfClustering(clusterIds, cellCosts, {2}, wiggleFactor, dt);
 
         const auto totalCost = std::accumulate(cellCosts.begin(), cellCosts.end(), 0);
         const auto effectiveDt = dt * wiggleFactor;
@@ -103,7 +104,7 @@ TEST_CASE("Cost function for LTS") {
           const auto wiggleFactor = 1.0 / j;
 
           const auto is =
-              computeLocalCostOfClustering(clusterIds, cellCosts, rate, wiggleFactor, dt);
+              computeLocalCostOfClustering(clusterIds, cellCosts, {rate}, wiggleFactor, dt);
 
           const auto effectiveDtCluster0 = dt * wiggleFactor;
           const auto effectiveDtCluster1 = rate * effectiveDtCluster0;
@@ -130,7 +131,7 @@ TEST_CASE("Cost function for LTS") {
           const auto wiggleFactor = 1.0 / j;
 
           const auto is =
-              computeLocalCostOfClustering(clusterIds, cellCosts, rate, wiggleFactor, dt);
+              computeLocalCostOfClustering(clusterIds, cellCosts, {rate}, wiggleFactor, dt);
 
           const auto effectiveDtCluster0 = dt * wiggleFactor;
           const auto effectiveDtCluster1 = rate * effectiveDtCluster0;
@@ -172,13 +173,13 @@ TEST_CASE("Auto merging of clusters") {
   const auto clusterIds = std::vector<int>{0, 0, 0, 0, 1, 1, 2};
   const auto cellCosts = std::vector<int>{1, 1, 1, 1, 3, 3, 9};
   const auto minDt = 0.5;
-  const auto costBeforeRate2 = computeLocalCostOfClustering(clusterIds, cellCosts, 2, 1.0, minDt);
-  const auto costBeforeRate3 = computeLocalCostOfClustering(clusterIds, cellCosts, 3, 1.0, minDt);
+  const auto costBeforeRate2 = computeLocalCostOfClustering(clusterIds, cellCosts, {2}, 1.0, minDt);
+  const auto costBeforeRate3 = computeLocalCostOfClustering(clusterIds, cellCosts, {3}, 1.0, minDt);
 
   SUBCASE("Reduces to GTS") {
     const auto should = 0;
     const auto is = computeMaxClusterIdAfterAutoMerge(
-        clusterIds, cellCosts, 2, std::numeric_limits<double>::max(), 1.0, minDt);
+        clusterIds, cellCosts, {2}, std::numeric_limits<double>::max(), 1.0, minDt);
     REQUIRE(is == should);
   }
 
@@ -186,7 +187,7 @@ TEST_CASE("Auto merging of clusters") {
     const auto should = 0;
     for (int i = 1; i <= 5; ++i) {
       const auto is = computeMaxClusterIdAfterAutoMerge(
-          enforceMaxClusterId(clusterIds, 0), cellCosts, 1, i, 0, 0);
+          enforceMaxClusterId(clusterIds, 0), cellCosts, {1}, i, 0, 0);
       REQUIRE(is == should);
     }
   }
@@ -195,12 +196,12 @@ TEST_CASE("Auto merging of clusters") {
     const auto should = 2;
     SUBCASE("Rate 2") {
       const auto is =
-          computeMaxClusterIdAfterAutoMerge(clusterIds, cellCosts, 2, costBeforeRate2, 1, minDt);
+          computeMaxClusterIdAfterAutoMerge(clusterIds, cellCosts, {2}, costBeforeRate2, 1, minDt);
       REQUIRE(is == should);
     }
     SUBCASE("Rate 3") {
       const auto is =
-          computeMaxClusterIdAfterAutoMerge(clusterIds, cellCosts, 3, costBeforeRate3, 1, minDt);
+          computeMaxClusterIdAfterAutoMerge(clusterIds, cellCosts, {3}, costBeforeRate3, 1, minDt);
       REQUIRE(is == should);
     }
   }
@@ -209,13 +210,13 @@ TEST_CASE("Auto merging of clusters") {
     SUBCASE("Merge one cluster") {
       const auto should = 1;
       const auto is = computeMaxClusterIdAfterAutoMerge(
-          clusterIds, cellCosts, 2, 1.25 * costBeforeRate2, 1, minDt);
+          clusterIds, cellCosts, {2}, 1.25 * costBeforeRate2, 1, minDt);
       REQUIRE(is == should);
     }
     SUBCASE("Merge two clusters") {
       const auto should = 0;
       const auto is = computeMaxClusterIdAfterAutoMerge(
-          clusterIds, cellCosts, 2, 2.06 * costBeforeRate2, 1, minDt);
+          clusterIds, cellCosts, {2}, 2.06 * costBeforeRate2, 1, minDt);
       REQUIRE(is == should);
     }
   }


### PR DESCRIPTION
("multi-varyrate" is a tentative name)

In essence, allow switching up the rates in the clustering hierarchy. One may now specify a list of rates as e.g. follows: `clusteredlts = '4 2'`; meaning that the first two clusters get combined (i.e. the first cluster starts with a rate of 4—all following clusters use a rate of 2).

Also, we extract a bit more code out of `LtsLayout` and move it into a separate file.
