### PR TITLE
Some small DR Adjustments

### DIFF
--- a/src/DynamicRupture/FrictionLaws/CpuImpl/BaseFrictionLaw.h
+++ b/src/DynamicRupture/FrictionLaws/CpuImpl/BaseFrictionLaw.h
@@ -34,7 +34,7 @@ class BaseFrictionLaw : public FrictionSolver {
                 const seissol::initializer::DynamicRupture* const dynRup,
                 real fullUpdateTime,
                 const FrictionTime& frictionTime,
-                const double timeWeights[ConvergenceOrder],
+                const double* timeWeights,
                 seissol::parallel::runtime::StreamRuntime& runtime) override {
     if (layerData.size() == 0) {
       return;
@@ -86,7 +86,7 @@ class BaseFrictionLaw : public FrictionSolver {
       // loop over sub time steps (i.e. quadrature points in time
       real startTime = 0;
       real updateTime = this->mFullUpdateTime;
-      for (std::size_t timeIndex = 0; timeIndex < ConvergenceOrder; timeIndex++) {
+      for (std::size_t timeIndex = 0; timeIndex < misc::TimeSteps; timeIndex++) {
         startTime = updateTime;
         updateTime += this->deltaT[timeIndex];
         for (unsigned i = 0; i < this->drParameters->nucleationCount; ++i) {

--- a/src/DynamicRupture/FrictionLaws/CpuImpl/ImposedSlipRates.h
+++ b/src/DynamicRupture/FrictionLaws/CpuImpl/ImposedSlipRates.h
@@ -73,7 +73,7 @@ class ImposedSlipRates : public BaseFrictionLaw<ImposedSlipRates<STF>> {
   void preHook(std::array<real, misc::NumPaddedPoints>& stateVariableBuffer, std::size_t ltsFace) {}
   void postHook(std::array<real, misc::NumPaddedPoints>& stateVariableBuffer, std::size_t ltsFace) {
   }
-  void saveDynamicStressOutput(std::size_t ltsFace) {}
+  void saveDynamicStressOutput(std::size_t ltsFace, real time) {}
 
   protected:
   real (*__restrict imposedSlipDirection1)[misc::NumPaddedPoints]{};

--- a/src/DynamicRupture/FrictionLaws/CpuImpl/LinearSlipWeakening.h
+++ b/src/DynamicRupture/FrictionLaws/CpuImpl/LinearSlipWeakening.h
@@ -135,13 +135,13 @@ class LinearSlipWeakeningLaw : public BaseFrictionLaw<LinearSlipWeakeningLaw<Spe
   /**
    * output time when shear stress is equal to the dynamic stress after rupture arrived
    */
-  void saveDynamicStressOutput(std::size_t ltsFace) {
+  void saveDynamicStressOutput(std::size_t ltsFace, real time) {
 #pragma omp simd
     for (std::uint32_t pointIndex = 0; pointIndex < misc::NumPaddedPoints; pointIndex++) {
       if (this->dynStressTimePending[ltsFace][pointIndex] &&
           std::fabs(this->accumulatedSlipMagnitude[ltsFace][pointIndex]) >=
               dC[ltsFace][pointIndex]) {
-        this->dynStressTime[ltsFace][pointIndex] = this->mFullUpdateTime;
+        this->dynStressTime[ltsFace][pointIndex] = time;
         this->dynStressTimePending[ltsFace][pointIndex] = false;
       }
     }

--- a/src/DynamicRupture/FrictionLaws/CpuImpl/NoFault.h
+++ b/src/DynamicRupture/FrictionLaws/CpuImpl/NoFault.h
@@ -33,7 +33,7 @@ class NoFault : public BaseFrictionLaw<NoFault> {
   };
   void postHook(std::array<real, misc::NumPaddedPoints>& stateVariableBuffer, std::size_t ltsFace) {
   };
-  void saveDynamicStressOutput(std::size_t ltsFace) {};
+  void saveDynamicStressOutput(std::size_t ltsFace, real time) {};
 };
 } // namespace seissol::dr::friction_law::cpu
 

--- a/src/DynamicRupture/FrictionLaws/CpuImpl/RateAndState.h
+++ b/src/DynamicRupture/FrictionLaws/CpuImpl/RateAndState.h
@@ -256,17 +256,17 @@ class RateAndStateBase : public BaseFrictionLaw<RateAndStateBase<Derived, TPMeth
     }
   }
 
-  void saveDynamicStressOutput(std::size_t faceIndex) {
+  void saveDynamicStressOutput(std::size_t faceIndex, real time) {
 #pragma omp simd
     for (std::uint32_t pointIndex = 0; pointIndex < misc::NumPaddedPoints; pointIndex++) {
 
       if (this->ruptureTime[faceIndex][pointIndex] > 0.0 &&
-          this->ruptureTime[faceIndex][pointIndex] <= this->mFullUpdateTime &&
+          this->ruptureTime[faceIndex][pointIndex] <= time &&
           this->dynStressTimePending[faceIndex][pointIndex] &&
           this->mu[faceIndex][pointIndex] <=
               (this->drParameters->muW +
                0.05 * (this->drParameters->rsF0 - this->drParameters->muW))) {
-        this->dynStressTime[faceIndex][pointIndex] = this->mFullUpdateTime;
+        this->dynStressTime[faceIndex][pointIndex] = time;
         this->dynStressTimePending[faceIndex][pointIndex] = false;
       }
     }

--- a/src/DynamicRupture/FrictionLaws/FrictionSolver.cpp
+++ b/src/DynamicRupture/FrictionLaws/FrictionSolver.cpp
@@ -17,18 +17,18 @@
 namespace seissol::dr::friction_law {
 
 FrictionSolver::FrictionTime FrictionSolver::computeDeltaT(const std::vector<double>& timePoints) {
-  std::vector<real> deltaT(ConvergenceOrder);
-  real sumDt = 0;
+  std::vector<double> deltaT(ConvergenceOrder);
 
-  deltaT[0] = timePoints[0];
-  sumDt = deltaT[0];
+  deltaT[0] = timePoints[0]; // - 0
   for (std::size_t timeIndex = 1; timeIndex < ConvergenceOrder; ++timeIndex) {
     deltaT[timeIndex] = timePoints[timeIndex] - timePoints[timeIndex - 1];
-    sumDt += deltaT[timeIndex];
   }
-  // to fill last segment of Gaussian integration
+
+  // include the last integration segment (from the last point to dt) into the last timestep
   deltaT[ConvergenceOrder - 1] = deltaT[ConvergenceOrder - 1] + deltaT[0];
-  sumDt += deltaT[0];
+
+  // use that time points are symmetric to compute dt
+  const auto sumDt = timePoints[ConvergenceOrder - 1] + timePoints[0];
 
   return {sumDt, deltaT};
 }

--- a/src/DynamicRupture/FrictionLaws/FrictionSolver.cpp
+++ b/src/DynamicRupture/FrictionLaws/FrictionSolver.cpp
@@ -17,18 +17,15 @@
 namespace seissol::dr::friction_law {
 
 FrictionSolver::FrictionTime FrictionSolver::computeDeltaT(const std::vector<double>& timePoints) {
-  std::vector<double> deltaT(ConvergenceOrder);
+  std::vector<double> deltaT(misc::TimeSteps);
 
   deltaT[0] = timePoints[0]; // - 0
-  for (std::size_t timeIndex = 1; timeIndex < ConvergenceOrder; ++timeIndex) {
+  for (std::size_t timeIndex = 1; timeIndex < misc::TimeSteps; ++timeIndex) {
     deltaT[timeIndex] = timePoints[timeIndex] - timePoints[timeIndex - 1];
   }
 
-  // include the last integration segment (from the last point to dt) into the last timestep
-  deltaT[ConvergenceOrder - 1] = deltaT[ConvergenceOrder - 1] + deltaT[0];
-
   // use that time points are symmetric to compute dt
-  const auto sumDt = timePoints[ConvergenceOrder - 1] + timePoints[0];
+  const auto sumDt = timePoints.back();
 
   return {sumDt, deltaT};
 }

--- a/src/DynamicRupture/FrictionLaws/FrictionSolver.h
+++ b/src/DynamicRupture/FrictionLaws/FrictionSolver.h
@@ -42,7 +42,7 @@ class FrictionSolver {
                         const seissol::initializer::DynamicRupture* dynRup,
                         real fullUpdateTime,
                         const FrictionTime& frictionTime,
-                        const double timeWeights[ConvergenceOrder],
+                        const double* timeWeights,
                         seissol::parallel::runtime::StreamRuntime& runtime) = 0;
 
   /**
@@ -65,7 +65,7 @@ class FrictionSolver {
    * Adjust initial stress by adding nucleation stress * nucleation function
    * For reference, see: https://strike.scec.org/cvws/download/SCEC_validation_slip_law.pdf.
    */
-  real deltaT[ConvergenceOrder] = {};
+  real deltaT[misc::TimeSteps] = {};
   real sumDt{};
 
   seissol::initializer::parameters::DRParameters* __restrict drParameters;
@@ -102,8 +102,8 @@ class FrictionSolver {
   real (*__restrict dynStressTime)[misc::NumPaddedPoints]{};
   bool (*__restrict dynStressTimePending)[misc::NumPaddedPoints]{};
 
-  real (*__restrict qInterpolatedPlus)[ConvergenceOrder][tensor::QInterpolated::size()]{};
-  real (*__restrict qInterpolatedMinus)[ConvergenceOrder][tensor::QInterpolated::size()]{};
+  real (*__restrict qInterpolatedPlus)[misc::TimeSteps][tensor::QInterpolated::size()]{};
+  real (*__restrict qInterpolatedMinus)[misc::TimeSteps][tensor::QInterpolated::size()]{};
 };
 } // namespace seissol::dr::friction_law
 

--- a/src/DynamicRupture/FrictionLaws/FrictionSolver.h
+++ b/src/DynamicRupture/FrictionLaws/FrictionSolver.h
@@ -34,8 +34,8 @@ class FrictionSolver {
   virtual ~FrictionSolver() = default;
 
   struct FrictionTime {
-    real sumDt;
-    std::vector<real> deltaT;
+    double sumDt;
+    std::vector<double> deltaT;
   };
 
   virtual void evaluate(seissol::initializer::Layer& layerData,

--- a/src/DynamicRupture/FrictionLaws/FrictionSolverCommon.h
+++ b/src/DynamicRupture/FrictionLaws/FrictionSolverCommon.h
@@ -75,35 +75,32 @@ struct VariableIndexing;
 
 template <>
 struct VariableIndexing<Executor::Host> {
-  static constexpr real&
-      index(real (&data)[ConvergenceOrder][misc::NumPaddedPoints], int o, int i) {
+  static constexpr real& index(real (&data)[misc::TimeSteps][misc::NumPaddedPoints], int o, int i) {
     return data[o][i];
   }
 
   static constexpr real
-      index(const real (&data)[ConvergenceOrder][misc::NumPaddedPoints], int o, int i) {
+      index(const real (&data)[misc::TimeSteps][misc::NumPaddedPoints], int o, int i) {
     return data[o][i];
   }
 };
 
 template <>
 struct VariableIndexing<Executor::Device> {
-  static constexpr real& index(real (&data)[ConvergenceOrder], int o, int i) { return data[o]; }
+  static constexpr real& index(real (&data)[misc::TimeSteps], int o, int i) { return data[o]; }
 
-  static constexpr real index(const real (&data)[ConvergenceOrder], int o, int i) {
-    return data[o];
-  }
+  static constexpr real index(const real (&data)[misc::TimeSteps], int o, int i) { return data[o]; }
 };
 
 /**
  * Asserts whether all relevant arrays are properly aligned
  */
 inline void checkAlignmentPreCompute(
-    const real qIPlus[ConvergenceOrder][dr::misc::NumQuantities][dr::misc::NumPaddedPoints],
-    const real qIMinus[ConvergenceOrder][dr::misc::NumQuantities][dr::misc::NumPaddedPoints],
+    const real qIPlus[misc::TimeSteps][dr::misc::NumQuantities][dr::misc::NumPaddedPoints],
+    const real qIMinus[misc::TimeSteps][dr::misc::NumQuantities][dr::misc::NumPaddedPoints],
     const FaultStresses<Executor::Host>& faultStresses) {
   using namespace dr::misc::quantity_indices;
-  for (unsigned o = 0; o < ConvergenceOrder; ++o) {
+  for (unsigned o = 0; o < misc::TimeSteps; ++o) {
     assert(reinterpret_cast<uintptr_t>(qIPlus[o][U]) % Alignment == 0);
     assert(reinterpret_cast<uintptr_t>(qIPlus[o][V]) % Alignment == 0);
     assert(reinterpret_cast<uintptr_t>(qIPlus[o][W]) % Alignment == 0);
@@ -144,8 +141,8 @@ SEISSOL_HOSTDEVICE inline void precomputeStressFromQInterpolated(
     FaultStresses<RangeExecutor<Type>::Exec>& faultStresses,
     const ImpedancesAndEta& impAndEta,
     const ImpedanceMatrices& impedanceMatrices,
-    const real qInterpolatedPlus[ConvergenceOrder][tensor::QInterpolated::size()],
-    const real qInterpolatedMinus[ConvergenceOrder][tensor::QInterpolated::size()],
+    const real qInterpolatedPlus[misc::TimeSteps][tensor::QInterpolated::size()],
+    const real qInterpolatedMinus[misc::TimeSteps][tensor::QInterpolated::size()],
     real etaPDamp,
     unsigned startLoopIndex = 0) {
   static_assert(tensor::QInterpolated::Shape[seissol::multisim::BasisFunctionDimension] ==
@@ -170,7 +167,7 @@ SEISSOL_HOSTDEVICE inline void precomputeStressFromQInterpolated(
   checkAlignmentPreCompute(qIPlus, qIMinus, faultStresses);
 #endif
 
-  for (unsigned o = 0; o < ConvergenceOrder; ++o) {
+  for (unsigned o = 0; o < misc::TimeSteps; ++o) {
     using Range = typename NumPoints<Type>::Range;
 
 #ifndef ACL_DEVICE
@@ -205,7 +202,7 @@ SEISSOL_HOSTDEVICE inline void precomputeStressFromQInterpolated(
   krnl.theta = thetaBuffer;
   auto thetaView = init::theta::view::create(thetaBuffer);
 
-  for (unsigned o = 0; o < ConvergenceOrder; ++o) {
+  for (unsigned o = 0; o < misc::TimeSteps; ++o) {
     krnl.Qplus = qInterpolatedPlus[o];
     krnl.Qminus = qInterpolatedMinus[o];
     krnl.execute();
@@ -224,10 +221,10 @@ SEISSOL_HOSTDEVICE inline void precomputeStressFromQInterpolated(
  * Asserts whether all relevant arrays are properly aligned
  */
 inline void checkAlignmentPostCompute(
-    const real qIPlus[ConvergenceOrder][dr::misc::NumQuantities][dr::misc::NumPaddedPoints],
-    const real qIMinus[ConvergenceOrder][dr::misc::NumQuantities][dr::misc::NumPaddedPoints],
-    const real imposedStateP[ConvergenceOrder][dr::misc::NumPaddedPoints],
-    const real imposedStateM[ConvergenceOrder][dr::misc::NumPaddedPoints],
+    const real qIPlus[misc::TimeSteps][dr::misc::NumQuantities][dr::misc::NumPaddedPoints],
+    const real qIMinus[misc::TimeSteps][dr::misc::NumQuantities][dr::misc::NumPaddedPoints],
+    const real imposedStateP[misc::TimeSteps][dr::misc::NumPaddedPoints],
+    const real imposedStateM[misc::TimeSteps][dr::misc::NumPaddedPoints],
     const FaultStresses<Executor::Host>& faultStresses,
     const TractionResults<Executor::Host>& tractionResults) {
   using namespace dr::misc::quantity_indices;
@@ -246,7 +243,7 @@ inline void checkAlignmentPostCompute(
   assert(reinterpret_cast<uintptr_t>(imposedStateM[T1]) % Alignment == 0);
   assert(reinterpret_cast<uintptr_t>(imposedStateM[T2]) % Alignment == 0);
 
-  for (size_t o = 0; o < ConvergenceOrder; ++o) {
+  for (size_t o = 0; o < misc::TimeSteps; ++o) {
     assert(reinterpret_cast<uintptr_t>(qIPlus[o][U]) % Alignment == 0);
     assert(reinterpret_cast<uintptr_t>(qIPlus[o][V]) % Alignment == 0);
     assert(reinterpret_cast<uintptr_t>(qIPlus[o][W]) % Alignment == 0);
@@ -289,9 +286,9 @@ SEISSOL_HOSTDEVICE inline void postcomputeImposedStateFromNewStress(
     const ImpedanceMatrices& impedanceMatrices,
     real imposedStatePlus[tensor::QInterpolated::size()],
     real imposedStateMinus[tensor::QInterpolated::size()],
-    const real qInterpolatedPlus[ConvergenceOrder][tensor::QInterpolated::size()],
-    const real qInterpolatedMinus[ConvergenceOrder][tensor::QInterpolated::size()],
-    const double timeWeights[ConvergenceOrder],
+    const real qInterpolatedPlus[misc::TimeSteps][tensor::QInterpolated::size()],
+    const real qInterpolatedMinus[misc::TimeSteps][tensor::QInterpolated::size()],
+    const double timeWeights[misc::TimeSteps],
     unsigned startIndex = 0) {
 
   // set imposed state to zero
@@ -323,7 +320,7 @@ SEISSOL_HOSTDEVICE inline void postcomputeImposedStateFromNewStress(
       qIPlus, qIMinus, imposedStateP, imposedStateM, faultStresses, tractionResults);
 #endif
 
-  for (unsigned o = 0; o < ConvergenceOrder; ++o) {
+  for (unsigned o = 0; o < misc::TimeSteps; ++o) {
     auto weight = timeWeights[o];
 
     using NumPointsRange = typename NumPoints<Type>::Range;
@@ -382,7 +379,7 @@ SEISSOL_HOSTDEVICE inline void postcomputeImposedStateFromNewStress(
   krnlM.theta = thetaBuffer;
   krnlP.theta = thetaBuffer;
 
-  for (unsigned o = 0; o < ConvergenceOrder; ++o) {
+  for (unsigned o = 0; o < misc::TimeSteps; ++o) {
     auto weight = timeWeights[o];
     // copy values to yateto dataformat
     for (unsigned i = 0; i < misc::NumPaddedPoints; ++i) {
@@ -547,10 +544,10 @@ SEISSOL_HOSTDEVICE inline void
 template <RangeType Type = RangeType::CPU>
 SEISSOL_HOSTDEVICE inline void computeFrictionEnergy(
     DREnergyOutput& energyData,
-    const real qInterpolatedPlus[ConvergenceOrder][tensor::QInterpolated::size()],
-    const real qInterpolatedMinus[ConvergenceOrder][tensor::QInterpolated::size()],
+    const real qInterpolatedPlus[misc::TimeSteps][tensor::QInterpolated::size()],
+    const real qInterpolatedMinus[misc::TimeSteps][tensor::QInterpolated::size()],
     const ImpedancesAndEta& impAndEta,
-    const double timeWeights[ConvergenceOrder],
+    const double timeWeights[misc::TimeSteps],
     const real spaceWeights[seissol::kernels::NumSpaceQuadraturePoints],
     const DRGodunovData& godunovData,
     const real slipRateMagnitude[misc::NumPaddedPoints],
@@ -572,7 +569,7 @@ SEISSOL_HOSTDEVICE inline void computeFrictionEnergy(
   using Range = typename NumPoints<Type>::Range;
 
   using namespace dr::misc::quantity_indices;
-  for (size_t o = 0; o < ConvergenceOrder; ++o) {
+  for (size_t o = 0; o < misc::TimeSteps; ++o) {
     const auto timeWeight = timeWeights[o];
 #ifndef ACL_DEVICE
 #pragma omp simd

--- a/src/DynamicRupture/FrictionLaws/GpuImpl/BaseFrictionSolver.h
+++ b/src/DynamicRupture/FrictionLaws/GpuImpl/BaseFrictionSolver.h
@@ -94,7 +94,7 @@ class BaseFrictionSolver : public FrictionSolverDetails {
 
     real startTime = 0;
     real updateTime = ctx.fullUpdateTime;
-    for (uint32_t timeIndex = 0; timeIndex < ConvergenceOrder; ++timeIndex) {
+    for (uint32_t timeIndex = 0; timeIndex < misc::TimeSteps; ++timeIndex) {
       const real dt = ctx.data->deltaT[timeIndex];
 
       startTime = updateTime;
@@ -171,11 +171,11 @@ class BaseFrictionSolver : public FrictionSolverDetails {
   }
 
   void copyParameters(seissol::parallel::runtime::StreamRuntime& runtime,
-                      const double timeWeights[ConvergenceOrder]) {
+                      const double* timeWeights) {
     device::DeviceInstance::getInstance().api->copyToAsync(
         data, &dataHost, sizeof(FrictionLawData), runtime.stream());
     device::DeviceInstance::getInstance().api->copyToAsync(
-        devTimeWeights, timeWeights, sizeof(double[ConvergenceOrder]), runtime.stream());
+        devTimeWeights, timeWeights, sizeof(double[misc::TimeSteps]), runtime.stream());
   }
 
   void evaluateKernel(seissol::parallel::runtime::StreamRuntime& runtime, real fullUpdateTime);
@@ -184,7 +184,7 @@ class BaseFrictionSolver : public FrictionSolverDetails {
                 const seissol::initializer::DynamicRupture* const dynRup,
                 real fullUpdateTime,
                 const FrictionTime& frictionTime,
-                const double timeWeights[ConvergenceOrder],
+                const double* timeWeights,
                 seissol::parallel::runtime::StreamRuntime& runtime) override {
 
     if (layerData.size() == 0) {

--- a/src/DynamicRupture/FrictionLaws/GpuImpl/FrictionSolverDetails.cpp
+++ b/src/DynamicRupture/FrictionLaws/GpuImpl/FrictionSolverDetails.cpp
@@ -29,7 +29,7 @@ void FrictionSolverDetails::allocateAuxiliaryMemory() {
 
   {
     devTimeWeights =
-        seissol::memory::allocTyped<double>(ConvergenceOrder, 1, memory::DeviceGlobalMemory);
+        seissol::memory::allocTyped<double>(misc::TimeSteps, 1, memory::DeviceGlobalMemory);
   }
 
   {

--- a/src/DynamicRupture/FrictionLaws/GpuImpl/FrictionSolverInterface.h
+++ b/src/DynamicRupture/FrictionLaws/GpuImpl/FrictionSolverInterface.h
@@ -16,7 +16,7 @@
 // which, in its turn, is not supposed to know anything about SYCL
 namespace seissol::dr::friction_law::gpu {
 struct FrictionLawData {
-  real deltaT[ConvergenceOrder] = {};
+  real deltaT[misc::TimeSteps] = {};
   real sumDt{};
 
   seissol::initializer::parameters::DRParameters drParameters;
@@ -52,8 +52,8 @@ struct FrictionLawData {
   real (*__restrict dynStressTime)[misc::NumPaddedPoints]{};
   bool (*__restrict dynStressTimePending)[misc::NumPaddedPoints]{};
 
-  const real (*__restrict qInterpolatedPlus)[ConvergenceOrder][tensor::QInterpolated::size()]{};
-  const real (*__restrict qInterpolatedMinus)[ConvergenceOrder][tensor::QInterpolated::size()]{};
+  const real (*__restrict qInterpolatedPlus)[misc::TimeSteps][tensor::QInterpolated::size()]{};
+  const real (*__restrict qInterpolatedMinus)[misc::TimeSteps][tensor::QInterpolated::size()]{};
 
   // LSW
   const real (*__restrict dC)[misc::NumPaddedPoints];

--- a/src/DynamicRupture/FrictionLaws/GpuImpl/ImposedSlipRates.h
+++ b/src/DynamicRupture/FrictionLaws/GpuImpl/ImposedSlipRates.h
@@ -70,7 +70,7 @@ class ImposedSlipRates : public BaseFrictionSolver<ImposedSlipRates<STF>> {
     ctx.tractionResults.traction2[timeIndex] = ctx.data->traction2[ctx.ltsFace][ctx.pointIndex];
   }
 
-  SEISSOL_DEVICE static void saveDynamicStressOutput(FrictionLawContext& ctx) {}
+  SEISSOL_DEVICE static void saveDynamicStressOutput(FrictionLawContext& ctx, real time) {}
   SEISSOL_DEVICE static void preHook(FrictionLawContext& ctx) {}
   SEISSOL_DEVICE static void postHook(FrictionLawContext& ctx) {}
 };

--- a/src/DynamicRupture/FrictionLaws/GpuImpl/LinearSlipWeakening.h
+++ b/src/DynamicRupture/FrictionLaws/GpuImpl/LinearSlipWeakening.h
@@ -110,11 +110,11 @@ class LinearSlipWeakeningBase : public BaseFrictionSolver<LinearSlipWeakeningBas
    * output time when shear stress is equal to the dynamic stress after rupture arrived
    * currently only for linear slip weakening
    */
-  SEISSOL_DEVICE static void saveDynamicStressOutput(FrictionLawContext& ctx) {
+  SEISSOL_DEVICE static void saveDynamicStressOutput(FrictionLawContext& ctx, real time) {
     if (ctx.data->dynStressTimePending[ctx.ltsFace][ctx.pointIndex] &&
         std::fabs(ctx.data->accumulatedSlipMagnitude[ctx.ltsFace][ctx.pointIndex]) >=
             ctx.data->dC[ctx.ltsFace][ctx.pointIndex]) {
-      ctx.data->dynStressTime[ctx.ltsFace][ctx.pointIndex] = ctx.fullUpdateTime;
+      ctx.data->dynStressTime[ctx.ltsFace][ctx.pointIndex] = time;
       ctx.data->dynStressTimePending[ctx.ltsFace][ctx.pointIndex] = false;
     }
   }

--- a/src/DynamicRupture/FrictionLaws/GpuImpl/NoFault.h
+++ b/src/DynamicRupture/FrictionLaws/GpuImpl/NoFault.h
@@ -36,7 +36,7 @@ class NoFault : public BaseFrictionSolver<NoFault> {
    * output time when shear stress is equal to the dynamic stress after rupture arrived
    * currently only for linear slip weakening
    */
-  SEISSOL_DEVICE static void saveDynamicStressOutput(FrictionLawContext& ctx) {}
+  SEISSOL_DEVICE static void saveDynamicStressOutput(FrictionLawContext& ctx, real time) {}
 
   SEISSOL_DEVICE static void preHook(FrictionLawContext& ctx) {}
   SEISSOL_DEVICE static void postHook(FrictionLawContext& ctx) {}

--- a/src/DynamicRupture/FrictionLaws/GpuImpl/RateAndState.h
+++ b/src/DynamicRupture/FrictionLaws/GpuImpl/RateAndState.h
@@ -198,15 +198,15 @@ class RateAndStateBase : public BaseFrictionSolver<RateAndStateBase<Derived, TPM
     ctx.data->slipRate2[ctx.ltsFace][ctx.pointIndex] = slipRate2;
   }
 
-  SEISSOL_DEVICE static void saveDynamicStressOutput(FrictionLawContext& ctx) {
+  SEISSOL_DEVICE static void saveDynamicStressOutput(FrictionLawContext& ctx, real time) {
     auto muW{ctx.data->drParameters.muW};
     auto rsF0{ctx.data->drParameters.rsF0};
 
     const auto localRuptureTime = ctx.data->ruptureTime[ctx.ltsFace][ctx.pointIndex];
-    if (localRuptureTime > 0.0 && localRuptureTime <= ctx.fullUpdateTime &&
+    if (localRuptureTime > 0.0 && localRuptureTime <= time &&
         ctx.data->dynStressTimePending[ctx.ltsFace][ctx.pointIndex] &&
         ctx.data->mu[ctx.ltsFace][ctx.pointIndex] <= (muW + 0.05 * (rsF0 - muW))) {
-      ctx.data->dynStressTime[ctx.ltsFace][ctx.pointIndex] = ctx.fullUpdateTime;
+      ctx.data->dynStressTime[ctx.ltsFace][ctx.pointIndex] = time;
       ctx.data->dynStressTimePending[ctx.ltsFace][ctx.pointIndex] = false;
     }
   }

--- a/src/DynamicRupture/Misc.h
+++ b/src/DynamicRupture/Misc.h
@@ -12,6 +12,7 @@
 #include "Kernels/Precision.h"
 
 #include "generated_code/init.h"
+#include <Common/Constants.h>
 #include <Initializer/Parameters/DRParameters.h>
 #include <cmath>
 #include <string>
@@ -45,6 +46,12 @@ static constexpr inline size_t NumPaddedPointsSingleSim =
     dimSize<init::QInterpolated, multisim::BasisFunctionDimension>();
 static constexpr inline size_t NumQuantities =
     misc::dimSize<init::QInterpolated, multisim::BasisFunctionDimension + 1>();
+
+/*
+ * Time integration point count
+ */
+
+static constexpr inline uint32_t TimeSteps = ConvergenceOrder;
 
 /**
  * Constants for Thermal Pressurization

--- a/src/DynamicRupture/Misc.h
+++ b/src/DynamicRupture/Misc.h
@@ -51,7 +51,7 @@ static constexpr inline size_t NumQuantities =
  * Time integration point count
  */
 
-static constexpr inline uint32_t TimeSteps = ConvergenceOrder;
+static constexpr inline uint32_t TimeSteps = ConvergenceOrder + 1;
 
 /**
  * Constants for Thermal Pressurization

--- a/src/DynamicRupture/Typedefs.h
+++ b/src/DynamicRupture/Typedefs.h
@@ -47,10 +47,10 @@ struct TractionResults;
  */
 template <>
 struct FaultStresses<Executor::Host> {
-  alignas(Alignment) real normalStress[ConvergenceOrder][misc::NumPaddedPoints] = {{}};
-  alignas(Alignment) real traction1[ConvergenceOrder][misc::NumPaddedPoints] = {{}};
-  alignas(Alignment) real traction2[ConvergenceOrder][misc::NumPaddedPoints] = {{}};
-  alignas(Alignment) real fluidPressure[ConvergenceOrder][misc::NumPaddedPoints] = {{}};
+  alignas(Alignment) real normalStress[misc::TimeSteps][misc::NumPaddedPoints] = {{}};
+  alignas(Alignment) real traction1[misc::TimeSteps][misc::NumPaddedPoints] = {{}};
+  alignas(Alignment) real traction2[misc::TimeSteps][misc::NumPaddedPoints] = {{}};
+  alignas(Alignment) real fluidPressure[misc::TimeSteps][misc::NumPaddedPoints] = {{}};
 };
 
 /**
@@ -59,8 +59,8 @@ struct FaultStresses<Executor::Host> {
  */
 template <>
 struct TractionResults<Executor::Host> {
-  alignas(Alignment) real traction1[ConvergenceOrder][misc::NumPaddedPoints] = {{}};
-  alignas(Alignment) real traction2[ConvergenceOrder][misc::NumPaddedPoints] = {{}};
+  alignas(Alignment) real traction1[misc::TimeSteps][misc::NumPaddedPoints] = {{}};
+  alignas(Alignment) real traction2[misc::TimeSteps][misc::NumPaddedPoints] = {{}};
 };
 
 /**
@@ -70,10 +70,10 @@ struct TractionResults<Executor::Host> {
  */
 template <>
 struct FaultStresses<Executor::Device> {
-  real normalStress[ConvergenceOrder] = {{}};
-  real traction1[ConvergenceOrder] = {{}};
-  real traction2[ConvergenceOrder] = {{}};
-  real fluidPressure[ConvergenceOrder] = {{}};
+  real normalStress[misc::TimeSteps] = {{}};
+  real traction1[misc::TimeSteps] = {{}};
+  real traction2[misc::TimeSteps] = {{}};
+  real fluidPressure[misc::TimeSteps] = {{}};
 };
 
 /**
@@ -82,8 +82,8 @@ struct FaultStresses<Executor::Device> {
  */
 template <>
 struct TractionResults<Executor::Device> {
-  real traction1[ConvergenceOrder] = {{}};
-  real traction2[ConvergenceOrder] = {{}};
+  real traction1[misc::TimeSteps] = {{}};
+  real traction2[misc::TimeSteps] = {{}};
 };
 
 } // namespace seissol::dr

--- a/src/Kernels/DynamicRupture.cpp
+++ b/src/Kernels/DynamicRupture.cpp
@@ -52,8 +52,8 @@ void DynamicRupture::spaceTimeInterpolation(
     DREnergyOutput* drEnergyOutput,
     const real* timeDerivativePlus,
     const real* timeDerivativeMinus,
-    real qInterpolatedPlus[ConvergenceOrder][seissol::tensor::QInterpolated::size()],
-    real qInterpolatedMinus[ConvergenceOrder][seissol::tensor::QInterpolated::size()],
+    real qInterpolatedPlus[dr::misc::TimeSteps][seissol::tensor::QInterpolated::size()],
+    real qInterpolatedMinus[dr::misc::TimeSteps][seissol::tensor::QInterpolated::size()],
     const real* timeDerivativePlusPrefetch,
     const real* timeDerivativeMinusPrefetch,
     const real* coeffs) {
@@ -73,16 +73,16 @@ void DynamicRupture::spaceTimeInterpolation(
   alignas(PagesizeStack) real degreesOfFreedomMinus[tensor::Q::size()];
 
   dynamicRupture::kernel::evaluateAndRotateQAtInterpolationPoints krnl = m_krnlPrototype;
-  for (std::size_t timeInterval = 0; timeInterval < ConvergenceOrder; ++timeInterval) {
+  for (std::size_t timeInterval = 0; timeInterval < dr::misc::TimeSteps; ++timeInterval) {
     m_timeKernel.evaluate(
         &coeffs[timeInterval * ConvergenceOrder], timeDerivativePlus, degreesOfFreedomPlus);
     m_timeKernel.evaluate(
         &coeffs[timeInterval * ConvergenceOrder], timeDerivativeMinus, degreesOfFreedomMinus);
 
-    const real* plusPrefetch = (timeInterval < ConvergenceOrder - 1)
+    const real* plusPrefetch = (timeInterval < dr::misc::TimeSteps - 1)
                                    ? &qInterpolatedPlus[timeInterval + 1][0]
                                    : timeDerivativePlusPrefetch;
-    const real* minusPrefetch = (timeInterval < ConvergenceOrder - 1)
+    const real* minusPrefetch = (timeInterval < dr::misc::TimeSteps - 1)
                                     ? &qInterpolatedMinus[timeInterval + 1][0]
                                     : timeDerivativeMinusPrefetch;
 
@@ -109,7 +109,7 @@ void DynamicRupture::batchedSpaceTimeInterpolation(
   real** degreesOfFreedomPlus{nullptr};
   real** degreesOfFreedomMinus{nullptr};
 
-  for (unsigned timeInterval = 0; timeInterval < ConvergenceOrder; ++timeInterval) {
+  for (unsigned timeInterval = 0; timeInterval < dr::misc::TimeSteps; ++timeInterval) {
     ConditionalKey timeIntegrationKey(*KernelNames::DrTime);
     if (table.find(timeIntegrationKey) != table.end()) {
       auto& entry = table[timeIntegrationKey];
@@ -217,8 +217,8 @@ void DynamicRupture::flopsGodunovState(const DRFaceInformation& faceInfo,
   hardwareFlops += dynamicRupture::kernel::evaluateAndRotateQAtInterpolationPoints::hardwareFlops(
       faceInfo.minusSide, faceInfo.faceRelation);
 
-  nonZeroFlops *= ConvergenceOrder;
-  hardwareFlops *= ConvergenceOrder;
+  nonZeroFlops *= dr::misc::TimeSteps;
+  hardwareFlops *= dr::misc::TimeSteps;
 }
 
 } // namespace seissol::kernels

--- a/src/Kernels/DynamicRupture.h
+++ b/src/Kernels/DynamicRupture.h
@@ -38,8 +38,8 @@ class DynamicRupture : public Kernel {
       DREnergyOutput* drEnergyOutput,
       const real* timeDerivativePlus,
       const real* timeDerivativeMinus,
-      real qInterpolatedPlus[ConvergenceOrder][seissol::tensor::QInterpolated::size()],
-      real qInterpolatedMinus[ConvergenceOrder][seissol::tensor::QInterpolated::size()],
+      real qInterpolatedPlus[dr::misc::TimeSteps][seissol::tensor::QInterpolated::size()],
+      real qInterpolatedMinus[dr::misc::TimeSteps][seissol::tensor::QInterpolated::size()],
       const real* timeDerivativePlusPrefetch,
       const real* timeDerivativeMinusPrefetch,
       const real* coeffs);

--- a/src/Memory/Descriptor/DynamicRupture.h
+++ b/src/Memory/Descriptor/DynamicRupture.h
@@ -81,8 +81,8 @@ struct DynamicRupture {
   Variable<real[dr::misc::NumPaddedPoints]> peakSlipRate;
   Variable<real[dr::misc::NumPaddedPoints]> traction1;
   Variable<real[dr::misc::NumPaddedPoints]> traction2;
-  Variable<real[ConvergenceOrder][tensor::QInterpolated::size()]> qInterpolatedPlus;
-  Variable<real[ConvergenceOrder][tensor::QInterpolated::size()]> qInterpolatedMinus;
+  Variable<real[dr::misc::TimeSteps][tensor::QInterpolated::size()]> qInterpolatedPlus;
+  Variable<real[dr::misc::TimeSteps][tensor::QInterpolated::size()]> qInterpolatedMinus;
 
   Scratchpad<real> idofsPlusOnDevice;
   Scratchpad<real> idofsMinusOnDevice;

--- a/src/Solver/TimeStepping/TimeCluster.cpp
+++ b/src/Solver/TimeStepping/TimeCluster.cpp
@@ -188,9 +188,15 @@ void TimeCluster::computeDynamicRupture(seissol::initializer::Layer& layerData) 
   auto* qInterpolatedPlus = layerData.var(dynRup->qInterpolatedPlus);
   auto* qInterpolatedMinus = layerData.var(dynRup->qInterpolatedMinus);
 
-  const auto [timePoints, timeWeights] =
-      seissol::quadrature::ShiftedGaussLegendre(ConvergenceOrder, 0, timeStepSize());
-  const auto pointsCollocate = seissol::kernels::timeBasis().collocate(timePoints, timeStepSize());
+  const auto timestep = timeStepSize();
+
+  auto [timePoints, timeWeights] =
+      seissol::quadrature::ShiftedGaussLegendre(ConvergenceOrder, 0, timestep);
+
+  timePoints.push_back(timestep);
+  timeWeights.push_back(0);
+
+  const auto pointsCollocate = seissol::kernels::timeBasis().collocate(timePoints, timestep);
   const auto frictionTime = seissol::dr::friction_law::FrictionSolver::computeDeltaT(timePoints);
 
 #pragma omp parallel
@@ -243,15 +249,20 @@ void TimeCluster::computeDynamicRuptureDevice(seissol::initializer::Layer& layer
   if (layerData.size() > 0) {
     // compute space time interpolation part
 
-    const double stepSizeWidth = timeStepSize();
+    const auto timestep = timeStepSize();
+
     ComputeGraphType graphType = ComputeGraphType::DynamicRuptureInterface;
     device.api->putProfilingMark("computeDrInterfaces", device::ProfilingColors::Cyan);
-    auto computeGraphKey = initializer::GraphKey(graphType, stepSizeWidth);
+    auto computeGraphKey = initializer::GraphKey(graphType, timestep);
     auto& table = layerData.getConditionalTable<inner_keys::Dr>();
 
-    const auto [timePoints, timeWeights] =
-        seissol::quadrature::ShiftedGaussLegendre(ConvergenceOrder, 0, timeStepSize());
-    const auto pointsCollocate = seissol::kernels::timeBasis().collocate(timePoints, stepSizeWidth);
+    auto [timePoints, timeWeights] =
+        seissol::quadrature::ShiftedGaussLegendre(ConvergenceOrder, 0, timestep);
+
+    timePoints.push_back(timestep);
+    timeWeights.push_back(0);
+
+    const auto pointsCollocate = seissol::kernels::timeBasis().collocate(timePoints, timestep);
     const auto frictionTime = seissol::dr::friction_law::FrictionSolver::computeDeltaT(timePoints);
 
     streamRuntime.runGraph(

--- a/src/tests/DynamicRupture/FrictionLaws/FrictionSolverCommon.t.h
+++ b/src/tests/DynamicRupture/FrictionLaws/FrictionSolverCommon.t.h
@@ -22,12 +22,11 @@ TEST_CASE("Friction Solver Common") {
   FaultStresses<Executor::Host> faultStresses{};
   TractionResults<Executor::Host> tractionResults{};
   ImpedancesAndEta impAndEta;
-  alignas(Alignment) real qInterpolatedPlus[ConvergenceOrder][tensor::QInterpolated::size()] = {{}};
-  alignas(Alignment)
-      real qInterpolatedMinus[ConvergenceOrder][tensor::QInterpolated::size()] = {{}};
+  alignas(Alignment) real qInterpolatedPlus[misc::TimeSteps][tensor::QInterpolated::size()] = {{}};
+  alignas(Alignment) real qInterpolatedMinus[misc::TimeSteps][tensor::QInterpolated::size()] = {{}};
   alignas(Alignment) real imposedStatePlus[tensor::QInterpolated::size()] = {};
   alignas(Alignment) real imposedStateMinus[tensor::QInterpolated::size()] = {};
-  double timeWeights[ConvergenceOrder];
+  double timeWeights[misc::TimeSteps];
   std::iota(std::begin(timeWeights), std::end(timeWeights), 1);
   constexpr real Epsilon = 1e6 * std::numeric_limits<real>::epsilon();
 
@@ -68,7 +67,7 @@ TEST_CASE("Friction Solver Common") {
   auto t1 = [](size_t o, size_t p) { return static_cast<real>(o + p); };
   auto t2 = [](size_t o, size_t p) { return static_cast<real>(2 * (o + p)); };
 
-  for (size_t o = 0; o < ConvergenceOrder; o++) {
+  for (size_t o = 0; o < misc::TimeSteps; o++) {
     for (size_t p = 0; p < misc::NumPaddedPoints; p++) {
       for (size_t q = 0; q < misc::NumQuantities; q++) {
         qIPlus[o][q][p] = qP(o, q, p);
@@ -84,7 +83,7 @@ TEST_CASE("Friction Solver Common") {
         faultStresses, impAndEta, impMats, qInterpolatedPlus, qInterpolatedMinus, 1.0);
 
     // Assure that qInterpolatedPlus and qInterpolatedMinus are const.
-    for (size_t o = 0; o < ConvergenceOrder; o++) {
+    for (size_t o = 0; o < misc::TimeSteps; o++) {
       for (size_t q = 0; q < misc::NumQuantities; q++) {
         for (size_t p = 0; p < misc::NumPaddedPoints; p++) {
           REQUIRE(qIPlus[o][q][p] == qP(o, q, p));
@@ -94,7 +93,7 @@ TEST_CASE("Friction Solver Common") {
     }
 
     // Assure that faultstresses were computed correctly
-    for (size_t o = 0; o < ConvergenceOrder; o++) {
+    for (size_t o = 0; o < misc::TimeSteps; o++) {
       for (size_t p = 0; p < misc::NumPaddedPoints; p++) {
         const real expectedNormalStress =
             impAndEta.etaP * (qM(o, 6, p) - qP(o, 6, p) + impAndEta.invZp * qP(o, 0, p) +
@@ -132,7 +131,7 @@ TEST_CASE("Friction Solver Common") {
       real expectedU[2]{};
       real expectedV[2]{};
       real expectedW[2]{};
-      for (size_t o = 0; o < ConvergenceOrder; o++) {
+      for (size_t o = 0; o < misc::TimeSteps; o++) {
         expectedNormalStress[0] += timeWeights[o] * faultStresses.normalStress[o][p];
         expectedTraction1[0] += timeWeights[o] * t1(o, p);
         expectedTraction2[0] += timeWeights[o] * t2(o, p);


### PR DESCRIPTION
We

* make the peak slip rate and rupture output more accurate (update it per DR timestep; not only per wavepropagation timestep)
* abstract the timestep count for the DR (that could even become a runtime variable in the future—in case accuracy is a concern)
* add a dummy point at the end of the timestep—since previously we'd just timestep _over_ the last quadpoint; treating it differently than the others. Downside: the DR becomes a little more expensive. Also, as tested with the precomputed tpv5; the energy values do change in the 5th digit already—i.e. probably a significant change. (I also tried, for fun, to double the number of timesteps in the DR; that changed the elastic energy _even_ more significantly)

Not 100%ly sure if the latter really solves the issue; or if maybe even Gauss Lobatto points would be better suited.
