### PR TITLE
Disable plasticity per group if wanted

### DIFF
--- a/docs/parameters.par
+++ b/docs/parameters.par
@@ -15,7 +15,7 @@ UseCellHomogenizedMaterial = 1
 !off-fault plasticity parameters (disabled iff Plasticity=0)
 Plasticity=0
 !comma-separated list of groups for which plasticity is disabled, even if we enable it globally
-plasticitydisable=''
+plasticitydisabledgroups=''
 Tv=0.05
 !yaml file defining spatial dependance of properties necessary for plasticity. MaterialFileName is taken for plasticity if this is not provided
 PlasticityFileName = ''

--- a/src/Initializer/BatchRecorders/PlasticityRecorder.cpp
+++ b/src/Initializer/BatchRecorders/PlasticityRecorder.cpp
@@ -40,7 +40,7 @@ void PlasticityRecorder::record(LTS::Layer& layer) {
   for (std::size_t cell = 0; cell < size; ++cell) {
     auto dataHost = currentLayer->cellRef(cell);
 
-    if (dataHost.get<LTS::CellInformation>().plasticity) {
+    if (dataHost.get<LTS::CellInformation>().plasticityEnabled) {
       ++psize;
     }
   }
@@ -59,7 +59,7 @@ void PlasticityRecorder::record(LTS::Layer& layer) {
       const auto dataHost = currentLayer->cellRef(cell);
       auto data = currentLayer->cellRef(cell, AllocationPlace::Device);
 
-      if (dataHost.get<LTS::CellInformation>().plasticity) {
+      if (dataHost.get<LTS::CellInformation>().plasticityEnabled) {
         dofsPtrs[pcell] = static_cast<real*>(data.get<LTS::Dofs>());
         qstressNodalPtrs[pcell] = &scratchMem[nodalStressTensorCounter];
         nodalStressTensorCounter += tensor::QStressNodal::size();

--- a/src/Initializer/CellLocalInformation.h
+++ b/src/Initializer/CellLocalInformation.h
@@ -33,7 +33,7 @@ struct CellLocalInformation {
   LtsSetup ltsSetup;
 
   // plasticity enabled
-  bool plasticity{false};
+  bool plasticityEnabled{false};
 };
 
 // cell local information which is not needed during the main iterations, but only during setup and

--- a/src/Initializer/InitProcedure/InitLayout.cpp
+++ b/src/Initializer/InitProcedure/InitLayout.cpp
@@ -303,7 +303,7 @@ void setupMemory(seissol::SeisSol& seissolInstance) {
 
   if (seissolParams.model.plasticity) {
     // remove disabled plasticity groups from the list
-    const auto& pdis = seissolParams.model.plasticityDisable;
+    const auto& pdis = seissolParams.model.plasticityDisabledGroups;
     for (auto& layer : ltsStorage.leaves(Ghost)) {
       const std::size_t size = layer.size();
       auto* cellInfo = layer.var<LTS::CellInformation>();
@@ -312,7 +312,7 @@ void setupMemory(seissol::SeisSol& seissolInstance) {
 #pragma omp parallel for schedule(static)
 #endif
       for (std::size_t i = 0; i < size; ++i) {
-        cellInfo[i].plasticity = pdis.find(cellInfo2[i].group) == pdis.end();
+        cellInfo[i].plasticityEnabled = pdis.find(cellInfo2[i].group) == pdis.end();
       }
     }
   }

--- a/src/Initializer/MemoryManager.cpp
+++ b/src/Initializer/MemoryManager.cpp
@@ -152,7 +152,7 @@ void MemoryManager::deriveRequiredScratchpadMemoryForWp(bool plasticity, LTS::St
     std::size_t integratedDofsCounter{0};
     std::size_t nodalDisplacementsCounter{0};
     std::size_t analyticCounter = 0;
-    std::size_t plasticityCells = 0;
+    std::size_t numPlasticCells = 0;
 
     std::array<std::size_t, 4> freeSurfacePerFace{};
     std::array<std::size_t, 4> dirichletPerFace{};
@@ -202,8 +202,8 @@ void MemoryManager::deriveRequiredScratchpadMemoryForWp(bool plasticity, LTS::St
           ++dirichletPerFace[face];
         }
 
-        if (cellInformation[cell].plasticity) {
-          ++plasticityCells;
+        if (cellInformation[cell].plasticityEnabled) {
+          ++numPlasticCells;
         }
       }
     }
@@ -232,11 +232,11 @@ void MemoryManager::deriveRequiredScratchpadMemoryForWp(bool plasticity, LTS::St
     layer.setEntrySize<LTS::AnalyticScratch>(analyticCounter * tensor::INodal::size() *
                                              sizeof(real));
     if (plasticity) {
-      layer.setEntrySize<LTS::FlagScratch>(plasticityCells * sizeof(unsigned));
-      layer.setEntrySize<LTS::PrevDofsScratch>(plasticityCells * tensor::Q::Size * sizeof(real));
-      layer.setEntrySize<LTS::QEtaNodalScratch>(plasticityCells * tensor::QEtaNodal::Size *
+      layer.setEntrySize<LTS::FlagScratch>(numPlasticCells * sizeof(unsigned));
+      layer.setEntrySize<LTS::PrevDofsScratch>(numPlasticCells * tensor::Q::Size * sizeof(real));
+      layer.setEntrySize<LTS::QEtaNodalScratch>(numPlasticCells * tensor::QEtaNodal::Size *
                                                 sizeof(real));
-      layer.setEntrySize<LTS::QStressNodalScratch>(plasticityCells * tensor::QStressNodal::Size *
+      layer.setEntrySize<LTS::QStressNodalScratch>(numPlasticCells * tensor::QStressNodal::Size *
                                                    sizeof(real));
     }
 

--- a/src/Initializer/Parameters/ModelParameters.cpp
+++ b/src/Initializer/Parameters/ModelParameters.cpp
@@ -69,12 +69,13 @@ ModelParameters readModelParameters(ParameterReader* baseReader) {
 
   const bool plasticity = reader->readWithDefault("plasticity", false);
 
-  const auto plasticityDisableRaw = reader->readWithDefault<std::string>("plasticitydisable", "");
-  std::unordered_set<int> plasticityDisable;
+  const auto plasticityDisabledGroupsRaw =
+      reader->readWithDefault<std::string>("plasticitydisabledgroups", "");
+  std::unordered_set<int> plasticityDisabledGroups;
   {
-    const auto groups = utils::StringUtils::split(plasticityDisableRaw, ',');
+    const auto groups = utils::StringUtils::split(plasticityDisabledGroupsRaw, ',');
     for (const auto& group : groups) {
-      plasticityDisable.emplace(std::stoi(group));
+      plasticityDisabledGroups.emplace(std::stoi(group));
     }
   }
 
@@ -117,7 +118,7 @@ ModelParameters readModelParameters(ParameterReader* baseReader) {
 
   return ModelParameters{hasBoundaryFile,
                          plasticity,
-                         plasticityDisable,
+                         plasticityDisabledGroups,
                          useCellHomogenizedMaterial,
                          freqCentral,
                          freqRatio,

--- a/src/Initializer/Parameters/ModelParameters.h
+++ b/src/Initializer/Parameters/ModelParameters.h
@@ -31,7 +31,7 @@ std::string fluxToString(NumericalFlux flux);
 struct ModelParameters {
   bool hasBoundaryFile{false};
   bool plasticity{false};
-  std::unordered_set<int> plasticityDisable;
+  std::unordered_set<int> plasticityDisabledGroups;
   bool useCellHomogenizedMaterial{true};
   double freqCentral{};
   double freqRatio{1.0};

--- a/src/Solver/TimeStepping/TimeCluster.cpp
+++ b/src/Solver/TimeStepping/TimeCluster.cpp
@@ -139,8 +139,8 @@ TimeCluster::TimeCluster(unsigned int clusterId,
 
   const auto* cellInfo = clusterData->var<LTS::CellInformation>();
   for (std::size_t i = 0; i < clusterData->size(); ++i) {
-    if (cellInfo[i].plasticity) {
-      ++plasticityCells;
+    if (cellInfo[i].plasticityEnabled) {
+      ++numPlasticCells;
     }
   }
 }
@@ -574,9 +574,9 @@ void TimeCluster::computeNeighboringIntegrationDevice(SEISSOL_GPU_PARAM double s
                            });
 
     seissolInstance.flopCounter().incrementNonZeroFlopsPlasticity(
-        plasticityCells * accFlopsNonZero[static_cast<int>(ComputePart::PlasticityCheck)]);
+        numPlasticCells * accFlopsNonZero[static_cast<int>(ComputePart::PlasticityCheck)]);
     seissolInstance.flopCounter().incrementHardwareFlopsPlasticity(
-        plasticityCells * accFlopsHardware[static_cast<int>(ComputePart::PlasticityCheck)]);
+        numPlasticCells * accFlopsHardware[static_cast<int>(ComputePart::PlasticityCheck)]);
   }
 
   device.api->popLastProfilingMark();
@@ -964,7 +964,7 @@ void TimeCluster::computeNeighboringIntegrationImplementation(double subTimeStar
         data, drMapping[cell], timeIntegrated, faceNeighborsPrefetch);
 
     if constexpr (UsePlasticity) {
-      if (data.get<LTS::CellInformation>().plasticity) {
+      if (data.get<LTS::CellInformation>().plasticityEnabled) {
         numberOfTetsWithPlasticYielding +=
             seissol::kernels::Plasticity::computePlasticity(oneMinusIntegratingFactor,
                                                             timestep,
@@ -984,9 +984,9 @@ void TimeCluster::computeNeighboringIntegrationImplementation(double subTimeStar
   if constexpr (UsePlasticity) {
     yieldCells[0] += numberOfTetsWithPlasticYielding;
     seissolInstance.flopCounter().incrementNonZeroFlopsPlasticity(
-        plasticityCells * accFlopsNonZero[static_cast<int>(ComputePart::PlasticityCheck)]);
+        numPlasticCells * accFlopsNonZero[static_cast<int>(ComputePart::PlasticityCheck)]);
     seissolInstance.flopCounter().incrementHardwareFlopsPlasticity(
-        plasticityCells * accFlopsHardware[static_cast<int>(ComputePart::PlasticityCheck)]);
+        numPlasticCells * accFlopsHardware[static_cast<int>(ComputePart::PlasticityCheck)]);
   }
 
   loopStatistics->end(regionComputeNeighboringIntegration, clusterSize, profilingId);

--- a/src/Solver/TimeStepping/TimeCluster.h
+++ b/src/Solver/TimeStepping/TimeCluster.h
@@ -130,7 +130,7 @@ class TimeCluster : public AbstractTimeCluster {
 
   seissol::memory::MemkindArray<std::size_t> yieldCells;
 
-  std::size_t plasticityCells{0};
+  std::size_t numPlasticCells{0};
 
   /**
    * Writes the receiver output if applicable (receivers present, receivers have to be written).


### PR DESCRIPTION
Allow to disable plasticity per material group, removing the need to specify a too high `plastCo` to emulate that.

Currently, we don't split the clusters by plasticity or not (i.e. there _might_ be tiny imbalances at least in the CPU case)—but that would also be doable with #1411 merged.
