### PR TITLE
PUML Periodic Boundary Conditions

### DIFF
--- a/src/Geometry/PUMLReader.h
+++ b/src/Geometry/PUMLReader.h
@@ -13,12 +13,16 @@
 #include "MeshReader.h"
 #include "PUML/PUML.h"
 #include "Parallel/MPI.h"
+#include <PUML/Topology.h>
 
 namespace seissol::initializer::time_stepping {
 class LtsWeights;
 } // namespace seissol::initializer::time_stepping
 
 namespace seissol::geometry {
+constexpr PUML::TopoType PumlTopology = PUML::TETRAHEDRON;
+using PumlMesh = PUML::PUML<PumlTopology>;
+
 inline int decodeBoundary(const void* data,
                           size_t cell,
                           int face,
@@ -59,13 +63,13 @@ class PUMLReader : public seissol::geometry::MeshReader {
   /**
    * Read the mesh
    */
-  void read(PUML::TETPUML& puml, const char* meshFile, bool topology);
+  void read(PumlMesh& meshTopology, const char* meshFile, bool topology);
 
   /**
    * Create the partitioning
    */
-  static void partition(PUML::TETPUML& puml,
-                        PUML::TETPUML& pumlP,
+  static void partition(PumlMesh& meshTopology,
+                        PumlMesh& meshGeometry,
                         initializer::time_stepping::LtsWeights* ltsWeights,
                         double tpwgt,
                         const char* meshFile,
@@ -73,14 +77,15 @@ class PUMLReader : public seissol::geometry::MeshReader {
   /**
    * Generate the PUML data structure
    */
-  static void generatePUML(PUML::TETPUML& puml, PUML::TETPUML& pumlP);
+  static void generatePUML(PumlMesh& meshTopology, PumlMesh& meshGeometry);
 
   /**
    * Get the mesh
    */
-  void getMesh(const PUML::TETPUML& puml, const PUML::TETPUML& pumlP);
+  void getMesh(const PumlMesh& meshTopology, const PumlMesh& meshGeometry);
 
-  void addMPINeighor(const PUML::TETPUML& puml, int rank, const std::vector<unsigned int>& faces);
+  void
+      addMPINeighor(const PumlMesh& meshTopology, int rank, const std::vector<unsigned int>& faces);
 };
 
 } // namespace seissol::geometry

--- a/src/Geometry/PUMLReader.h
+++ b/src/Geometry/PUMLReader.h
@@ -44,6 +44,8 @@ class PUMLReader : public seissol::geometry::MeshReader {
              const char* partitioningLib,
              seissol::initializer::parameters::BoundaryFormat boundaryFormat =
                  seissol::initializer::parameters::BoundaryFormat::I32,
+             seissol::initializer::parameters::TopologyFormat topologyFormat =
+                 seissol::initializer::parameters::TopologyFormat::Connect,
              initializer::time_stepping::LtsWeights* ltsWeights = nullptr,
              double tpwgt = 1.0);
 
@@ -52,16 +54,18 @@ class PUMLReader : public seissol::geometry::MeshReader {
 
   private:
   seissol::initializer::parameters::BoundaryFormat boundaryFormat;
+  seissol::initializer::parameters::TopologyFormat topologyFormat;
 
   /**
    * Read the mesh
    */
-  void read(PUML::TETPUML& puml, const char* meshFile);
+  void read(PUML::TETPUML& puml, const char* meshFile, bool topology);
 
   /**
    * Create the partitioning
    */
   static void partition(PUML::TETPUML& puml,
+                        PUML::TETPUML& pumlP,
                         initializer::time_stepping::LtsWeights* ltsWeights,
                         double tpwgt,
                         const char* meshFile,
@@ -69,12 +73,12 @@ class PUMLReader : public seissol::geometry::MeshReader {
   /**
    * Generate the PUML data structure
    */
-  static void generatePUML(PUML::TETPUML& puml);
+  static void generatePUML(PUML::TETPUML& puml, PUML::TETPUML& pumlP);
 
   /**
    * Get the mesh
    */
-  void getMesh(const PUML::TETPUML& puml);
+  void getMesh(const PUML::TETPUML& puml, const PUML::TETPUML& pumlP);
 
   void addMPINeighor(const PUML::TETPUML& puml, int rank, const std::vector<unsigned int>& faces);
 };

--- a/src/Initializer/InitProcedure/InitMesh.cpp
+++ b/src/Initializer/InitProcedure/InitMesh.cpp
@@ -130,6 +130,7 @@ void readMeshPUML(const seissol::initializer::parameters::SeisSolParameters& sei
   logInfo() << "Reading PUML mesh";
 
   auto boundaryFormat = seissolParams.mesh.pumlBoundaryFormat;
+  auto topologyFormat = seissolParams.mesh.pumlTopologyFormat;
 
   if (boundaryFormat == seissol::initializer::parameters::BoundaryFormat::Auto) {
     logInfo() << "Inferring boundary format.";
@@ -212,6 +213,21 @@ void readMeshPUML(const seissol::initializer::parameters::SeisSolParameters& sei
     logInfo() << "Using boundary format: i32x4 (4xi32)";
   }
 
+  if (topologyFormat == seissol::initializer::parameters::TopologyFormat::Auto) {
+    logInfo() << "Inferring topology format; i.e. set it to the connectivity.";
+    topologyFormat = seissol::initializer::parameters::TopologyFormat::Connect;
+  }
+
+  if (topologyFormat == seissol::initializer::parameters::TopologyFormat::Connect) {
+    logInfo() << "Using the geometric topology.";
+  }
+  if (topologyFormat == seissol::initializer::parameters::TopologyFormat::CellIdentify) {
+    logInfo() << "Using cellvertex identification for topology.";
+  }
+  if (topologyFormat == seissol::initializer::parameters::TopologyFormat::VertexIdentify) {
+    logInfo() << "Using vertex identification for topology.";
+  }
+
   seissol::Stopwatch watch;
   watch.start();
 
@@ -228,6 +244,7 @@ void readMeshPUML(const seissol::initializer::parameters::SeisSolParameters& sei
   auto* meshReader = new seissol::geometry::PUMLReader(seissolParams.mesh.meshFileName.c_str(),
                                                        seissolParams.mesh.partitioningLib.c_str(),
                                                        boundaryFormat,
+                                                       topologyFormat,
                                                        ltsWeights.get(),
                                                        nodeWeight);
   seissolInstance.setMeshReader(meshReader);

--- a/src/Initializer/ParameterDB.cpp
+++ b/src/Initializer/ParameterDB.cpp
@@ -16,6 +16,7 @@
 #include <Equations/viscoelastic2/Model/Datastructures.h>
 #include <Geometry/MeshDefinition.h>
 #include <Geometry/MeshTools.h>
+#include <Geometry/PUMLReader.h>
 #include <Kernels/Precision.h>
 #include <Model/CommonDatastructures.h>
 #include <Model/Datastructures.h>
@@ -33,8 +34,6 @@
 #include <vector>
 #ifdef USE_HDF
 // PUML.h needs to be included before Downward.h
-
-#include "PUML/PUML.h"
 
 #include "PUML/Downward.h"
 
@@ -82,7 +81,7 @@ CellToVertexArray
 }
 
 #ifdef USE_HDF
-CellToVertexArray CellToVertexArray::fromPUML(const PUML::TETPUML& mesh) {
+CellToVertexArray CellToVertexArray::fromPUML(const seissol::geometry::PumlMesh& mesh) {
   const int* groups = reinterpret_cast<const int*>(mesh.cellData(0));
   const auto& elements = mesh.cells();
   const auto& vertices = mesh.vertices();

--- a/src/Initializer/ParameterDB.h
+++ b/src/Initializer/ParameterDB.h
@@ -10,6 +10,7 @@
 #ifndef SEISSOL_SRC_INITIALIZER_PARAMETERDB_H_
 #define SEISSOL_SRC_INITIALIZER_PARAMETERDB_H_
 
+#include <Geometry/PUMLReader.h>
 #include <memory>
 #include <set>
 #include <string>
@@ -56,7 +57,7 @@ struct CellToVertexArray {
 
   static CellToVertexArray fromMeshReader(const seissol::geometry::MeshReader& meshReader);
 #ifdef USE_HDF
-  static CellToVertexArray fromPUML(const PUML::TETPUML& mesh);
+  static CellToVertexArray fromPUML(const seissol::geometry::PumlMesh& mesh);
 #endif
   static CellToVertexArray
       fromVectors(const std::vector<std::array<std::array<double, 3>, 4>>& vertices,

--- a/src/Initializer/Parameters/MeshParameters.cpp
+++ b/src/Initializer/Parameters/MeshParameters.cpp
@@ -32,6 +32,15 @@ MeshParameters readMeshParameters(ParameterReader* baseReader) {
                                                             {"i64", BoundaryFormat::I64},
                                                             {"i32x4", BoundaryFormat::I32x4},
                                                         });
+  const auto pumlTopologyFormat = reader->readWithDefaultStringEnum<TopologyFormat>(
+      "pumltopologyformat",
+      "auto",
+      {
+          {"auto", TopologyFormat::Auto},
+          {"connect", TopologyFormat::Connect},
+          {"cell", TopologyFormat::CellIdentify},
+          {"vertex", TopologyFormat::VertexIdentify},
+      });
 
   const auto displacementRaw = seissol::initializer::convertStringToArray<double, 3>(
       reader->readWithDefault("displacement", std::string("0.0 0.0 0.0")));
@@ -52,6 +61,7 @@ MeshParameters readMeshParameters(ParameterReader* baseReader) {
 
   return MeshParameters{showEdgeCutStatistics,
                         pumlBoundaryFormat,
+                        pumlTopologyFormat,
                         meshFormat,
                         meshFileName,
                         partitioningLib,

--- a/src/Initializer/Parameters/MeshParameters.h
+++ b/src/Initializer/Parameters/MeshParameters.h
@@ -20,9 +20,12 @@ enum class MeshFormat : int { Netcdf, PUML, CubeGenerator };
 
 enum class BoundaryFormat : int { Auto, I32, I64, I32x4 };
 
+enum class TopologyFormat : int { Auto, Connect, CellIdentify, VertexIdentify };
+
 struct MeshParameters {
   bool showEdgeCutStatistics;
   BoundaryFormat pumlBoundaryFormat;
+  TopologyFormat pumlTopologyFormat;
   MeshFormat meshFormat;
   std::string meshFileName;
   std::string partitioningLib;

--- a/src/Initializer/TimeStepping/LtsWeights/LtsWeights.cpp
+++ b/src/Initializer/TimeStepping/LtsWeights/LtsWeights.cpp
@@ -118,7 +118,7 @@ LtsWeights::LtsWeights(const LtsWeightsConfig& config, seissol::SeisSol& seissol
       m_vertexWeightFreeSurfaceWithGravity(config.vertexWeightFreeSurfaceWithGravity),
       boundaryFormat(config.boundaryFormat) {}
 
-void LtsWeights::computeWeights(PUML::TETPUML const& mesh) {
+void LtsWeights::computeWeights(PUML::TETPUML const& mesh, PUML::TETPUML const& meshP) {
   bool continueComputation = true;
   if (!model::MaterialT::SupportsLTS) {
     logInfo() << "The material" << model::MaterialT::Text
@@ -134,6 +134,7 @@ void LtsWeights::computeWeights(PUML::TETPUML const& mesh) {
 
   // Note: Return value optimization is guaranteed while returning temp. objects in C++17
   m_mesh = &mesh;
+  m_meshP = &meshP;
   m_details = collectGlobalTimeStepDetails();
   m_cellCosts = computeCostsPerTimestep();
 
@@ -406,7 +407,7 @@ int LtsWeights::ipow(int x, int y) {
 
 seissol::initializer::GlobalTimestep LtsWeights::collectGlobalTimeStepDetails() {
   return seissol::initializer::computeTimesteps(
-      seissol::initializer::CellToVertexArray::fromPUML(*m_mesh),
+      seissol::initializer::CellToVertexArray::fromPUML(*m_meshP),
       seissolInstance.getSeisSolParameters());
 }
 

--- a/src/Initializer/TimeStepping/LtsWeights/LtsWeights.cpp
+++ b/src/Initializer/TimeStepping/LtsWeights/LtsWeights.cpp
@@ -29,7 +29,6 @@
 #include <mpi.h>
 
 #include "PUML/Downward.h"
-#include "PUML/PUML.h"
 #include "PUML/Upward.h"
 
 #include "Initializer/TimeStepping/GlobalTimestep.h"
@@ -118,7 +117,8 @@ LtsWeights::LtsWeights(const LtsWeightsConfig& config, seissol::SeisSol& seissol
       m_vertexWeightFreeSurfaceWithGravity(config.vertexWeightFreeSurfaceWithGravity),
       boundaryFormat(config.boundaryFormat) {}
 
-void LtsWeights::computeWeights(PUML::TETPUML const& mesh, PUML::TETPUML const& meshP) {
+void LtsWeights::computeWeights(const seissol::geometry::PumlMesh& meshTopology,
+                                const seissol::geometry::PumlMesh& meshGeometry) {
   bool continueComputation = true;
   if (!model::MaterialT::SupportsLTS) {
     logInfo() << "The material" << model::MaterialT::Text
@@ -133,8 +133,8 @@ void LtsWeights::computeWeights(PUML::TETPUML const& mesh, PUML::TETPUML const& 
   logInfo() << "Computing LTS weights.";
 
   // Note: Return value optimization is guaranteed while returning temp. objects in C++17
-  m_mesh = &mesh;
-  m_meshP = &meshP;
+  m_meshTopology = &meshTopology;
+  m_meshGeometry = &meshGeometry;
   m_details = collectGlobalTimeStepDetails();
   m_cellCosts = computeCostsPerTimestep();
 
@@ -407,7 +407,7 @@ int LtsWeights::ipow(int x, int y) {
 
 seissol::initializer::GlobalTimestep LtsWeights::collectGlobalTimeStepDetails() {
   return seissol::initializer::computeTimesteps(
-      seissol::initializer::CellToVertexArray::fromPUML(*m_meshP),
+      seissol::initializer::CellToVertexArray::fromPUML(*m_meshGeometry),
       seissolInstance.getSeisSolParameters());
 }
 
@@ -432,7 +432,7 @@ int LtsWeights::computeClusterIdsAndEnforceMaximumDifferenceCached(double curWig
 #ifdef _OPENMP
 #pragma omp parallel for reduction(+ : cellchanges)
 #endif
-      for (unsigned cell = 0; cell < m_mesh->cells().size(); ++cell) {
+      for (unsigned cell = 0; cell < m_meshTopology->cells().size(); ++cell) {
         if (lb->second[cell] > newClusterIds[cell]) {
           ++cellchanges;
         }
@@ -440,7 +440,7 @@ int LtsWeights::computeClusterIdsAndEnforceMaximumDifferenceCached(double curWig
       }
     } else {
       m_clusterIds = computeClusterIds(curWiggleFactor);
-      cellchanges = m_mesh->cells().size();
+      cellchanges = m_meshTopology->cells().size();
     }
     const auto& ltsParameters = seissolInstance.getSeisSolParameters().timeStepping.lts;
     if (ltsParameters.getWiggleFactorEnforceMaximumDifference()) {
@@ -456,7 +456,7 @@ int LtsWeights::computeClusterIdsAndEnforceMaximumDifferenceCached(double curWig
 }
 
 std::vector<int> LtsWeights::computeClusterIds(double curWiggleFactor) {
-  const auto& cells = m_mesh->cells();
+  const auto& cells = m_meshTopology->cells();
   std::vector<int> clusterIds(cells.size(), 0);
 #ifdef _OPENMP
 #pragma omp parallel for
@@ -469,16 +469,16 @@ std::vector<int> LtsWeights::computeClusterIds(double curWiggleFactor) {
 }
 
 std::vector<int> LtsWeights::computeCostsPerTimestep() {
-  const auto& cells = m_mesh->cells();
+  const auto& cells = m_meshTopology->cells();
 
   std::vector<int> cellCosts(cells.size());
-  const void* boundaryCond = m_mesh->cellData(1);
+  const void* boundaryCond = m_meshTopology->cellData(1);
   for (unsigned cell = 0; cell < cells.size(); ++cell) {
     int dynamicRupture = 0;
     int freeSurfaceWithGravity = 0;
 
     unsigned int faceids[4];
-    PUML::Downward::faces(*m_mesh, cells[cell], faceids);
+    PUML::Downward::faces(*m_meshTopology, cells[cell], faceids);
 
     for (unsigned face = 0; face < 4; ++face) {
       const auto faceType = getBoundaryCondition(boundaryCond, cell, face);
@@ -511,15 +511,15 @@ int LtsWeights::enforceMaximumDifference() {
 }
 
 void LtsWeights::prepareDifferenceEnforcement() {
-  const auto& cells = m_mesh->cells();
-  const auto& faces = m_mesh->faces();
-  const void* boundaryCond = m_mesh->cellData(1);
+  const auto& cells = m_meshTopology->cells();
+  const auto& faces = m_meshTopology->faces();
+  const void* boundaryCond = m_meshTopology->cellData(1);
 
   std::unordered_map<int, std::vector<std::size_t>> rankToSharedFacesPre;
   for (unsigned cell = 0; cell < cells.size(); ++cell) {
     unsigned int faceids[4]{};
     bool atBoundary = false;
-    PUML::Downward::faces(*m_mesh, cells[cell], faceids);
+    PUML::Downward::faces(*m_meshTopology, cells[cell], faceids);
     for (unsigned f = 0; f < 4; ++f) {
       const auto boundary = getBoundaryCondition(boundaryCond, cell, f);
       // Continue for regular, dynamic rupture, and periodic boundary cells
@@ -558,9 +558,9 @@ void LtsWeights::prepareDifferenceEnforcement() {
 int LtsWeights::enforceMaximumDifferenceLocal(int maxDifference) {
   int numberOfReductions = 0;
 
-  const auto& cells = m_mesh->cells();
-  const auto& faces = m_mesh->faces();
-  const void* boundaryCond = m_mesh->cellData(1);
+  const auto& cells = m_meshTopology->cells();
+  const auto& faces = m_meshTopology->faces();
+  const void* boundaryCond = m_meshTopology->cellData(1);
 
 #ifdef _OPENMP
 #pragma omp parallel for reduction(+ : numberOfReductions)
@@ -569,7 +569,7 @@ int LtsWeights::enforceMaximumDifferenceLocal(int maxDifference) {
     int timeCluster = m_clusterIds[cell];
 
     unsigned int faceids[4]{};
-    PUML::Downward::faces(*m_mesh, cells[cell], faceids);
+    PUML::Downward::faces(*m_meshTopology, cells[cell], faceids);
     for (unsigned f = 0; f < 4; ++f) {
       int difference = maxDifference;
       const auto boundary = getBoundaryCondition(boundaryCond, cell, f);
@@ -579,7 +579,7 @@ int LtsWeights::enforceMaximumDifferenceLocal(int maxDifference) {
         const auto& face = faces.at(faceids[f]);
         if (!face.isShared()) {
           int cellIds[2];
-          PUML::Upward::cells(*m_mesh, face, cellIds);
+          PUML::Upward::cells(*m_meshTopology, face, cellIds);
 
           const int neighborCell = (cellIds[0] == static_cast<int>(cell)) ? cellIds[1] : cellIds[0];
           const int otherTimeCluster = m_clusterIds[neighborCell];
@@ -638,7 +638,7 @@ int LtsWeights::enforceMaximumDifferenceLocal(int maxDifference) {
     int& timeCluster = m_clusterIds[cell];
 
     unsigned int faceids[4]{};
-    PUML::Downward::faces(*m_mesh, cells[cell], faceids);
+    PUML::Downward::faces(*m_meshTopology, cells[cell], faceids);
     for (unsigned f = 0; f < 4; ++f) {
       int difference = maxDifference;
       const auto boundary = getBoundaryCondition(boundaryCond, cell, f);

--- a/src/Initializer/TimeStepping/LtsWeights/LtsWeights.h
+++ b/src/Initializer/TimeStepping/LtsWeights/LtsWeights.h
@@ -19,12 +19,6 @@
 
 #include "Initializer/TimeStepping/GlobalTimestep.h"
 
-#ifndef PUML_PUML_H
-namespace PUML {
-class TETPUML;
-}
-#endif // PUML_PUML_H
-
 namespace seissol {
 class SeisSol;
 namespace initializer::time_stepping {
@@ -63,7 +57,8 @@ class LtsWeights {
   LtsWeights(const LtsWeightsConfig& config, seissol::SeisSol& seissolInstance);
 
   virtual ~LtsWeights() = default;
-  void computeWeights(PUML::TETPUML const& mesh, PUML::TETPUML const& meshP);
+  void computeWeights(const seissol::geometry::PumlMesh& meshTopology,
+                      const seissol::geometry::PumlMesh& meshGeometry);
 
   [[nodiscard]] const int* vertexWeights() const;
   [[nodiscard]] const double* imbalances() const;
@@ -101,8 +96,8 @@ class LtsWeights {
   int m_vertexWeightDynamicRupture{};
   int m_vertexWeightFreeSurfaceWithGravity{};
   int m_ncon{std::numeric_limits<int>::infinity()};
-  const PUML::TETPUML* m_mesh{nullptr};
-  const PUML::TETPUML* m_meshP{nullptr};
+  const geometry::PumlMesh* m_meshTopology{nullptr};
+  const geometry::PumlMesh* m_meshGeometry{nullptr};
   std::vector<int> m_clusterIds;
   double wiggleFactor = 1.0;
   std::map<double, decltype(m_clusterIds), std::greater<>>

--- a/src/Initializer/TimeStepping/LtsWeights/LtsWeights.h
+++ b/src/Initializer/TimeStepping/LtsWeights/LtsWeights.h
@@ -63,7 +63,7 @@ class LtsWeights {
   LtsWeights(const LtsWeightsConfig& config, seissol::SeisSol& seissolInstance);
 
   virtual ~LtsWeights() = default;
-  void computeWeights(PUML::TETPUML const& mesh);
+  void computeWeights(PUML::TETPUML const& mesh, PUML::TETPUML const& meshP);
 
   [[nodiscard]] const int* vertexWeights() const;
   [[nodiscard]] const double* imbalances() const;
@@ -102,6 +102,7 @@ class LtsWeights {
   int m_vertexWeightFreeSurfaceWithGravity{};
   int m_ncon{std::numeric_limits<int>::infinity()};
   const PUML::TETPUML* m_mesh{nullptr};
+  const PUML::TETPUML* m_meshP{nullptr};
   std::vector<int> m_clusterIds;
   double wiggleFactor = 1.0;
   std::map<double, decltype(m_clusterIds), std::greater<>>


### PR DESCRIPTION
Implement periodic boundary conditions for PUML by splitting into a geometric and a topological mesh. (which makes the seemingly hard-to-implement problem pretty simple to get done)

In effect, two options for entering the topological mesh are possible right now:
* add a new connectivity array which contains identified vertices
* add a vertex identification array

Note that the periodicity is also included in the partitioning already.

Needs the respective PUML PR to be merged first (and still needs one bug fixed).
