### PR TITLE
Disable NVHPC tests

### DIFF
--- a/.github/workflows/build-seissol-cpu.yml
+++ b/.github/workflows/build-seissol-cpu.yml
@@ -63,10 +63,10 @@ jobs:
             cxx: icpx
             fc: ifx
             container: seissol/gha-gpu-intel:davschneller-gpu-image
-          - cc: nvc
-            cxx: nvc++
-            fc: nvfortran
-            container: seissol/gha-gpu-nvhpc:davschneller-gpu-image
+          #- cc: nvc
+          #  cxx: nvc++
+          #  fc: nvfortran
+          #  container: seissol/gha-gpu-nvhpc:davschneller-gpu-image
     steps:
       - id: checkout
         name: checkout-seissol
@@ -384,12 +384,12 @@ jobs:
             container: seissol/gha-gpu-intel:davschneller-gpu-image
             pythonbreak: false
             mpi: intel
-          - cc: nvc
-            cxx: nvc++
-            fc: nvfortran
-            container: seissol/gha-gpu-nvhpc:davschneller-gpu-image
-            pythonbreak: true
-            mpi: openmpi
+          #- cc: nvc
+          #  cxx: nvc++
+          #  fc: nvfortran
+          #  container: seissol/gha-gpu-nvhpc:davschneller-gpu-image
+          #  pythonbreak: true
+          #  mpi: openmpi
         parallel:
           - ranks: 1
             threads: 4


### PR DESCRIPTION
Disable NVHPC tests; since the container seems to fail now. Still a TODO: rebuild the container.

(more CI updates are prepared on the `davschneller/ci-merge` branch; however I fear that'll still take a bit)
