### PR TITLE
Forward the "How To Cite" to the README and the Docs

### DIFF
--- a/Documentation/conf.py
+++ b/Documentation/conf.py
@@ -27,7 +27,7 @@
 # -- Project information -----------------------------------------------------
 
 project = "SeisSol"
-copyright = "2012-2024 SeisSol Group"
+copyright = "2012-2025 SeisSol Group"
 author = "SeisSol Group"
 
 # The short X.Y version

--- a/Documentation/related-publications.rst
+++ b/Documentation/related-publications.rst
@@ -16,10 +16,11 @@ How To Cite
 -----------
 
 If you utilize SeisSol in a publication or want to refer to it,
-then please cite `doi.org/10.5281/zenodo.4672483 <https://doi.org/10.5281/zenodo.4672483>`__
-for SeisSol as software package.
+please follow the suggestions on our `How To Cite <https://seissol.org/about/howtocite/>`__
+page.
+It also includes examples how to cite specific SeisSol features,
+models or previous use cases.
 
-If you make use specific SeisSol features,
-or require a list of applications, visit the
-`How To Cite page <https://seissol.org/about/howtocite/>`__ on our website.
-It also includes an example on how to cite SeisSol itself.
+To reference SeisSol as a software package and the specific version you used,
+please provide the link `doi.org/10.5281/zenodo.4672483 <https://doi.org/10.5281/zenodo.4672483>`__
+which points to Zenodo.

--- a/Documentation/related-publications.rst
+++ b/Documentation/related-publications.rst
@@ -6,33 +6,20 @@
 
   SPDX-FileContributor: Author lists in /AUTHORS and /CITATION.cff
 
-Related publications
-====================
+Publications and Citing SeisSol
+===============================
 
+See the `publication list on the SeisSol webpage <https://seissol.org/publications/>`__
+for a list of publications involving SeisSol.
 
-Ulrich, T., A.-A. Gabriel,, J. P., Ampuero, & W. Xu, (2019). Dynamic viability of the 2016 Mw 7.8 Kaikōura earthquake cascade on weak crustal faults. Nature communications.
-doi: `10.1038/s41467-019-09125-w <https://doi.org/10.1038/s41467-019-09125-w>`_.
+How To Cite
+-----------
 
-Wollherr, S., A.-A. Gabriel, and C. Uphoff (2018), Off-fault plasticity in three-dimensional dynamic rupture simulations using a modal Discontinuous Galerkin method on unstructured meshes: implementation, verification and application, Geophys. J. Int., 214(3), 1556-1584, doi: `10.1093/gji/ggy213 <https://doi.org/10.1093/gji/ggy213>`_.
+If you utilize SeisSol in a publication or want to refer to it,
+then please cite `doi.org/10.5281/zenodo.4672483 <https://doi.org/10.5281/zenodo.4672483>`__
+for SeisSol as software package.
 
-Uphoff, C., S. Rettenberger, M. Bader, E. H. Madden, T. Ulrich, S. Wollherr, and A.-A. Gabriel (2017), Extreme scale multi-physics simulations of the tsunamigenic 2004 sumatra megathrust earthquake, in Proceedings of the International Conference for High Performance Computing, Networking, Storage and Analysis, edited, pp. 1-16, ACM, Denver, Colorado, doi: `10.1145/3126908.3126948 <https://doi.org/10.1145/3126908.3126948>`_.
-
-Breuer, A., A. Heinecke, and M. Bader (2016), Petascale Local Time Stepping for the ADER-DG Finite Element Method, paper presented at 2016 IEEE International Parallel and Distributed Processing Symposium (IPDPS), 23-27 May 2016. doi: `10.1109/IPDPS.2016.109 <https://doi.org/10.1109/IPDPS.2016.109>`_.
-
-Pelties, C., A. A. Gabriel, and J. P. Ampuero (2014), Verification of an ADER-DG method for complex dynamic rupture problems, Geosci. Model Dev., 7(3), 847-866, doi: `10.5194/gmd-7-847-2014 <https://doi.org/10.5194/gmd-7-847-2014>`_.
-
-Breuer, A., A. Heinecke, S. Rettenberger, M. Bader, A.-A. Gabriel, and C. Pelties (2014), Sustained Petascale Performance of Seismic Simulations with SeisSol on SuperMUC, Springer International Publishing, Cham, doi: `10.1007/978-3-319-07518-1_1 <https://doi.org/10.1007/978-3-319-07518-1_1>`_.
-
-Heinecke, A., A. Breuer, S. Rettenberger, M. Bader, A. Gabriel, C. Pelties, A. Bode, W. Barth, X. Liao, K. Vaidyanathan, M. Smelyanskiy, and P. Dubey (2014), Petascale High Order Dynamic Rupture Earthquake Simulations on Heterogeneous Supercomputers, paper presented at SC '14: Proceedings of the International Conference for High Performance Computing, Networking, Storage and Analysis, 16-21 Nov. 2014, doi: `10.1109/SC.2014.6 <https://doi.org/10.1109/SC.2014.6>`_.
-
-Pelties, C., J. de la Puente, J.-P. Ampuero, G. B. Brietzke, and M. Käser (2012), Three-dimensional dynamic rupture simulation with a high-order discontinuous Galerkin method on unstructured tetrahedral meshes, J. Geophys. Res., 117(B2), doi: `10.1029/2011JB008857 <https://doi.org/10.1029/2011JB008857>`_.
-
-de la Puente, J., J.-P. Ampuero, and M. Käser (2009), Dynamic rupture modeling on unstructured meshes using a discontinuous Galerkin method, J. Geophys. Res., 114(B10), doi: `10.1029/2008JB006271 <https://doi.org/10.1029/2008JB006271>`_.
-
-Käser, M., M. Dumbser, J. de la Puente, and H. Igel (2007), An arbitrary high-order discontinuous Galerkin method for elastic waves on unstructured meshes - III. Viscoelastic attenuation, Geophys. J. Int., 168(1), 224-242, doi: `10.1111/j.1365-246X.2006.03193.x  <https://doi.org/10.1111/j.1365-246X.2006.03193.x>`_..
-
-Käser, M., and M. Dumbser (2006), An arbitrary high-order discontinuous Galerkin method for elastic waves on unstructured meshes - I. The two-dimensional isotropic case with external source terms, Geophys. J. Int., 166(2), 855-877, doi: `10.1111/j.1365-246X.2006.03051.x  <https://doi.org/10.1111/j.1365-246X.2006.03051.x>`_.
-
-Dumbser, M. and Käser, M. (2006), An arbitrary high‐order discontinuous Galerkin method for elastic waves on unstructured meshes – II. The three‐dimensional isotropic case. Geophysical J. Int., 167: 319-336. doi: `10.1111/j.1365-246X.2006.03120.x <https://doi.org/10.1111/j.1365-246X.2006.03120.x>`_.
-
-
+If you make use specific SeisSol features,
+or require a list of applications, visit the
+`How To Cite page <https://seissol.org/about/howtocite/>`__ on our website.
+It also includes an example on how to cite SeisSol itself.

--- a/README.md
+++ b/README.md
@@ -32,13 +32,14 @@ general users.
 # Citing SeisSol
 
 If you utilize SeisSol in a publication or want to refer to it,
-then please cite [doi.org/10.5281/zenodo.4672483](https://doi.org/10.5281/zenodo.4672483)
-for SeisSol as software package.
+please follow the suggestions on our [How To Cite](https://seissol.org/about/howtocite/)
+page.
+It also includes examples how to cite specific SeisSol features,
+models or previous use cases.
 
-If you make use specific SeisSol features,
-or require a list of applications, visit the
-[How To Cite page](https://seissol.org/about/howtocite/) on our website.
-It also includes an example on how to cite SeisSol itself.
+To reference SeisSol as a software package and the specific version you used,
+please provide the link [doi.org/10.5281/zenodo.4672483](https://doi.org/10.5281/zenodo.4672483)
+which points to Zenodo.
 
 # Collaboration
 

--- a/README.md
+++ b/README.md
@@ -51,10 +51,10 @@ Please follow the rules when participating in our community.
 
 # Contributing
 
-We will be happy if you plan to contribute new features, extensions or bug fixes
-to SeisSol. To start off, please, open a new issue and discuss your feature with
-us before diving into coding. Visit our [doxygen documentation](https://ci_seissol.pages.gitlab.lrz.de/SeisSol/master)
-to learn more about the source code structure.
+You are very welcome to contribute new features, extensions or bug fixes
+to SeisSol.
+Before starting, it is best to discuss your planned feature with us;
+e.g. by opening a new issue for it.
 
 To learn more about contributing to SeisSol, please read our [**Contribution page**](CONTRIBUTING.md).
 
@@ -62,6 +62,6 @@ To learn more about contributing to SeisSol, please read our [**Contribution pag
 
 The source code of SeisSol is licensed under the BSD-3-Clause license.
 Some files in the `cmake` and `external` folders may have different licenses
-(BSL-1.0, MIT).
+(BSL-1.0, MIT, BSD-2-Clause).
 
 See the [LICENSE](LICENSE) file for more details.

--- a/README.md
+++ b/README.md
@@ -29,6 +29,17 @@ SeisSol is still under heavy development and comes without any guaranteed
 functionality. At the moment we can only provide very limited support for
 general users.
 
+# Citing SeisSol
+
+If you utilize SeisSol in a publication or want to refer to it,
+then please cite [doi.org/10.5281/zenodo.4672483](https://doi.org/10.5281/zenodo.4672483)
+for SeisSol as software package.
+
+If you make use specific SeisSol features,
+or require a list of applications, visit the
+[How To Cite page](https://seissol.org/about/howtocite/) on our website.
+It also includes an example on how to cite SeisSol itself.
+
 # Collaboration
 
 If you are interested in a close collaboration, please contact [Alice Gabriel](https://www.alicegabriel.com/).


### PR DESCRIPTION
Forward the new "How To Cite" page to:

* the README
* the readthedocs

Also, a tiny bit of README cleanup. Furthermore, we remove the duplicate (and outdated) publication list from the readthedocs (and thus also the SeisSol repository).
