### PR TITLE
Update the Hdf5 parallel warning for Hdf5 2.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -217,8 +217,8 @@ if (HDF5)
   endif()
   target_compile_definitions(seissol-common-properties INTERFACE USE_HDF)
 
-  # HDF5_PROVIDES_PARALLEL needed for Hdf5 2.0 upwards
-  if (NOT (HDF5_IS_PARALLEL OR HDF5_PROVIDES_PARALLEL))
+  # HDF5_PROVIDES_PARALLEL needed for Hdf5 2.0 upwards (cf. https://www.hdfgroup.org/2025/11/10/release-of-hdf5-2-0-0-newsletter-207/ )
+  if (NOT (HDF5_IS_PARALLEL OR HDF5_ENABLE_PARALLEL OR HDF5_PROVIDES_PARALLEL))
     message(WARNING "The found parallel Hdf5 installation is not parallel (i.e. MPI-ready). Compile errors will occur.")
   endif()
 endif()


### PR DESCRIPTION
`HDF5_IS_PARALLEL` (or `HDF5_ENABLE_PARALLEL`) does not seem to exist in the CMake config files anymore at that point.

Cf. https://www.hdfgroup.org/2025/11/10/release-of-hdf5-2-0-0-newsletter-207/#side .
