### PR TITLE
More more former parameters as "deprecated" instead of "unknown"

### DIFF
--- a/src/Initializer/Parameters/DRParameters.cpp
+++ b/src/Initializer/Parameters/DRParameters.cpp
@@ -179,7 +179,12 @@ DRParameters readDRParameters(ParameterReader* baseReader) {
                               .value_or(reader->read<double>("etastop").value_or(
                                   std::numeric_limits<double>::infinity()));
 
-  reader->warnDeprecated({"rf_output_on", "backgroundtype"});
+  reader->warnDeprecated({"rf_output_on",
+                          "backgroundtype",
+                          "gpwise",
+                          "magnitude_output_on",
+                          "energy_rate_output_on",
+                          "energy_rate_printtimeinterval"});
 
   return DRParameters{isDynamicRuptureEnabled,
                       isThermalPressureOn,

--- a/src/Initializer/Parameters/LtsParameters.cpp
+++ b/src/Initializer/Parameters/LtsParameters.cpp
@@ -84,6 +84,8 @@ LtsParameters readLtsParameters(ParameterReader* baseReader) {
                                       LtsWeightsTypes::ExponentialBalancedWeights,
                                       LtsWeightsTypes::EncodedBalancedWeights,
                                   });
+
+  reader->warnDeprecated({"dgmethod"});
   return {rates,
           wiggleFactorMinimum,
           wiggleFactorStepsize,


### PR DESCRIPTION
Cf. the warnings thrown by the scenario used in #1539 .