### PR TITLE
Fix ICC Builds, receiver timing and some compiler warnings

### DIFF
--- a/src/DynamicRupture/Output/OutputAux.cpp
+++ b/src/DynamicRupture/Output/OutputAux.cpp
@@ -248,12 +248,12 @@ std::vector<double> getAllVertices(const seissol::dr::ReceiverPoints& receiverPo
   std::vector<double> vertices(3 * (3 * receiverPoints.size()), 0.0);
 
   for (uint32_t pointIndex{0}; pointIndex < receiverPoints.size(); ++pointIndex) {
-    for (int vertexIndex{0}; vertexIndex < ExtTriangle::size(); ++vertexIndex) {
+    for (std::uint32_t vertexIndex{0}; vertexIndex < ExtTriangle::size(); ++vertexIndex) {
       const auto& triangle = receiverPoints[pointIndex].globalTriangle;
       const auto& point = triangle.point(vertexIndex);
 
       const size_t globalVertexIndex = 3 * pointIndex + vertexIndex;
-      for (int coordIndex{0}; coordIndex < ExtVrtxCoords::size(); ++coordIndex) {
+      for (std::uint32_t coordIndex{0}; coordIndex < ExtVrtxCoords::size(); ++coordIndex) {
         vertices[3 * globalVertexIndex + coordIndex] = point[coordIndex];
       }
     }

--- a/src/DynamicRupture/Output/OutputManager.cpp
+++ b/src/DynamicRupture/Output/OutputManager.cpp
@@ -202,7 +202,7 @@ void OutputManager::initElementwiseOutput() {
     std::vector<real*> dataPointers;
     auto recordPointers = [&dataPointers](auto& var, int) {
       if (var.isActive) {
-        for (int dim = 0; dim < var.dim(); ++dim) {
+        for (std::size_t dim = 0; dim < var.dim(); ++dim) {
           dataPointers.push_back(var.data[dim]);
         }
       }
@@ -267,7 +267,7 @@ void OutputManager::initElementwiseOutput() {
 
     misc::forEach(ewOutputData->vars, [&](auto& var, int i) {
       if (var.isActive) {
-        for (int d = 0; d < var.dim(); ++d) {
+        for (std::size_t d = 0; d < var.dim(); ++d) {
           auto* data = var.data[d];
           writer.addPointData<real>(VariableLabels[i][d],
                                     std::vector<std::size_t>(),
@@ -361,7 +361,7 @@ void OutputManager::initPickpointOutput() {
       auto collectVariableNames =
           [&baseHeader, &labelCounter, &simIndex, &pointIndex, suffix](auto& var, int) {
             if (var.isActive) {
-              for (int dim = 0; dim < var.dim(); ++dim) {
+              for (std::size_t dim = 0; dim < var.dim(); ++dim) {
                 baseHeader << " ,\"" << writer::FaultWriterExecutor::getLabelName(labelCounter)
                            << suffix(pointIndex + 1, simIndex + 1) << '\"';
                 ++labelCounter;
@@ -375,8 +375,6 @@ void OutputManager::initPickpointOutput() {
   }
 
   for (size_t i = 0; i < ppFiles.size(); ++i) {
-    const auto& receiver = outputData->receiverPoints[i];
-
     const auto& ppfile = ppFiles[i];
 
     if (!seissol::filesystem::exists(ppfile.fileName)) {
@@ -528,7 +526,7 @@ void OutputManager::flushPickpointDataToFile() {
       for (std::size_t pointId : ppfile.indices) {
         auto recordResults = [pointId, level, &data](auto& var, int) {
           if (var.isActive) {
-            for (int dim = 0; dim < var.dim(); ++dim) {
+            for (std::size_t dim = 0; dim < var.dim(); ++dim) {
               data << makeFormatted(var(dim, level, pointId)) << '\t';
             }
           }

--- a/src/Geometry/PUMLReader.cpp
+++ b/src/Geometry/PUMLReader.cpp
@@ -441,8 +441,9 @@ void PUMLReader::getMesh(const PUML::TETPUML& puml) {
       PUML::Upward::cells(puml, faces[info.second[i]], cellIds);
       assert(cellIds[1] < 0);
 
-      const auto side = copySide[k][i];
-      const auto gSide = ghostSide[k][i];
+      // the linters demanded a double cast here
+      const auto side = static_cast<std::size_t>(static_cast<unsigned char>(copySide[k][i]));
+      const auto gSide = static_cast<std::size_t>(static_cast<unsigned char>(ghostSide[k][i]));
       m_elements[cellIds[0]].neighborSides[PumlFaceToSeisSol[side]] = PumlFaceToSeisSol[gSide];
 
       // Set side sideOrientation

--- a/src/IO/Reader/File/Hdf5Reader.cpp
+++ b/src/IO/Reader/File/Hdf5Reader.cpp
@@ -107,7 +107,7 @@ std::size_t Hdf5Reader::dataCount(const std::string& name) {
   MPI_Comm_size(comm, &mpisize);
   MPI_Comm_rank(comm, &mpirank);
 
-  return dims[0] / mpisize + ((dims[0] % mpisize) > mpirank ? 1 : 0);
+  return dims[0] / mpisize + ((dims[0] % mpisize) > static_cast<std::size_t>(mpirank) ? 1 : 0);
 }
 void Hdf5Reader::readDataRaw(void* data,
                              const std::string& name,

--- a/src/Initializer/CellLocalMatrices.cpp
+++ b/src/Initializer/CellLocalMatrices.cpp
@@ -636,8 +636,8 @@ void initializeDynamicRuptureMatrices(const seissol::geometry::MeshReader& meshR
                                             matTinv);
 
       /// Materials
-      seissol::model::Material* plusMaterial = nullptr;
-      seissol::model::Material* minusMaterial = nullptr;
+      seissol::model::MaterialT* plusMaterial = nullptr;
+      seissol::model::MaterialT* minusMaterial = nullptr;
       const std::size_t plusLtsId =
           (fault[meshFace].element >= 0)
               ? ltsLut->ltsId(ltsTree->info(lts->material).mask, fault[meshFace].element)
@@ -693,10 +693,8 @@ void initializeDynamicRuptureMatrices(const seissol::geometry::MeshReader& meshR
 
       switch (plusMaterial->getMaterialType()) {
       case seissol::model::MaterialType::Poroelastic: {
-        auto plusEigenpair =
-            seissol::model::getEigenDecomposition(*dynamic_cast<model::MaterialT*>(plusMaterial));
-        auto minusEigenpair =
-            seissol::model::getEigenDecomposition(*dynamic_cast<model::MaterialT*>(minusMaterial));
+        auto plusEigenpair = seissol::model::getEigenDecomposition(*plusMaterial);
+        auto minusEigenpair = seissol::model::getEigenDecomposition(*minusMaterial);
 
         // The impedance matrices are diagonal in the (visco)elastic case, so we only store
         // the values Zp, Zs. In the poroelastic case, the fluid pressure and normal component
@@ -719,7 +717,11 @@ void initializeDynamicRuptureMatrices(const seissol::geometry::MeshReader& meshR
         break;
       }
       default: {
-        if constexpr (!model::MaterialT::SupportsDR) {
+
+        // NOTE: could be made `if constexpr`. However, that breaks ICC with a segfault.
+        // So we don't do that, yet (until we drop ICC support at least).
+
+        if (!model::MaterialT::SupportsDR) {
           logError() << "The Dynamic Rupture mechanism does not work with the given material yet. "
                         "(built with:"
                      << model::MaterialT::Text << ")";
@@ -727,10 +729,8 @@ void initializeDynamicRuptureMatrices(const seissol::geometry::MeshReader& meshR
         break;
       }
       }
-      seissol::model::getTransposedCoefficientMatrix(
-          *dynamic_cast<model::MaterialT*>(plusMaterial), 0, matAPlus);
-      seissol::model::getTransposedCoefficientMatrix(
-          *dynamic_cast<model::MaterialT*>(minusMaterial), 0, matAMinus);
+      seissol::model::getTransposedCoefficientMatrix(*plusMaterial, 0, matAPlus);
+      seissol::model::getTransposedCoefficientMatrix(*minusMaterial, 0, matAMinus);
 
       /// Traction matrices for "average" traction
       auto tractionPlusMatrix =

--- a/src/Kernels/Receiver.cpp
+++ b/src/Kernels/Receiver.cpp
@@ -178,7 +178,7 @@ double ReceiverCluster::calcReceivers(
 
       double receiverTime = time;
       while (receiverTime < expansionPoint + timeStepWidth) {
-        const auto coeffs = timeBasis.point(time - expansionPoint, timeStepWidth);
+        const auto coeffs = timeBasis.point(receiverTime - expansionPoint, timeStepWidth);
 
         timeKernel.evaluate(coeffs.data(), timeDerivatives, timeEvaluated);
 

--- a/src/Physics/InitialField.cpp
+++ b/src/Physics/InitialField.cpp
@@ -180,8 +180,8 @@ seissol::physics::AcousticTravellingWaveITM::AcousticTravellingWaveITM(
     : rho0(materialData.local.rho),
       c0(sqrt(materialData.local.getLambdaBar() / materialData.local.rho)),
       k(acousticTravellingWaveParametersItm.k),
-      tITMMinus(acousticTravellingWaveParametersItm.itmStartingTime), tITMPlus(tITMMinus + tau),
-      tau(acousticTravellingWaveParametersItm.itmDuration),
+      tITMMinus(acousticTravellingWaveParametersItm.itmStartingTime),
+      tau(acousticTravellingWaveParametersItm.itmDuration), tITMPlus(tITMMinus + tau),
       n(acousticTravellingWaveParametersItm.itmVelocityScalingFactor) {
   logInfo() << "Starting Test for Acoustic Travelling Wave with ITM";
 


### PR DESCRIPTION
* Make ICC builds work (again). Could be done by removing a non-performance critical `constexpr`.
* Fix receiver timing in a cell; i.e. with very small receiver timing. Actually a bug from #1374 which borrowed from the STP implementation. (I'm sorry—again)
* Fix some more compiler warnings that appeared in the meantime
