### PR TITLE
Fix fault output interval, take 2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,7 +82,7 @@ if(NOT CMAKE_BUILD_TYPE)
   message(STATUS "Set build type to Release as none was supplied.")
 endif()
 set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS
-        "Debug" "Release" "RelWithDebInfo") # MinSizeRel is useless for us
+        "Release" "Debug" "RelWithDebInfo") # MinSizeRel is useless for us
 
 if (NOT (DEVICE_BACKEND STREQUAL "hip" AND DEVICE_ARCH MATCHES "sm_*"))
   # Note: hip 4.x has a bug during setting rpath while compiling

--- a/src/Solver/TimeStepping/ActorState.cpp
+++ b/src/Solver/TimeStepping/ActorState.cpp
@@ -98,9 +98,8 @@ bool DynamicRuptureScheduler::mayComputeInterior(long curCorrectionSteps) const 
 }
 
 bool DynamicRuptureScheduler::mayComputeFaultOutput(long curCorrectionSteps) const {
-  return !hasDynamicRuptureFaces() ||
-         (curCorrectionSteps == lastCorrectionStepsInterior &&
-          curCorrectionSteps == lastCorrectionStepsCopy && curCorrectionSteps > lastFaultOutput);
+  return curCorrectionSteps == lastCorrectionStepsInterior &&
+         curCorrectionSteps == lastCorrectionStepsCopy && curCorrectionSteps > lastFaultOutput;
 }
 
 void DynamicRuptureScheduler::setLastCorrectionStepsInterior(long steps) {

--- a/src/Solver/TimeStepping/TimeCluster.cpp
+++ b/src/Solver/TimeStepping/TimeCluster.cpp
@@ -725,23 +725,25 @@ void TimeCluster::correct() {
   // Note, if this is a copy layer actor, we need the FL_Copy and the FL_Int.
   // Otherwise, this is an interior layer actor, and we need only the FL_Int.
   // We need to avoid computing it twice.
-  if (dynamicRuptureScheduler->hasDynamicRuptureFaces()) {
-    if (dynamicRuptureScheduler->mayComputeInterior(ct.stepsSinceStart)) {
+  if (dynamicRuptureScheduler->mayComputeInterior(ct.stepsSinceStart)) {
+    if (dynamicRuptureScheduler->hasDynamicRuptureFaces()) {
       handleDynamicRupture(*dynRupInteriorData);
       seissolInstance.flopCounter().incrementNonZeroFlopsDynamicRupture(
           accFlopsNonZero[static_cast<int>(ComputePart::DRFrictionLawInterior)]);
       seissolInstance.flopCounter().incrementHardwareFlopsDynamicRupture(
           accFlopsHardware[static_cast<int>(ComputePart::DRFrictionLawInterior)]);
-      dynamicRuptureScheduler->setLastCorrectionStepsInterior(ct.stepsSinceStart);
     }
-    if (layerType == Copy) {
+    dynamicRuptureScheduler->setLastCorrectionStepsInterior(ct.stepsSinceStart);
+  }
+  if (layerType == Copy) {
+    if (dynamicRuptureScheduler->hasDynamicRuptureFaces()) {
       handleDynamicRupture(*dynRupCopyData);
       seissolInstance.flopCounter().incrementNonZeroFlopsDynamicRupture(
           accFlopsNonZero[static_cast<int>(ComputePart::DRFrictionLawCopy)]);
       seissolInstance.flopCounter().incrementHardwareFlopsDynamicRupture(
           accFlopsHardware[static_cast<int>(ComputePart::DRFrictionLawCopy)]);
-      dynamicRuptureScheduler->setLastCorrectionStepsCopy((ct.stepsSinceStart));
     }
+    dynamicRuptureScheduler->setLastCorrectionStepsCopy((ct.stepsSinceStart));
   }
 
 #ifdef ACL_DEVICE


### PR DESCRIPTION
Unfortunately, #1386 went into the right direction; but ran the output twice—once for the interior, once for the copy layer. Thus: strategy switch; we now "emulate" the DR scheduler to run, even if it doesn't have any DR faces.

I've tested it with tpv13-fused locally, and it seems to work—whereas the current master does explicitly _not_ work.
