### PR TITLE
Move setDevice to serial region

### DIFF
--- a/src/Initializer/InitProcedure/Internal/Buckets.cpp
+++ b/src/Initializer/InitProcedure/Internal/Buckets.cpp
@@ -239,8 +239,8 @@ void setupBuckets(LTS::Layer& layer, std::vector<solver::RemoteCluster>& comm) {
   const auto derivativeSize = yateto::computeFamilySize<tensor::dQ>();
 
 #ifdef ACL_DEVICE
-    device::DeviceInstance& device = device::DeviceInstance::getInstance();
-    device.api->setDevice(0);
+  device::DeviceInstance& device = device::DeviceInstance::getInstance();
+  device.api->setDevice(0);
 #endif // ACL_DEVICE
 
 #ifdef _OPENMP

--- a/src/Initializer/InitProcedure/Internal/Buckets.cpp
+++ b/src/Initializer/InitProcedure/Internal/Buckets.cpp
@@ -238,15 +238,15 @@ void setupBuckets(LTS::Layer& layer, std::vector<solver::RemoteCluster>& comm) {
   const auto bufferSize = tensor::I::size();
   const auto derivativeSize = yateto::computeFamilySize<tensor::dQ>();
 
-#ifdef _OPENMP
-#pragma omp parallel
-#endif
-  {
 #ifdef ACL_DEVICE
     device::DeviceInstance& device = device::DeviceInstance::getInstance();
     device.api->setDevice(0);
 #endif // ACL_DEVICE
 
+#ifdef _OPENMP
+#pragma omp parallel
+#endif
+  {
 #ifdef _OPENMP
 #pragma omp for schedule(static)
 #endif


### PR DESCRIPTION
setDevice is currently called in a parallel region and this tripped up the debugger. I dunno whether this is intentional, but if it is the setDevice function needs to be thread-safe.