### PR TITLE
Fix the non-volume writer executors getting stuck

### DIFF
--- a/src/ResultWriter/FaultWriterExecutor.cpp
+++ b/src/ResultWriter/FaultWriterExecutor.cpp
@@ -33,6 +33,8 @@ void seissol::writer::FaultWriterExecutor::execInit(const async::ExecInfo& info,
 
   MPI_Comm_split(seissol::MPI::mpi.comm(), (nCells > 0 ? 0 : MPI_UNDEFINED), 0, &m_comm);
 
+  m_enabled = true;
+
   if (nCells > 0) {
     int rank = 0;
     MPI_Comm_rank(m_comm, &rank);

--- a/src/ResultWriter/FaultWriterExecutor.h
+++ b/src/ResultWriter/FaultWriterExecutor.h
@@ -54,6 +54,8 @@ class FaultWriterExecutor {
   /** Backend stopwatch */
   Stopwatch m_stopwatch;
 
+  bool m_enabled{false};
+
   public:
   FaultWriterExecutor()
       : m_comm(MPI_COMM_NULL)
@@ -88,7 +90,8 @@ class FaultWriterExecutor {
   }
 
   void finalize() {
-    if (m_xdmfWriter != nullptr) {
+    if (m_enabled) {
+      // note: also includes some ranks which do nothing at all
       m_stopwatch.printTime("Time fault writer backend:");
     }
 

--- a/src/ResultWriter/FreeSurfaceWriterExecutor.cpp
+++ b/src/ResultWriter/FreeSurfaceWriterExecutor.cpp
@@ -33,6 +33,8 @@ void seissol::writer::FreeSurfaceWriterExecutor::execInit(
 
   MPI_Comm_split(seissol::MPI::mpi.comm(), (nCells > 0 ? 0 : MPI_UNDEFINED), 0, &m_comm);
 
+  m_enabled = true;
+
   if (nCells > 0) {
     int rank = 0;
     MPI_Comm_rank(m_comm, &rank);

--- a/src/ResultWriter/FreeSurfaceWriterExecutor.h
+++ b/src/ResultWriter/FreeSurfaceWriterExecutor.h
@@ -47,6 +47,8 @@ class FreeSurfaceWriterExecutor {
   /** Backend stopwatch */
   Stopwatch m_stopwatch;
 
+  bool m_enabled{false};
+
   public:
   FreeSurfaceWriterExecutor() = default;
 
@@ -78,8 +80,10 @@ class FreeSurfaceWriterExecutor {
   }
 
   void finalize() {
-    // note: also includes some ranks which do nothing at all
-    m_stopwatch.printTime("Time free surface writer backend:");
+    if (m_enabled) {
+      // note: also includes some ranks which do nothing at all
+      m_stopwatch.printTime("Time free surface writer backend:");
+    }
 
     if (m_comm != MPI_COMM_NULL) {
       MPI_Comm_free(&m_comm);


### PR DESCRIPTION
Fix the simulation getting stuck after being already finished.

The stopwatches need to be triggered by all ranks right now (which caused an issue with the old fault and surface writers); thus we now do that.
