### PR TITLE
Refactor the face type input

### DIFF
--- a/docs/parameters.par
+++ b/docs/parameters.par
@@ -111,6 +111,7 @@ pumlboundaryformat = 'auto'      ! the boundary data type for PUML files ('auto'
 pumltopologyformat = 'auto'      ! the topology type for PUML files ('auto', 'geometric', 'identify-face', 'identify-vertex')
 meshgenerator = 'PUML'          ! Name of meshgenerator (Netcdf or PUML)
 PartitioningLib = 'Default' ! name of the partitioning library (see src/Geometry/PartitioningLib.cpp for a list of possible options, you may need to enable additional libraries during the build process)
+facemapfile = '' ! filename name of the face tag file
 /
 
 &Discretization

--- a/docs/puml-mesh-format.rst
+++ b/docs/puml-mesh-format.rst
@@ -115,7 +115,7 @@ The following convention for defining a face ID is used:
 
 You may supply a separate face type configuration as a YAML file. The file consists of a sole YAML dictionary
 with the tags ``regular``, ``freeSurface``, ``freeSurfaceGravity``, ``dynamicRupture``, ``dirichlet``,
-``outflow``, or ``analytic``.
+``outflow``, or ``analytical``.
 
 Each entry has a list with the boundary condition IDs / face tags that are associated to it.
 You may also add a range of the format e.g. ``10-23`` or ``10-`` if you want all larger tags
@@ -139,7 +139,7 @@ As an example, the following would replicate the default SeisSol behavior.
       - 4
    outflow:
       - 5
-   analytic:
+   analytical:
       - 7
 
 Topological Connectivity (e.g. for periodic or stitched domains)

--- a/docs/puml-mesh-format.rst
+++ b/docs/puml-mesh-format.rst
@@ -101,7 +101,7 @@ SeisSol indexes the boundary conditions as follows:
 
 - 5: absorbing. Boundary condition; no neighbor.
 
-- 6: identified. Similar to a regular face (0) between two cells. Formerly known as "periodic".
+- 6: regular. Like face type 0, a regular face between two cells. Formerly known as "periodic" or "identified".
 
 - 7: analytical. Boundary condition given by
 
@@ -112,6 +112,35 @@ The following convention for defining a face ID is used:
 .. code-block:: python
 
    s_vert[0,:] = [0,2,1];   s_vert[1,:] = [0,1,3];    s_vert[2,:] = [1,2,3]; s_vert[3,:] = [0,3,2];
+
+You may supply a separate face type configuration as a YAML file. The file consists of a sole YAML dictionary
+with the tags ``regular``, ``freeSurface``, ``freeSurfaceGravity``, ``dynamicRupture``, ``dirichlet``,
+``outflow``, or ``analytic``.
+
+Each entry has a list with the boundary condition IDs / face tags that are associated to it.
+You may also add a range of the format e.g. ``10-23`` or ``10-`` if you want all larger tags
+to be matched to this boundary condition. Ranges are inclusive on both sides.
+
+As an example, the following would replicate the default SeisSol behavior.
+
+.. code-block:: yaml
+
+   regular:
+      - 0
+      - 6
+   freeSurface:
+      - 1
+   freeSurfaceGravity:
+      - 2
+   dynamicRupture:
+      - 3
+      - 65- # note the open range
+   dirichlet:
+      - 4
+   outflow:
+      - 5
+   analytic:
+      - 7
 
 Topological Connectivity (e.g. for periodic or stitched domains)
 ----------------------------------------------------------------

--- a/src/Common/SegmentMap.h
+++ b/src/Common/SegmentMap.h
@@ -1,0 +1,105 @@
+// SPDX-FileCopyrightText: 2026 SeisSol Group
+//
+// SPDX-License-Identifier: BSD-3-Clause
+// SPDX-LicenseComments: Full text under /LICENSE and /LICENSES/
+//
+// SPDX-FileContributor: Author lists in /AUTHORS and /CITATION.cff
+#ifndef SEISSOL_SRC_COMMON_SEGMENTMAP_H_
+#define SEISSOL_SRC_COMMON_SEGMENTMAP_H_
+
+#include <cmath>
+#include <map>
+#include <numeric>
+#include <optional>
+#include <utility>
+#include <utils/logger.h>
+
+namespace seissol {
+
+/**
+    A map that supports range inputs and point queries.
+    Somewhat remniscient to a segment tree, but without a fancy query function.
+
+    How it works internally: use the tree structure of a std::map.
+    Add the start and end range points for each value.
+    Add sentinel (i.e. empty optional) ranges to fill the rest.
+
+    Query via upper_bound and lower_bound
+ */
+template <typename KeyT, typename ValueT>
+class SegmentMap {
+  public:
+  SegmentMap() {
+    ranges[std::numeric_limits<KeyT>::min()] = {};
+    ranges[std::numeric_limits<KeyT>::max()] = {};
+  }
+
+  /**
+      Inserts a range. start and end are both inclusive; but can be unbounded (== empty optional).
+   */
+  void addRange(std::optional<KeyT> start, std::optional<KeyT> end, ValueT type) {
+    const auto trueStart = start.value_or(std::numeric_limits<KeyT>::min());
+    const auto trueEnd = end.value_or(std::numeric_limits<KeyT>::max());
+
+    if (trueStart > trueEnd) {
+      logError() << "Invalid range:" << trueStart << "to" << trueEnd;
+    }
+
+    // check if we're empty first (i.e. look for a lower bound; then increment once; we should be
+    // outside the interval again)
+    const auto lb = ranges.lower_bound(trueEnd);
+    const auto pb = std::prev(lb);
+
+    if ((lb->first == trueEnd && lb->second.has_value()) || pb->first > trueStart ||
+        (pb->first == trueStart && pb->second.has_value())) {
+      logError() << "Map error: range not empty." << trueStart << "to" << trueEnd;
+      throw;
+    }
+
+    // insert the ranges and sentinel ranges. Also take care of any overflows/underflows that could
+    // occur. (in case we would not have a sentinel range)
+
+    ranges[trueEnd] = type;
+    if (trueEnd < std::numeric_limits<KeyT>::max()) {
+      const auto pos = trueEnd + 1;
+      ranges.try_emplace(pos);
+    }
+
+    ranges[trueStart] = type;
+    if (trueStart > std::numeric_limits<KeyT>::min()) {
+      const auto pos = trueStart - 1;
+      ranges.try_emplace(pos);
+    }
+  }
+
+  /**
+    Add a point entry.
+    */
+  void addEntry(KeyT value, ValueT type) { addRange(value, value, type); }
+
+  /**
+    Query a value in the segment map. Will return an empty optional if nothing was found.
+   */
+  [[nodiscard]] std::optional<ValueT> at(KeyT index) const {
+    // (ab)use a std::map as a sort of segment tree; to support ranges
+    const auto exact = ranges.find(index);
+    const auto upper = ranges.upper_bound(index);
+    const auto lower = ranges.lower_bound(index);
+
+    if (exact != ranges.end()) {
+      return exact->second;
+    } else if (upper->second == lower->second) {
+      return lower->second;
+    } else {
+      // error (we should not end up here)
+      logError() << "Map error: internal issue.";
+      throw;
+    }
+  }
+
+  private:
+  std::map<KeyT, std::optional<ValueT>> ranges;
+};
+
+} // namespace seissol
+#endif // SEISSOL_SRC_COMMON_SEGMENTMAP_H_

--- a/src/Geometry/CubeGenerator.cpp
+++ b/src/Geometry/CubeGenerator.cpp
@@ -9,6 +9,7 @@
 
 #include "Common/Constants.h"
 #include "Geometry/MeshDefinition.h"
+#include "Initializer/FaceMap.h"
 #include "Initializer/Parameters/CubeGeneratorParameters.h"
 #include "MeshReader.h"
 #include "Parallel/MPI.h"
@@ -458,13 +459,14 @@ void CubeGenerator::cubeGenerator(const std::array<std::size_t, 4> numCubes,
     }
   }
 
-  int* elemBoundaries = new int[numElemPerPart[3] * 4];
+  std::vector<FaceType> elemBoundaries(numElemPerPart[3] * 4);
+
+  const auto faceMap = defaultFaceMap();
 
   // Calculate elemBoundaries
   for (std::size_t z = 0; z < numPartitions[2]; z++) {
     for (std::size_t y = 0; y < numPartitions[1]; y++) {
       const std::size_t x = rank;
-      memset(elemBoundaries, 0, sizeof(int) * numElemPerPart[3] * 4);
 
       if (x == 0) { // first partition in x dimension
 
@@ -474,14 +476,15 @@ void CubeGenerator::cubeGenerator(const std::array<std::size_t, 4> numCubes,
             const int odd = (zz + yy) % 2;
             if (odd != 0) {
               elemBoundaries[static_cast<size_t>((zz * numCubesPerPart[1] + yy) *
-                                                 numCubesPerPart[0] * 20)] = boundaryMinx;
+                                                 numCubesPerPart[0] * 20)] =
+                  faceMap.at(boundaryMinx).value();
               elemBoundaries[(zz * numCubesPerPart[1] + yy) * numCubesPerPart[0] * 20 + 10] =
-                  boundaryMinx;
+                  faceMap.at(boundaryMinx).value();
             } else {
               elemBoundaries[(zz * numCubesPerPart[1] + yy) * numCubesPerPart[0] * 20 + 2] =
-                  boundaryMinx;
+                  faceMap.at(boundaryMinx).value();
               elemBoundaries[(zz * numCubesPerPart[1] + yy) * numCubesPerPart[0] * 20 + 12] =
-                  boundaryMinx;
+                  faceMap.at(boundaryMinx).value();
             }
           }
         }
@@ -496,20 +499,20 @@ void CubeGenerator::cubeGenerator(const std::array<std::size_t, 4> numCubes,
               elemBoundaries[((zz * numCubesPerPart[1] + yy) * numCubesPerPart[0] +
                               numCubesPerPart[0] - 1) *
                                  20 +
-                             7] = boundaryMaxx;
+                             7] = faceMap.at(boundaryMaxx).value();
               elemBoundaries[((zz * numCubesPerPart[1] + yy) * numCubesPerPart[0] +
                               numCubesPerPart[0] - 1) *
                                  20 +
-                             12] = boundaryMaxx;
+                             12] = faceMap.at(boundaryMaxx).value();
             } else {
               elemBoundaries[((zz * numCubesPerPart[1] + yy) * numCubesPerPart[0] +
                               numCubesPerPart[0] - 1) *
                                  20 +
-                             6] = boundaryMaxx;
+                             6] = faceMap.at(boundaryMaxx).value();
               elemBoundaries[((zz * numCubesPerPart[1] + yy) * numCubesPerPart[0] +
                               numCubesPerPart[0] - 1) *
                                  20 +
-                             9] = boundaryMaxx;
+                             9] = faceMap.at(boundaryMaxx).value();
             }
           }
         }
@@ -522,14 +525,14 @@ void CubeGenerator::cubeGenerator(const std::array<std::size_t, 4> numCubes,
             const int odd = (zz + xx) % 2;
             if (odd != 0) {
               elemBoundaries[(zz * numCubesPerPart[1] * numCubesPerPart[0] + xx) * 20 + 6] =
-                  boundaryMiny;
+                  faceMap.at(boundaryMiny).value();
               elemBoundaries[(zz * numCubesPerPart[1] * numCubesPerPart[0] + xx) * 20 + 9] =
-                  boundaryMiny;
+                  faceMap.at(boundaryMiny).value();
             } else {
               elemBoundaries[(zz * numCubesPerPart[1] * numCubesPerPart[0] + xx) * 20 + 1] =
-                  boundaryMiny;
+                  faceMap.at(boundaryMiny).value();
               elemBoundaries[(zz * numCubesPerPart[1] * numCubesPerPart[0] + xx) * 20 + 10] =
-                  boundaryMiny;
+                  faceMap.at(boundaryMiny).value();
             }
           }
         }
@@ -544,20 +547,20 @@ void CubeGenerator::cubeGenerator(const std::array<std::size_t, 4> numCubes,
               elemBoundaries
                   [((zz * numCubesPerPart[1] + numCubesPerPart[1] - 1) * numCubesPerPart[0] + xx) *
                        20 +
-                   3] = boundaryMaxy;
+                   3] = faceMap.at(boundaryMaxy).value();
               elemBoundaries
                   [((zz * numCubesPerPart[1] + numCubesPerPart[1] - 1) * numCubesPerPart[0] + xx) *
                        20 +
-                   14] = boundaryMaxy;
+                   14] = faceMap.at(boundaryMaxy).value();
             } else {
               elemBoundaries
                   [((zz * numCubesPerPart[1] + numCubesPerPart[1] - 1) * numCubesPerPart[0] + xx) *
                        20 +
-                   7] = boundaryMaxy;
+                   7] = faceMap.at(boundaryMaxy).value();
               elemBoundaries
                   [((zz * numCubesPerPart[1] + numCubesPerPart[1] - 1) * numCubesPerPart[0] + xx) *
                        20 +
-                   13] = boundaryMaxy;
+                   13] = faceMap.at(boundaryMaxy).value();
             }
           }
         }
@@ -570,12 +573,15 @@ void CubeGenerator::cubeGenerator(const std::array<std::size_t, 4> numCubes,
           for (std::size_t xx = 0; xx < numCubesPerPart[0]; xx++) {
             const int odd = (yy + xx) % 2;
             if (odd != 0) {
-              elemBoundaries[(yy * numCubesPerPart[0] + xx) * 20 + 1] = boundaryMinz;
-              elemBoundaries[(yy * numCubesPerPart[0] + xx) * 20 + 5] = boundaryMinz;
+              elemBoundaries[(yy * numCubesPerPart[0] + xx) * 20 + 1] =
+                  faceMap.at(boundaryMinz).value();
+              elemBoundaries[(yy * numCubesPerPart[0] + xx) * 20 + 5] =
+                  faceMap.at(boundaryMinz).value();
             } else {
               elemBoundaries[static_cast<size_t>((yy * numCubesPerPart[0] + xx) * 20)] =
-                  boundaryMinz;
-              elemBoundaries[(yy * numCubesPerPart[0] + xx) * 20 + 5] = boundaryMinz;
+                  faceMap.at(boundaryMinz).value();
+              elemBoundaries[(yy * numCubesPerPart[0] + xx) * 20 + 5] =
+                  faceMap.at(boundaryMinz).value();
             }
           }
         }
@@ -592,20 +598,20 @@ void CubeGenerator::cubeGenerator(const std::array<std::size_t, 4> numCubes,
             elemBoundaries
                 [(((numCubesPerPart[2] - 1) * numCubesPerPart[1] + yy) * numCubesPerPart[0] + xx) *
                      20 +
-                 11] = boundaryMaxz;
+                 11] = faceMap.at(boundaryMaxz).value();
             elemBoundaries
                 [(((numCubesPerPart[2] - 1) * numCubesPerPart[1] + yy) * numCubesPerPart[0] + xx) *
                      20 +
-                 15] = boundaryMaxz;
+                 15] = faceMap.at(boundaryMaxz).value();
             //                                                                    } else {
             //                                                                            elemBoundaries[(((numCubesPerPart[2]-1)*numCubesPerPart[1]+yy)*numCubesPerPart[0]+xx)
             //                                                                            * 20 + 11]
             //                                                                            =
-            //                                                                            boundaryMaxz;
+            //                                                                            faceMap.at(boundaryMaxz).value();
             //                                                                            elemBoundaries[(((numCubesPerPart[2]-1)*numCubesPerPart[1]+yy)*numCubesPerPart[0]+xx)
             //                                                                            * 20 + 15]
             //                                                                            =
-            //                                                                            boundaryMaxz;
+            //                                                                            faceMap.at(boundaryMaxz).value();
             //                                                                    }
           }
         }
@@ -1413,7 +1419,6 @@ void CubeGenerator::cubeGenerator(const std::array<std::size_t, 4> numCubes,
   delete[] elemNeighborsCast;
   delete[] elemNeighborSides;
   delete[] elemSideOrientations;
-  delete[] elemBoundaries;
   delete[] elemNeighborRanks;
   delete[] elemMPIIndices;
   delete[] elemGroup;

--- a/src/Geometry/MeshDefinition.h
+++ b/src/Geometry/MeshDefinition.h
@@ -10,6 +10,7 @@
 #define SEISSOL_SRC_GEOMETRY_MESHDEFINITION_H_
 
 #include "Common/Constants.h"
+#include "Initializer/BasicTypedefs.h"
 
 #include <cstddef>
 #include <vector>
@@ -25,7 +26,7 @@ using ElemVertices = LocalVertexId[Cell::NumVertices];
 using ElemNeighbors = LocalElemId[Cell::NumFaces];
 using ElemNeighborSides = SideId[Cell::NumFaces];
 using ElemSideOrientations = int[Cell::NumFaces];
-using ElemBoundaries = int[Cell::NumFaces];
+using ElemBoundaries = FaceType[Cell::NumFaces];
 using ElemNeighborRanks = int[Cell::NumFaces]; // type prescribed by MPI
 /** The index of this element (side) in the communication array */
 using ElemMPIIndices = int[Cell::NumFaces];

--- a/src/Geometry/MeshReader.cpp
+++ b/src/Geometry/MeshReader.cpp
@@ -9,6 +9,7 @@
 
 #include "Common/Constants.h"
 #include "Common/Iterator.h"
+#include "Initializer/BasicTypedefs.h"
 #include "Initializer/ParameterDB.h"
 #include "Initializer/Parameters/DRParameters.h"
 #include "Initializer/TimeStepping/GlobalTimestep.h"

--- a/src/Geometry/MeshReader.cpp
+++ b/src/Geometry/MeshReader.cpp
@@ -89,8 +89,8 @@ void MeshReader::scaleMesh(const Eigen::Matrix3d& scalingMatrix) {
 void MeshReader::disableDR() {
   for (auto& elem : m_elements) {
     for (std::size_t j = 0; j < Cell::NumFaces; ++j) {
-      if (elem.boundaries[j] == 3) {
-        elem.boundaries[j] = 0;
+      if (elem.boundaries[j] == FaceType::DynamicRupture) {
+        elem.boundaries[j] = FaceType::Regular;
       }
     }
   }
@@ -107,7 +107,7 @@ void MeshReader::extractFaultInformation(
       // Set default mpi fault indices
       i.mpiFaultIndices[j] = -1;
 
-      if (i.boundaries[j] != 3) {
+      if (i.boundaries[j] != FaceType::DynamicRupture) {
         continue;
       }
 

--- a/src/Geometry/PUMLReader.cpp
+++ b/src/Geometry/PUMLReader.cpp
@@ -12,6 +12,7 @@
 #include "Common/Iterator.h"
 #include "Geometry/MeshDefinition.h"
 #include "Geometry/MeshReader.h"
+#include "Initializer/FaceMap.h"
 #include "Initializer/Parameters/MeshParameters.h"
 #include "Initializer/TimeStepping/LtsWeights/LtsWeights.h"
 #include "Monitoring/Instrumentation.h"
@@ -64,8 +65,8 @@ void logassertI(bool condition, const std::string& file, int line) {
 /**
  * Decodes the boundary condition tag into a string representation.
  */
-inline std::string bcToString(uint32_t id) {
-  const auto type = boundaryTagToFaceType(id);
+inline std::string bcToString(uint32_t id, const FaceMap& faceMap) {
+  const auto type = faceMap.at(id);
   if (type == FaceType::Regular) {
     return std::string("regular");
   } else if (type == FaceType::FreeSurface) {
@@ -105,11 +106,12 @@ inline bool
                                 const std::array<int, seissol::Cell::NumFaces>& cellNeighbors,
                                 uint8_t side,
                                 uint32_t sideBC,
-                                uint64_t cellIdAsInFile) {
+                                uint64_t cellIdAsInFile,
+                                const FaceMap& faceMap) {
   // all of these will only issue warnings here -- the "logError()" is supposed to come later, after
   // all warning have been logged
 
-  const auto faceType = boundaryTagToFaceType(sideBC);
+  const auto faceType = faceMap.at(sideBC);
 
   if (faceType.has_value()) {
 
@@ -118,7 +120,7 @@ inline bool
     if (getBCType(faceType.value()) == BCType::Internal) {
       if (cellNeighbors[side] < 0 && !face.isShared()) {
         logWarning() << "Element" << cellIdAsInFile << ", side" << side << " has a"
-                     << bcToString(sideBC)
+                     << bcToString(sideBC, faceMap)
                      << "boundary condition, but the neighboring element doesn't exist";
         return false;
       }
@@ -127,7 +129,7 @@ inline bool
     else {
       if (cellNeighbors[side] >= 0 || face.isShared()) {
         logWarning() << "Element" << cellIdAsInFile << ", side" << side << " has a"
-                     << bcToString(sideBC)
+                     << bcToString(sideBC, faceMap)
                      << "boundary condition, but a neighboring element exists";
         return false;
       }
@@ -161,6 +163,7 @@ const std::array<std::int32_t, 4> FirstFaceVertex = {0, 0, 0, 1};
 
 PUMLReader::PUMLReader(const std::string& meshFile,
                        const std::string& partitioningLib,
+                       const seissol::FaceMap& faceMap,
                        seissol::initializer::parameters::BoundaryFormat boundaryFormat,
                        seissol::initializer::parameters::TopologyFormat topologyFormat,
                        initializer::time_stepping::LtsWeights* ltsWeights,
@@ -217,7 +220,7 @@ PUMLReader::PUMLReader(const std::string& meshFile,
 
   generatePUML(meshTopology, meshGeometry);
 
-  getMesh(meshTopology, meshGeometry, boundaryFormat);
+  getMesh(meshTopology, meshGeometry, faceMap, boundaryFormat);
 }
 
 void PUMLReader::read(PumlMesh& meshTopology,
@@ -312,6 +315,7 @@ void PUMLReader::generatePUML(PumlMesh& meshTopology, PumlMesh& meshGeometry) {
 
 void PUMLReader::getMesh(const PumlMesh& meshTopology,
                          const PumlMesh& meshGeometry,
+                         const FaceMap& faceMap,
                          seissol::initializer::parameters::BoundaryFormat boundaryFormat) {
   SCOREP_USER_REGION("PUMLReader_getmesh", SCOREP_USER_REGION_TYPE_FUNCTION);
 
@@ -358,7 +362,7 @@ void PUMLReader::getMesh(const PumlMesh& meshTopology,
     for (std::size_t j = 0; j < Cell::NumFaces; j++) {
       const auto faceTag = decodeBoundary(boundaryCond, i, j, boundaryFormat);
       const bool isLocallyCorrect = checkMeshCorrectnessLocally<PumlTopology>(
-          faces[faceids[j]], neighbors, j, faceTag, cellIdsAsInFile[i]);
+          faces[faceids[j]], neighbors, j, faceTag, cellIdsAsInFile[i], faceMap);
       isMeshCorrect &= isLocallyCorrect;
       if (neighbors[j] < 0) {
         m_elements[i].neighbors[PumlFaceToSeisSol[j]] = cellsGeometry.size();
@@ -401,7 +405,7 @@ void PUMLReader::getMesh(const PumlMesh& meshTopology,
         m_elements[i].neighborRanks[PumlFaceToSeisSol[j]] = rank;
       }
 
-      const auto bcCurrentFace = boundaryTagToFaceType(faceTag);
+      const auto bcCurrentFace = faceMap.at(faceTag);
 
       m_elements[i].boundaries[PumlFaceToSeisSol[j]] = bcCurrentFace.value_or(FaceType::Regular);
       m_elements[i].faultTags[PumlFaceToSeisSol[j]] = faceTag;

--- a/src/Geometry/PUMLReader.cpp
+++ b/src/Geometry/PUMLReader.cpp
@@ -79,7 +79,7 @@ inline std::string bcToString(uint32_t id, const FaceMap& faceMap) {
   } else if (type == FaceType::Outflow) {
     return std::string("outflow");
   } else if (type == FaceType::Analytical) {
-    return std::string("analytic");
+    return std::string("analytical");
   } else if (type == FaceType::DynamicRupture) {
     std::stringstream s;
     s << "dynamic rupture (face tag " << id << ")";

--- a/src/Geometry/PUMLReader.cpp
+++ b/src/Geometry/PUMLReader.cpp
@@ -43,6 +43,8 @@
 #include <utils/logger.h>
 #include <vector>
 
+namespace seissol::geometry {
+
 namespace {
 
 // PUML sanity checks
@@ -59,47 +61,26 @@ void logassertI(bool condition, const std::string& file, int line) {
 
 #define logassert(x) logassertI(x, __FILE__, __LINE__)
 
-/*
- * Possible types of boundary conditions for SeisSol.
- */
-enum class BCType { Internal, External, Unknown };
-
-/**
- * Decodes the boundary condition tag into a BCType.
- */
-constexpr BCType bcToType(int id) {
-  if (id == 0 || id == 3 || id == 6 || id > 64) {
-    return BCType::Internal;
-  } else if (id == 1 || id == 2 || id == 4 || id == 5 || id == 7) {
-    return BCType::External;
-  } else {
-    return BCType::Unknown;
-  }
-}
-
 /**
  * Decodes the boundary condition tag into a string representation.
  */
-inline std::string bcToString(int id) {
-  if (id == 0) {
+inline std::string bcToString(uint32_t id) {
+  const auto type = boundaryTagToFaceType(id);
+  if (type == FaceType::Regular) {
     return std::string("regular");
-  } else if (id == 1) {
+  } else if (type == FaceType::FreeSurface) {
     return std::string("free surface");
-  } else if (id == 2) {
+  } else if (type == FaceType::FreeSurfaceGravity) {
     return std::string("free surface with gravity");
-  } else if (id == 3) {
-    return std::string("dynamic rupture");
-  } else if (id == 4) {
+  } else if (type == FaceType::Dirichlet) {
     return std::string("dirichlet");
-  } else if (id == 5) {
-    return std::string("absorbing");
-  } else if (id == 6) {
-    return std::string("periodic");
-  } else if (id == 7) {
+  } else if (type == FaceType::Outflow) {
+    return std::string("outflow");
+  } else if (type == FaceType::Analytical) {
     return std::string("analytic");
-  } else if (id > 64) {
+  } else if (type == FaceType::DynamicRupture) {
     std::stringstream s;
-    s << "fault-tagging (" << id << ")";
+    s << "dynamic rupture (face tag " << id << ")";
     return s.str();
   } else {
     std::stringstream s;
@@ -122,34 +103,40 @@ template <PUML::TopoType Topo>
 inline bool
     checkMeshCorrectnessLocally(const typename PUML::PUML<Topo>::face_t& face,
                                 const std::array<int, seissol::Cell::NumFaces>& cellNeighbors,
-                                int side,
-                                int sideBC,
+                                uint8_t side,
+                                uint32_t sideBC,
                                 uint64_t cellIdAsInFile) {
   // all of these will only issue warnings here -- the "logError()" is supposed to come later, after
   // all warning have been logged
 
-  // if a face is an internal face, it has to have a neighbor on either this rank or somewhere else:
-  if (bcToType(sideBC) == BCType::Internal) {
-    if (cellNeighbors[side] < 0 && !face.isShared()) {
-      logWarning() << "Element" << cellIdAsInFile << ", side" << side << " has a"
-                   << bcToString(sideBC)
-                   << "boundary condition, but the neighboring element doesn't exist";
-      return false;
+  const auto faceType = boundaryTagToFaceType(sideBC);
+
+  if (faceType.has_value()) {
+
+    // if a face is an internal face, it has to have a neighbor on either this rank or somewhere
+    // else:
+    if (getBCType(faceType.value()) == BCType::Internal) {
+      if (cellNeighbors[side] < 0 && !face.isShared()) {
+        logWarning() << "Element" << cellIdAsInFile << ", side" << side << " has a"
+                     << bcToString(sideBC)
+                     << "boundary condition, but the neighboring element doesn't exist";
+        return false;
+      }
     }
-  }
-  // external boundaries must not have neighboring elements:
-  else if (bcToType(sideBC) == BCType::External) {
-    if (cellNeighbors[side] >= 0 || face.isShared()) {
-      logWarning() << "Element" << cellIdAsInFile << ", side" << side << " has a"
-                   << bcToString(sideBC) << "boundary condition, but a neighboring element exists";
-      return false;
+    // external boundaries must not have neighboring elements:
+    else {
+      if (cellNeighbors[side] >= 0 || face.isShared()) {
+        logWarning() << "Element" << cellIdAsInFile << ", side" << side << " has a"
+                     << bcToString(sideBC)
+                     << "boundary condition, but a neighboring element exists";
+        return false;
+      }
     }
-  }
-  // ignore unknown boundary conditions and warn
-  else {
+  } else {
+    // ignore unknown boundary conditions and warn
     logWarning() << "Element" << cellIdAsInFile << ", side" << side << " has a boundary condition ("
                  << sideBC << ") which is not understood by this version of SeisSol";
-    return true;
+    return false;
   }
   return true;
 }
@@ -171,8 +158,6 @@ const std::array<std::array<std::int32_t, 4>, 4> FaceVertexToOrientation = {
 // FaceVertexToOrientation[i] to not be -1)
 const std::array<std::int32_t, 4> FirstFaceVertex = {0, 0, 0, 1};
 } // namespace
-
-namespace seissol::geometry {
 
 PUMLReader::PUMLReader(const std::string& meshFile,
                        const std::string& partitioningLib,
@@ -371,9 +356,9 @@ void PUMLReader::getMesh(const PumlMesh& meshTopology,
     PUML::Neighbor::face(meshTopology, i, neighbors.data());
 
     for (std::size_t j = 0; j < Cell::NumFaces; j++) {
-      int bcCurrentFace = decodeBoundary(boundaryCond, i, j, boundaryFormat);
+      const auto faceTag = decodeBoundary(boundaryCond, i, j, boundaryFormat);
       const bool isLocallyCorrect = checkMeshCorrectnessLocally<PumlTopology>(
-          faces[faceids[j]], neighbors, j, bcCurrentFace, cellIdsAsInFile[i]);
+          faces[faceids[j]], neighbors, j, faceTag, cellIdsAsInFile[i]);
       isMeshCorrect &= isLocallyCorrect;
       if (neighbors[j] < 0) {
         m_elements[i].neighbors[PumlFaceToSeisSol[j]] = cellsGeometry.size();
@@ -416,12 +401,10 @@ void PUMLReader::getMesh(const PumlMesh& meshTopology,
         m_elements[i].neighborRanks[PumlFaceToSeisSol[j]] = rank;
       }
 
-      const int faultTag = bcCurrentFace;
-      if (bcCurrentFace > 64) {
-        bcCurrentFace = 3;
-      }
-      m_elements[i].boundaries[PumlFaceToSeisSol[j]] = bcCurrentFace;
-      m_elements[i].faultTags[PumlFaceToSeisSol[j]] = faultTag;
+      const auto bcCurrentFace = boundaryTagToFaceType(faceTag);
+
+      m_elements[i].boundaries[PumlFaceToSeisSol[j]] = bcCurrentFace.value_or(FaceType::Regular);
+      m_elements[i].faultTags[PumlFaceToSeisSol[j]] = faceTag;
       m_elements[i].mpiIndices[PumlFaceToSeisSol[j]] = 0;
     }
 

--- a/src/Geometry/PUMLReader.cpp
+++ b/src/Geometry/PUMLReader.cpp
@@ -12,6 +12,7 @@
 #include "Common/Iterator.h"
 #include "Geometry/MeshDefinition.h"
 #include "Geometry/MeshReader.h"
+#include "Initializer/BasicTypedefs.h"
 #include "Initializer/FaceMap.h"
 #include "Initializer/Parameters/MeshParameters.h"
 #include "Initializer/TimeStepping/LtsWeights/LtsWeights.h"

--- a/src/Geometry/PUMLReader.h
+++ b/src/Geometry/PUMLReader.h
@@ -24,10 +24,10 @@ namespace seissol::geometry {
 constexpr PUML::TopoType PumlTopology = PUML::TETRAHEDRON;
 using PumlMesh = PUML::PUML<PumlTopology>;
 
-inline int decodeBoundary(const void* data,
-                          size_t cell,
-                          int face,
-                          seissol::initializer::parameters::BoundaryFormat format) {
+inline uint32_t decodeBoundary(const void* data,
+                               size_t cell,
+                               uint8_t face,
+                               seissol::initializer::parameters::BoundaryFormat format) {
   if (format == seissol::initializer::parameters::BoundaryFormat::I32) {
     const auto* dataCasted = reinterpret_cast<const uint32_t*>(data);
     return (dataCasted[cell] >> (8 * face)) & 0xff;
@@ -35,12 +35,38 @@ inline int decodeBoundary(const void* data,
     const auto* dataCasted = reinterpret_cast<const uint64_t*>(data);
     return (dataCasted[cell] >> (16 * face)) & 0xffff;
   } else if (format == seissol::initializer::parameters::BoundaryFormat::I32x4) {
-    const int* dataCasted = reinterpret_cast<const int*>(data);
+    const auto* dataCasted = reinterpret_cast<const int*>(data);
     return dataCasted[cell * Cell::NumFaces + face];
   } else {
-    logError() << "Unknown boundary format:" << static_cast<int>(format);
+    logError() << "Unknown boundary format:" << static_cast<uint32_t>(format);
     return 0;
   }
+}
+
+inline std::optional<FaceType> boundaryTagToFaceType(uint32_t tag) {
+  if (tag == 0 || tag == 6) {
+    return FaceType::Regular;
+  }
+  if (tag == 1) {
+    return FaceType::FreeSurface;
+  }
+  if (tag == 2) {
+    return FaceType::FreeSurfaceGravity;
+  }
+  if (tag == 3 || tag > 64) {
+    return FaceType::DynamicRupture;
+  }
+  if (tag == 4) {
+    return FaceType::Dirichlet;
+  }
+  if (tag == 5) {
+    return FaceType::Outflow;
+  }
+  if (tag == 7) {
+    return FaceType::Analytical;
+  }
+
+  return {};
 }
 
 class PUMLReader : public seissol::geometry::MeshReader {

--- a/src/Geometry/PUMLReader.h
+++ b/src/Geometry/PUMLReader.h
@@ -9,6 +9,7 @@
 #ifndef SEISSOL_SRC_GEOMETRY_PUMLREADER_H_
 #define SEISSOL_SRC_GEOMETRY_PUMLREADER_H_
 
+#include "Initializer/FaceMap.h"
 #include "Initializer/Parameters/MeshParameters.h"
 #include "MeshReader.h"
 #include "Parallel/MPI.h"
@@ -43,36 +44,11 @@ inline uint32_t decodeBoundary(const void* data,
   }
 }
 
-inline std::optional<FaceType> boundaryTagToFaceType(uint32_t tag) {
-  if (tag == 0 || tag == 6) {
-    return FaceType::Regular;
-  }
-  if (tag == 1) {
-    return FaceType::FreeSurface;
-  }
-  if (tag == 2) {
-    return FaceType::FreeSurfaceGravity;
-  }
-  if (tag == 3 || tag > 64) {
-    return FaceType::DynamicRupture;
-  }
-  if (tag == 4) {
-    return FaceType::Dirichlet;
-  }
-  if (tag == 5) {
-    return FaceType::Outflow;
-  }
-  if (tag == 7) {
-    return FaceType::Analytical;
-  }
-
-  return {};
-}
-
 class PUMLReader : public seissol::geometry::MeshReader {
   public:
   PUMLReader(const std::string& meshFile,
              const std::string& partitioningLib,
+             const seissol::FaceMap& faceMap,
              seissol::initializer::parameters::BoundaryFormat boundaryFormat =
                  seissol::initializer::parameters::BoundaryFormat::I32,
              seissol::initializer::parameters::TopologyFormat topologyFormat =
@@ -110,6 +86,7 @@ class PUMLReader : public seissol::geometry::MeshReader {
    */
   void getMesh(const PumlMesh& meshTopology,
                const PumlMesh& meshGeometry,
+               const FaceMap& faceMap,
                seissol::initializer::parameters::BoundaryFormat boundaryFormat);
 
   void

--- a/src/Initializer/BasicTypedefs.h
+++ b/src/Initializer/BasicTypedefs.h
@@ -36,27 +36,55 @@ enum class FaceType : uint8_t {
   // absorbing/outflow boundary
   Outflow = 5,
 
-  // periodic boundary
-  Periodic = 6,
+  // periodic boundary (obsolete; now equivalent to Regular)
+  // Periodic = 6,
 
   // analytical boundary (from initial cond.)
   Analytical = 7
 };
 
+enum class BCType {
+  // an internal face, with a neighbor
+  Internal,
+
+  // a boundary face with a fake neighbor
+  ExternalFake,
+
+  // a boundary face without a fake neighbor
+  ExternalNone,
+
+  // unhandled face type
+  Unknown
+};
+
 // Once the FaceType enum is updated, make sure to update these methods here as well.
+
+constexpr BCType getBCType(FaceType faceType) {
+  if (faceType == FaceType::Regular || faceType == FaceType::DynamicRupture) {
+    return BCType::Internal;
+  }
+  if (faceType == FaceType::FreeSurface || faceType == FaceType::FreeSurfaceGravity ||
+      faceType == FaceType::Dirichlet || faceType == FaceType::Analytical) {
+    return BCType::ExternalFake;
+  }
+  if (faceType == FaceType::Outflow) {
+    return BCType::ExternalNone;
+  }
+
+  // should never happen, unless you forgot to implement something
+  return BCType::Unknown;
+}
 
 // Checks if a face type is an internal face (i.e. there are two cells adjacent to it).
 // That includes all interior and dynamic rupture faces, but also periodic faces.
 constexpr bool isInternalFaceType(FaceType faceType) {
-  return faceType == FaceType::Regular || faceType == FaceType::DynamicRupture ||
-         faceType == FaceType::Periodic;
+  return getBCType(faceType) == BCType::Internal;
 }
 
 // Checks if a face type is an external boundary face (i.e. there is only one cell adjacent to it).
 // (note that Outflow is purposefully excluded here)
 constexpr bool isExternalBoundaryFaceType(FaceType faceType) {
-  return faceType == FaceType::FreeSurface || faceType == FaceType::FreeSurfaceGravity ||
-         faceType == FaceType::Dirichlet || faceType == FaceType::Analytical;
+  return getBCType(faceType) == BCType::ExternalFake;
 }
 
 enum class ComputeGraphType {

--- a/src/Initializer/BasicTypedefs.h
+++ b/src/Initializer/BasicTypedefs.h
@@ -50,10 +50,10 @@ enum class BCType {
   // an internal face, with a neighbor
   Internal,
 
-  // a boundary face with a fake neighbor
+  // a boundary face with a fake neighbor (it needs the Neighbor kernel)
   ExternalFake,
 
-  // a boundary face without a fake neighbor
+  // a boundary face without a fake neighbor (can handle everything in the Local kernel)
   ExternalNone,
 
   // unhandled face type
@@ -67,12 +67,12 @@ constexpr BCType getBCType(FaceType faceType) {
     return BCType::Internal;
   }
   if (faceType == FaceType::FreeSurface || faceType == FaceType::FreeSurfaceGravity ||
-      faceType == FaceType::Dirichlet || faceType == FaceType::Analytical) {
-    return BCType::ExternalFake;
-  }
-  if (faceType == FaceType::Outflow) {
+      faceType == FaceType::Dirichlet || faceType == FaceType::Analytical ||
+      faceType == FaceType::Outflow) {
     return BCType::ExternalNone;
   }
+
+  // currently, there is no ExternalFake BC
 
   // should never happen, unless you forgot to implement something
   return BCType::Unknown;
@@ -82,12 +82,6 @@ constexpr BCType getBCType(FaceType faceType) {
 // That includes all interior and dynamic rupture faces, but also periodic faces.
 constexpr bool isInternalFaceType(FaceType faceType) {
   return getBCType(faceType) == BCType::Internal;
-}
-
-// Checks if a face type is an external boundary face (i.e. there is only one cell adjacent to it).
-// (note that Outflow is purposefully excluded here)
-constexpr bool isExternalBoundaryFaceType(FaceType faceType) {
-  return getBCType(faceType) == BCType::ExternalFake;
 }
 
 enum class ComputeGraphType {

--- a/src/Initializer/BasicTypedefs.h
+++ b/src/Initializer/BasicTypedefs.h
@@ -13,33 +13,36 @@ namespace seissol {
 
 enum class HaloType { Ghost, Copy, Interior };
 
-// face types
-// Note: When introducting new types also change
-// int seissol::initializer::time_stepping::LtsWeights::getBoundaryCondition
-// and PUMLReader. Otherwise it might become a DR face...
+/*
+  Face types that a tetrahedron face may assume.
+
+  Note: When introducting new types also change
+  the defaultFaceMap() (FaceMap.cpp), the docs,
+  and the methods below. Otherwise, it'll probably cause bugs and errors.
+*/
 enum class FaceType : uint8_t {
-  // regular: inside the computational domain
+  // regular: inside the computational domain (interior face, linear)
   Regular = 0,
 
-  // free surface boundary
+  // free surface boundary (boundary, linear)
   FreeSurface = 1,
 
-  // free surface boundary with gravity
+  // free surface boundary with gravity (boundary, nonlinear)
   FreeSurfaceGravity = 2,
 
-  // dynamic rupture boundary
+  // dynamic rupture boundary (interior face, nonlinear)
   DynamicRupture = 3,
 
-  // Dirichlet boundary
+  // Dirichlet boundary (boundary, nonlinear)
   Dirichlet = 4,
 
-  // absorbing/outflow boundary
+  // absorbing/outflow boundary (boundary, linear)
   Outflow = 5,
 
   // periodic boundary (obsolete; now equivalent to Regular)
   // Periodic = 6,
 
-  // analytical boundary (from initial cond.)
+  // analytical boundary, taken from the initial conditions (boundary, nonlinear)
   Analytical = 7
 };
 

--- a/src/Initializer/BatchRecorders/DataTypes/EncodedConstants.h
+++ b/src/Initializer/BatchRecorders/DataTypes/EncodedConstants.h
@@ -122,8 +122,7 @@ enum struct FaceKinds : size_t {
   FreeSurface = 1 << 1,
   Outflow = 1 << 2,
   DynamicRupture = 1 << 3,
-  Periodic = 1 << 4,
-  Count = 5,
+  Count = 4,
   None = encodeAny(Count)
 };
 

--- a/src/Initializer/BatchRecorders/NeighIntegrationRecorder.cpp
+++ b/src/Initializer/BatchRecorders/NeighIntegrationRecorder.cpp
@@ -59,8 +59,7 @@ void NeighIntegrationRecorder::recordDofsTimeEvaluation() {
 
           // maybe, because of BCs, a pointer can be a nullptr, i.e. skip it
           if (neighborBuffer != nullptr) {
-            if (dataHost.get<LTS::CellInformation>().faceTypes[face] != FaceType::Outflow &&
-                dataHost.get<LTS::CellInformation>().faceTypes[face] != FaceType::DynamicRupture) {
+            if (dataHost.get<LTS::CellInformation>().faceTypes[face] == FaceType::Regular) {
 
               const bool isNeighbProvidesDerivatives =
                   dataHost.get<LTS::CellInformation>().ltsSetup.neighborHasDerivatives(face);
@@ -160,9 +159,6 @@ void NeighIntegrationRecorder::recordNeighborFluxIntegrals() {
         }
         break;
       }
-      case FaceType::FreeSurface: {
-        break;
-      }
       case FaceType::DynamicRupture: {
         const auto faceRelation =
             drMappingDevice[cell][face].side + 4 * drMappingDevice[cell][face].faceRelation;
@@ -177,6 +173,8 @@ void NeighIntegrationRecorder::recordNeighborFluxIntegrals() {
 #endif
         break;
       }
+      case FaceType::FreeSurface:
+        [[fallthrough]];
       case FaceType::Outflow:
         [[fallthrough]];
       case FaceType::Analytical:
@@ -185,8 +183,7 @@ void NeighIntegrationRecorder::recordNeighborFluxIntegrals() {
         [[fallthrough]];
       case FaceType::Dirichlet: {
         // Do not need to compute anything in the neighboring macro-kernel
-        // for outflow, analytical, freeSurfaceGravity and dirichlet
-        // boundary conditions
+        // for most boundary conditions
         break;
       }
       default: {

--- a/src/Initializer/BatchRecorders/NeighIntegrationRecorder.cpp
+++ b/src/Initializer/BatchRecorders/NeighIntegrationRecorder.cpp
@@ -202,7 +202,7 @@ void NeighIntegrationRecorder::recordNeighborFluxIntegrals() {
     for (size_t faceRelation = 0; faceRelation < (*FaceRelations::Count); ++faceRelation) {
       if (!regularPeriodicDofs[face][faceRelation].empty()) {
         const ConditionalKey key(
-            *KernelNames::NeighborFlux, FaceKinds::Regular, face, faceRelation);
+            *KernelNames::NeighborFlux, *FaceKinds::Regular, face, faceRelation);
         checkKey(key);
 
         (*currentTable)[key].set(inner_keys::Wp::Id::Idofs,

--- a/src/Initializer/BatchRecorders/NeighIntegrationRecorder.cpp
+++ b/src/Initializer/BatchRecorders/NeighIntegrationRecorder.cpp
@@ -134,9 +134,7 @@ void NeighIntegrationRecorder::recordNeighborFluxIntegrals() {
 
     for (std::size_t face = 0; face < Cell::NumFaces; face++) {
       switch (dataHost.get<LTS::CellInformation>().faceTypes[face]) {
-      case FaceType::Regular:
-        [[fallthrough]];
-      case FaceType::Periodic: {
+      case FaceType::Regular: {
         // compute face type relation
 
         real* neighborBufferPtr = faceNeighborsDevice[cell][face];
@@ -203,10 +201,8 @@ void NeighIntegrationRecorder::recordNeighborFluxIntegrals() {
     // regular and periodic
     for (size_t faceRelation = 0; faceRelation < (*FaceRelations::Count); ++faceRelation) {
       if (!regularPeriodicDofs[face][faceRelation].empty()) {
-        const ConditionalKey key(*KernelNames::NeighborFlux,
-                                 (FaceKinds::Regular || FaceKinds::Periodic),
-                                 face,
-                                 faceRelation);
+        const ConditionalKey key(
+            *KernelNames::NeighborFlux, FaceKinds::Regular, face, faceRelation);
         checkKey(key);
 
         (*currentTable)[key].set(inner_keys::Wp::Id::Idofs,

--- a/src/Initializer/FaceMap.cpp
+++ b/src/Initializer/FaceMap.cpp
@@ -8,16 +8,20 @@
 
 #include "Initializer/BasicTypedefs.h"
 
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <unordered_map>
 #include <utils/logger.h>
 #include <utils/stringutils.h>
 #include <yaml-cpp/yaml.h>
 
 namespace seissol {
 
-FaceMap parseFaceMap(YAML::Node node) {
+FaceMap parseFaceMap(const YAML::Node& node) {
   FaceMap map;
 
-  const static std::unordered_map<std::string, FaceType> stringToNameMap = {
+  const static std::unordered_map<std::string, FaceType> StringToNameMap = {
       {"regular", FaceType::Regular},
       {"freeSurface", FaceType::FreeSurface},
       {"freeSurfaceGravity", FaceType::FreeSurfaceGravity},
@@ -29,8 +33,8 @@ FaceMap parseFaceMap(YAML::Node node) {
 
   for (const auto& entry : node) {
     const auto stringType = entry.first.as<std::string>();
-    const auto typeFind = stringToNameMap.find(stringType);
-    if (typeFind == stringToNameMap.end()) {
+    const auto typeFind = StringToNameMap.find(stringType);
+    if (typeFind == StringToNameMap.end()) {
       logError() << "";
     }
     const auto type = typeFind->second;

--- a/src/Initializer/FaceMap.cpp
+++ b/src/Initializer/FaceMap.cpp
@@ -41,12 +41,23 @@ FaceMap parseFaceMap(const YAML::Node& node) {
 
     const auto processEntry = [&](const auto& listEntry) {
       auto strParts = utils::StringUtils::split(listEntry, ',');
+      if (utils::StringUtils::endsWith(listEntry, ",")) {
+        // FIXME: the StringUtils::split does not consider TRAILING '-'s in this case.
+        strParts.emplace_back();
+      }
+
       for (auto& part : strParts) {
         std::optional<uint32_t> lower;
         std::optional<uint32_t> upper;
 
         utils::StringUtils::trim(part);
         auto subParts = utils::StringUtils::split(part, '-');
+
+        if (utils::StringUtils::endsWith(part, "-")) {
+          // FIXME: the StringUtils::split does not consider TRAILING '-'s in this case.
+          subParts.emplace_back();
+        }
+
         for (auto& subPart : subParts) {
           utils::StringUtils::trim(subPart);
         }
@@ -54,18 +65,18 @@ FaceMap parseFaceMap(const YAML::Node& node) {
           lower = std::stoi(subParts[0]);
           upper = lower;
         } else if (subParts.size() == 2) {
-          if (subParts[0].empty()) {
+          if (subParts[0] == "") {
             lower = {};
           } else {
             lower = std::stoi(subParts[0]);
           }
-          if (subParts[1].empty()) {
+          if (subParts[1] == "") {
             upper = {};
           } else {
-            upper = std::stoi(subParts[0]);
+            upper = std::stoi(subParts[1]);
           }
         } else {
-          logError() << "Parsing error.";
+          logError() << "Parsing error while parsing face map. At:" << part << "i.e." << subParts;
         }
 
         map.addRange(lower, upper, type);

--- a/src/Initializer/FaceMap.cpp
+++ b/src/Initializer/FaceMap.cpp
@@ -1,0 +1,104 @@
+// SPDX-FileCopyrightText: 2026 SeisSol Group
+//
+// SPDX-License-Identifier: BSD-3-Clause
+// SPDX-LicenseComments: Full text under /LICENSE and /LICENSES/
+//
+// SPDX-FileContributor: Author lists in /AUTHORS and /CITATION.cff
+#include "FaceMap.h"
+
+#include "Initializer/BasicTypedefs.h"
+
+#include <utils/logger.h>
+#include <utils/stringutils.h>
+#include <yaml-cpp/yaml.h>
+
+namespace seissol {
+
+FaceMap parseFaceMap(YAML::Node node) {
+  FaceMap map;
+
+  const static std::unordered_map<std::string, FaceType> stringToNameMap = {
+      {"regular", FaceType::Regular},
+      {"freeSurface", FaceType::FreeSurface},
+      {"freeSurfaceGravity", FaceType::FreeSurfaceGravity},
+      {"dynamicRupture", FaceType::DynamicRupture},
+      {"dirichlet", FaceType::Dirichlet},
+      {"outflow", FaceType::Outflow},
+      {"analytic", FaceType::Analytical},
+  };
+
+  for (const auto& entry : node) {
+    const auto stringType = entry.first.as<std::string>();
+    const auto typeFind = stringToNameMap.find(stringType);
+    if (typeFind == stringToNameMap.end()) {
+      logError() << "";
+    }
+    const auto type = typeFind->second;
+
+    const auto processEntry = [&](const auto& listEntry) {
+      auto strParts = utils::StringUtils::split(listEntry, ',');
+      for (auto& part : strParts) {
+        std::optional<uint32_t> lower;
+        std::optional<uint32_t> upper;
+
+        utils::StringUtils::trim(part);
+        auto subParts = utils::StringUtils::split(part, '-');
+        for (auto& subPart : subParts) {
+          utils::StringUtils::trim(subPart);
+        }
+        if (subParts.size() == 1) {
+          lower = std::stoi(subParts[0]);
+          upper = lower;
+        } else if (subParts.size() == 2) {
+          if (subParts[0].empty()) {
+            lower = {};
+          } else {
+            lower = std::stoi(subParts[0]);
+          }
+          if (subParts[1].empty()) {
+            upper = {};
+          } else {
+            upper = std::stoi(subParts[0]);
+          }
+        } else {
+          logError() << "Parsing error.";
+        }
+
+        map.addRange(lower, upper, type);
+      }
+    };
+
+    if (entry.second.IsSequence()) {
+      for (const auto& listEntry : entry.second) {
+        processEntry(listEntry.as<std::string>());
+      }
+    } else {
+      processEntry(entry.second.as<std::string>());
+    }
+  }
+
+  return map;
+}
+
+FaceMap defaultFaceMap() {
+  FaceMap map;
+
+  map.addEntry(0, FaceType::Regular);
+  map.addEntry(6, FaceType::Regular);
+
+  map.addEntry(1, FaceType::FreeSurface);
+  map.addEntry(2, FaceType::FreeSurfaceGravity);
+
+  map.addEntry(3, FaceType::DynamicRupture);
+  map.addRange(65, {}, FaceType::DynamicRupture);
+
+  map.addEntry(4, FaceType::Dirichlet);
+
+  map.addEntry(5, FaceType::Outflow);
+
+  map.addEntry(7, FaceType::Analytical);
+
+  return map;
+}
+
+} // namespace seissol

--- a/src/Initializer/FaceMap.cpp
+++ b/src/Initializer/FaceMap.cpp
@@ -28,7 +28,7 @@ FaceMap parseFaceMap(const YAML::Node& node) {
       {"dynamicRupture", FaceType::DynamicRupture},
       {"dirichlet", FaceType::Dirichlet},
       {"outflow", FaceType::Outflow},
-      {"analytic", FaceType::Analytical},
+      {"analytical", FaceType::Analytical},
   };
 
   for (const auto& entry : node) {

--- a/src/Initializer/FaceMap.h
+++ b/src/Initializer/FaceMap.h
@@ -12,13 +12,13 @@
 
 namespace YAML {
 class Node;
-}
+} // namespace YAML
 
 namespace seissol {
 
 using FaceMap = SegmentMap<uint32_t, FaceType>;
 
-FaceMap parseFaceMap(YAML::Node node);
+FaceMap parseFaceMap(const YAML::Node& node);
 FaceMap defaultFaceMap();
 
 } // namespace seissol

--- a/src/Initializer/FaceMap.h
+++ b/src/Initializer/FaceMap.h
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: 2026 SeisSol Group
+//
+// SPDX-License-Identifier: BSD-3-Clause
+// SPDX-LicenseComments: Full text under /LICENSE and /LICENSES/
+//
+// SPDX-FileContributor: Author lists in /AUTHORS and /CITATION.cff
+#ifndef SEISSOL_SRC_INITIALIZER_FACEMAP_H_
+#define SEISSOL_SRC_INITIALIZER_FACEMAP_H_
+
+#include "Common/SegmentMap.h"
+#include "Initializer/BasicTypedefs.h"
+
+namespace YAML {
+class Node;
+}
+
+namespace seissol {
+
+using FaceMap = SegmentMap<uint32_t, FaceType>;
+
+FaceMap parseFaceMap(YAML::Node node);
+FaceMap defaultFaceMap();
+
+} // namespace seissol
+#endif // SEISSOL_SRC_INITIALIZER_FACEMAP_H_

--- a/src/Initializer/InitProcedure/InitLayout.cpp
+++ b/src/Initializer/InitProcedure/InitLayout.cpp
@@ -227,7 +227,7 @@ void setupMemory(seissol::SeisSol& seissolInstance) {
         secondaryCellInformation[index].group = element.group;
         for (std::size_t face = 0; face < Cell::NumFaces; ++face) {
           secondaryCellInformation[index].neighborRanks[face] = element.neighborRanks[face];
-          cellInformation[index].faceTypes[face] = static_cast<FaceType>(element.boundaries[face]);
+          cellInformation[index].faceTypes[face] = element.boundaries[face];
           cellInformation[index].faceRelations[face][0] = element.neighborSides[face];
           cellInformation[index].faceRelations[face][1] = element.sideOrientations[face];
 
@@ -283,7 +283,7 @@ void setupMemory(seissol::SeisSol& seissolInstance) {
           secondaryCellInformation[i].neighborRanks[face] = rank;
           cellInformation[i].neighborConfigIds[face] = neighbor.color;
           cellInformation[i].faceTypes[face] =
-              static_cast<FaceType>(elementNeighbor.boundaries[boundaryElement.localSide]);
+              elementNeighbor.boundaries[boundaryElement.localSide];
           cellInformation[i].faceRelations[face][0] = boundaryElement.localSide;
           cellInformation[i].faceRelations[face][1] =
               elementNeighbor.sideOrientations[boundaryElement.localSide];

--- a/src/Initializer/InitProcedure/InitMesh.cpp
+++ b/src/Initializer/InitProcedure/InitMesh.cpp
@@ -30,6 +30,7 @@
 
 #include <hdf5.h>
 #endif // defined(USE_HDF)
+#include "Initializer/FaceMap.h"
 #include "Initializer/TimeStepping/LtsWeights/WeightsFactory.h"
 #include "Modules/Modules.h"
 #include "Monitoring/Stopwatch.h"
@@ -276,6 +277,16 @@ void readMeshPUML(const seissol::initializer::parameters::SeisSolParameters& sei
   seissol::Stopwatch watch;
   watch.start();
 
+  const auto faceMap = [&]() {
+    const auto faceMapFile = seissolParams.mesh.faceMapFile;
+    if (faceMapFile.has_value()) {
+      const auto yamlNode = YAML::Load(faceMapFile.value());
+      return parseFaceMap(yamlNode);
+    } else {
+      return defaultFaceMap();
+    }
+  }();
+
   using namespace seissol::initializer::time_stepping;
   const LtsWeightsConfig config{
       boundaryFormat,
@@ -288,6 +299,7 @@ void readMeshPUML(const seissol::initializer::parameters::SeisSolParameters& sei
       seissolParams.timeStepping.lts.getLtsWeightsType(), config, seissolInstance);
   auto* meshReader = new seissol::geometry::PUMLReader(seissolParams.mesh.meshFileName,
                                                        seissolParams.mesh.partitioningLib,
+                                                       faceMap,
                                                        boundaryFormat,
                                                        topologyFormat,
                                                        ltsWeights.get(),

--- a/src/Initializer/InitProcedure/Internal/Buckets.cpp
+++ b/src/Initializer/InitProcedure/Internal/Buckets.cpp
@@ -281,7 +281,7 @@ void setupFaceNeighbors(LTS::Storage& storage, LTS::Layer& layer) {
   for (std::size_t cell = 0; cell < layer.size(); ++cell) {
     for (std::size_t face = 0; face < Cell::NumFaces; ++face) {
       const auto& faceNeighbor = secondaryCellInformation[cell].faceNeighbors[face];
-      if (cellInformation[cell].faceTypes[face] != FaceType::Outflow) {
+      if (getBCType(cellInformation[cell].faceTypes[face]) != BCType::ExternalNone) {
         if (faceNeighbor == StoragePosition::NullPosition) {
           if (cellInformation[cell].ltsSetup.neighborHasDerivatives(face)) {
             faceNeighbors[cell][face] = layer.var<LTS::Derivatives>()[cell];

--- a/src/Initializer/InitProcedure/Internal/LtsSetup.cpp
+++ b/src/Initializer/InitProcedure/Internal/LtsSetup.cpp
@@ -102,10 +102,13 @@ LtsSetup getLtsSetup(const CellLocalInformation& ownPrimary,
 
   // iterate over the faces
   for (std::size_t face = 0; face < Cell::NumFaces; ++face) {
-    if (ownPrimary.faceTypes[face] == FaceType::Outflow) {
+
+    const auto bcType = getBCType(ownPrimary.faceTypes[face]);
+
+    if (bcType == BCType::ExternalNone) {
       // continue for outflow boundary conditions
       continue;
-    } else if (isExternalBoundaryFaceType(ownPrimary.faceTypes[face])) {
+    } else if (bcType == BCType::ExternalFake) {
       // fake neighbors are GTS
       ltsSetup.setNeighborGTSRelation(face, true);
     } else if (ownPrimary.faceTypes[face] == FaceType::DynamicRupture) {

--- a/src/Initializer/InitProcedure/Internal/LtsSetup.cpp
+++ b/src/Initializer/InitProcedure/Internal/LtsSetup.cpp
@@ -106,9 +106,10 @@ LtsSetup getLtsSetup(const CellLocalInformation& ownPrimary,
     const auto bcType = getBCType(ownPrimary.faceTypes[face]);
 
     if (bcType == BCType::ExternalNone) {
-      // continue for outflow boundary conditions
+      // continue for external boundary conditions without Neighbor kernel usage
       continue;
     } else if (bcType == BCType::ExternalFake) {
+      // needs the Neighbor kernel for whatever reason; add the cell itself as a fake neighbor
       // fake neighbors are GTS
       ltsSetup.setNeighborGTSRelation(face, true);
     } else if (ownPrimary.faceTypes[face] == FaceType::DynamicRupture) {
@@ -161,16 +162,15 @@ LtsSetup getLtsSetup(const CellLocalInformation& ownPrimary,
   }
 
   /*
-   * Normalize for special case "free surface/dirichlet on derivatives":
+   * Normalize for special case ExternalFake boundary types:
    *   If a cell provides either buffers in a LTS fashion or derivatives only,
    *   the neighboring contribution of the boundary intergral is required to work on the cells
-   * derivatives. Free surface/dirichlet boundary conditions work on the cells DOFs in the
-   * neighboring contribution: Enable cell local derivatives in this case and mark that the "fake
-   * neighbor" provides derivatives.
+   * derivatives. It's mostly non-relevant by now (all these operations can be done in the local
+   * kernel); but maybe it'll be required again at some point.
    */
   for (std::size_t face = 0; face < Cell::NumFaces; face++) {
     // check for special case free-surface/dirichlet requirements
-    const bool isSpecialCase = isExternalBoundaryFaceType(ownPrimary.faceTypes[face]);
+    const bool isSpecialCase = getBCType(ownPrimary.faceTypes[face]) == BCType::ExternalFake;
 
     // need special case face and either LTS buffers, or no buffers at all
     if (isSpecialCase && (ltsSetup.accumulateBuffers() || !ltsSetup.hasBuffers())) {

--- a/src/Initializer/MemoryManager.cpp
+++ b/src/Initializer/MemoryManager.cpp
@@ -172,8 +172,7 @@ void MemoryManager::deriveRequiredScratchpadMemoryForWp(bool plasticity, LTS::St
 
           // maybe, because of BCs, a pointer can be a nullptr, i.e. skip it
           if (neighborBuffer != nullptr) {
-            if (cellInformation[cell].faceTypes[face] != FaceType::Outflow &&
-                cellInformation[cell].faceTypes[face] != FaceType::DynamicRupture) {
+            if (cellInformation[cell].faceTypes[face] == FaceType::Regular) {
 
               const bool isNeighbProvidesDerivatives =
                   cellInformation[cell].ltsSetup.neighborHasDerivatives(face);

--- a/src/Initializer/Parameters/MeshParameters.cpp
+++ b/src/Initializer/Parameters/MeshParameters.cpp
@@ -58,6 +58,8 @@ MeshParameters readMeshParameters(ParameterReader* baseReader) {
 
   const bool showEdgeCutStatistics = reader->readWithDefault("showedgecutstatistics", false);
 
+  const auto faceMap = reader->readPath("facemapfile");
+
   reader->warnDeprecated({"periodic", "periodic_direction"});
 
   return MeshParameters{showEdgeCutStatistics,
@@ -66,6 +68,7 @@ MeshParameters readMeshParameters(ParameterReader* baseReader) {
                         meshFormat,
                         meshFileName,
                         partitioningLib,
+                        faceMap,
                         displacement,
                         scaling};
 }

--- a/src/Initializer/Parameters/MeshParameters.cpp
+++ b/src/Initializer/Parameters/MeshParameters.cpp
@@ -11,6 +11,7 @@
 #include "Initializer/Parameters/ParameterReader.h"
 
 #include <Eigen/Core>
+#include <optional>
 
 namespace seissol::initializer::parameters {
 

--- a/src/Initializer/Parameters/MeshParameters.cpp
+++ b/src/Initializer/Parameters/MeshParameters.cpp
@@ -58,7 +58,8 @@ MeshParameters readMeshParameters(ParameterReader* baseReader) {
 
   const bool showEdgeCutStatistics = reader->readWithDefault("showedgecutstatistics", false);
 
-  const auto faceMap = reader->readPath("facemapfile");
+  const auto faceMapPre = reader->readPath("facemapfile");
+  const auto faceMap = faceMapPre == "" ? std::optional<std::string>{} : faceMapPre;
 
   reader->warnDeprecated({"periodic", "periodic_direction"});
 

--- a/src/Initializer/Parameters/MeshParameters.h
+++ b/src/Initializer/Parameters/MeshParameters.h
@@ -12,6 +12,7 @@
 #include "ParameterReader.h"
 
 #include <Eigen/Dense>
+#include <optional>
 #include <string>
 
 namespace seissol::initializer::parameters {
@@ -29,6 +30,7 @@ struct MeshParameters {
   MeshFormat meshFormat{MeshFormat::PUML};
   std::string meshFileName;
   std::string partitioningLib;
+  std::optional<std::string> faceMapFile;
   Eigen::Vector3d displacement;
   Eigen::Matrix3d scaling;
 };

--- a/src/Initializer/TimeStepping/ClusterLayout.cpp
+++ b/src/Initializer/TimeStepping/ClusterLayout.cpp
@@ -7,6 +7,7 @@
 #include "Initializer/TimeStepping/ClusterLayout.h"
 
 #include "Geometry/MeshReader.h"
+#include "Initializer/BasicTypedefs.h"
 #include "Monitoring/Unit.h"
 #include "Numerical/StableSum.h"
 #include "Numerical/Statistics.h"

--- a/src/Initializer/TimeStepping/ClusterLayout.cpp
+++ b/src/Initializer/TimeStepping/ClusterLayout.cpp
@@ -76,7 +76,7 @@ ClusterLayout ClusterLayout::fromMesh(const std::vector<std::uint64_t>& rates,
     for (const auto& element : mesh.getElements()) {
       ++clusters[static_cast<std::size_t>(element.clusterId)];
       for (int i = 0; i < 4; ++i) {
-        if (element.boundaries[i] == 3) {
+        if (element.boundaries[i] == FaceType::DynamicRupture) {
           ++clustersDR[static_cast<std::size_t>(element.clusterId)];
         }
       }

--- a/src/Kernels/LinearCK/Local.cpp
+++ b/src/Kernels/LinearCK/Local.cpp
@@ -168,7 +168,7 @@ void Local::computeIntegral(
               auto slicedBoundaryDofs = multisim::simtensor(boundaryDofs, s);
               auto slicedDisplacement = multisim::simtensor(displacement, s);
 
-              for (unsigned int i = 0;
+              for (std::size_t i = 0;
                    i < nodal::tensor::nodes2D::Shape[multisim::BasisFunctionDimension];
                    ++i) {
                 const double rho = materialData.local->getDensity();

--- a/src/Kernels/LinearCK/Neighbor.cpp
+++ b/src/Kernels/LinearCK/Neighbor.cpp
@@ -120,7 +120,7 @@ void Neighbor::computeBatchedNeighborsIntegral(
             // regular and periodic
             unsigned faceRelation = i;
 
-            ConditionalKey key(*KernelNames::NeighborFlux, FaceKinds::Regular, face, faceRelation);
+            ConditionalKey key(*KernelNames::NeighborFlux, *FaceKinds::Regular, face, faceRelation);
 
             if (table.find(key) != table.end()) {
               auto& entry = table[key];

--- a/src/Kernels/LinearCK/Neighbor.cpp
+++ b/src/Kernels/LinearCK/Neighbor.cpp
@@ -69,9 +69,7 @@ void Neighbor::computeNeighborsIntegral(
 
   for (std::size_t face = 0; face < Cell::NumFaces; face++) {
     switch (data.get<LTS::CellInformation>().faceTypes[face]) {
-    case FaceType::Regular:
-      // Fallthrough intended
-    case FaceType::Periodic: {
+    case FaceType::Regular: {
       // Standard neighboring flux
       // Compute the neighboring elements flux matrix id.
       assert(reinterpret_cast<uintptr_t>(timeIntegrated[face]) % Alignment == 0);
@@ -122,10 +120,7 @@ void Neighbor::computeBatchedNeighborsIntegral(
             // regular and periodic
             unsigned faceRelation = i;
 
-            ConditionalKey key(*KernelNames::NeighborFlux,
-                               (FaceKinds::Regular || FaceKinds::Periodic),
-                               face,
-                               faceRelation);
+            ConditionalKey key(*KernelNames::NeighborFlux, FaceKinds::Regular, face, faceRelation);
 
             if (table.find(key) != table.end()) {
               auto& entry = table[key];
@@ -203,8 +198,6 @@ void Neighbor::flopsNeighborsIntegral(
     // compute the neighboring elements flux matrix id.
     switch (faceTypes[face]) {
     case FaceType::Regular:
-      // Fallthrough intended
-    case FaceType::Periodic:
       // regular neighbor
       assert(neighboringIndices[face][0] < Cell::NumFaces && neighboringIndices[face][1] < 3);
       nonZeroFlops += kernel::neighboringFlux::nonZeroFlops(

--- a/src/Kernels/LinearCK/Neighbor.cpp
+++ b/src/Kernels/LinearCK/Neighbor.cpp
@@ -118,7 +118,7 @@ void Neighbor::computeBatchedNeighborsIntegral(
         (*FaceRelations::Count) + (*DrFaceRelations::Count), [&](void* stream, size_t i) {
           if (i < (*FaceRelations::Count)) {
             // regular and periodic
-            unsigned faceRelation = i;
+            const auto faceRelation = i;
 
             ConditionalKey key(*KernelNames::NeighborFlux, *FaceKinds::Regular, face, faceRelation);
 
@@ -147,7 +147,7 @@ void Neighbor::computeBatchedNeighborsIntegral(
               device.api->freeMemAsync(reinterpret_cast<void*>(tmpMem), stream);
             }
           } else {
-            unsigned faceRelation = i - (*FaceRelations::Count);
+            const auto faceRelation = i - (*FaceRelations::Count);
 
             ConditionalKey key(
                 *KernelNames::NeighborFlux, *FaceKinds::DynamicRupture, face, faceRelation);

--- a/src/Kernels/LinearCK/Time.cpp
+++ b/src/Kernels/LinearCK/Time.cpp
@@ -84,7 +84,7 @@ void Spacetime::computeAder(const real* coeffs,
   auto* derivativesBuffer = (timeDerivatives != nullptr) ? timeDerivatives : temporaryBuffer;
 
   kernel::derivative krnl = m_krnlPrototype;
-  for (unsigned i = 0; i < yateto::numFamilyMembers<tensor::star>(); ++i) {
+  for (std::size_t i = 0; i < yateto::numFamilyMembers<tensor::star>(); ++i) {
     krnl.star(i) = data.get<LTS::LocalIntegration>().starMatrices[i];
   }
 
@@ -92,7 +92,7 @@ void Spacetime::computeAder(const real* coeffs,
   set_ET(krnl, get_ptr_sourceMatrix(data.get<LTS::LocalIntegration>().specific));
 
   krnl.dQ(0) = const_cast<real*>(data.get<LTS::Dofs>());
-  for (unsigned i = 1; i < yateto::numFamilyMembers<tensor::dQ>(); ++i) {
+  for (std::size_t i = 1; i < yateto::numFamilyMembers<tensor::dQ>(); ++i) {
     krnl.dQ(i) = derivativesBuffer + yateto::computeFamilySize<tensor::dQ>(1, i);
   }
 
@@ -156,14 +156,14 @@ void Spacetime::computeBatchedAder(
     derivativesKrnl.I = (entry.get(inner_keys::Wp::Id::Idofs))->getDeviceDataPtr();
 
     SEISSOL_ARRAY_OFFSET_ASSERT(LocalIntegrationData, starMatrices);
-    for (unsigned i = 0; i < yateto::numFamilyMembers<tensor::star>(); ++i) {
+    for (std::size_t i = 0; i < yateto::numFamilyMembers<tensor::star>(); ++i) {
       derivativesKrnl.star(i) = const_cast<const real**>(
           (entry.get(inner_keys::Wp::Id::LocalIntegrationData))->getDeviceDataPtr());
       derivativesKrnl.extraOffset_star(i) =
           SEISSOL_ARRAY_OFFSET(LocalIntegrationData, starMatrices, i);
     }
 
-    for (unsigned i = 0; i < yateto::numFamilyMembers<tensor::dQ>(); ++i) {
+    for (std::size_t i = 0; i < yateto::numFamilyMembers<tensor::dQ>(); ++i) {
       derivativesKrnl.dQ(i) = (entry.get(inner_keys::Wp::Id::Derivatives))->getDeviceDataPtr();
       derivativesKrnl.extraOffset_dQ(i) = yateto::computeFamilySize<tensor::dQ>(1, i);
     }
@@ -231,7 +231,7 @@ void Time::evaluate(const real* coeffs,
 
   kernel::derivativeTaylorExpansion krnl;
   krnl.I = timeEvaluated;
-  for (unsigned i = 0; i < yateto::numFamilyMembers<tensor::dQ>(); ++i) {
+  for (std::size_t i = 0; i < yateto::numFamilyMembers<tensor::dQ>(); ++i) {
     krnl.dQ(i) = timeDerivatives + yateto::computeFamilySize<tensor::dQ>(1, i);
     krnl.power(i) = coeffs[i];
   }

--- a/src/Kernels/LinearCKAnelastic/Local.cpp
+++ b/src/Kernels/LinearCKAnelastic/Local.cpp
@@ -13,6 +13,7 @@
 #include "Kernels/Common.h"
 
 #include <cassert>
+#include <cstddef>
 #include <cstring>
 #include <stdint.h>
 #include <yateto.h>
@@ -78,7 +79,7 @@ void Local::computeIntegral(
   kernel::volumeExt volKrnl = m_volumeKernelPrototype;
   volKrnl.Qext = Qext;
   volKrnl.I = timeIntegratedDoFs;
-  for (unsigned i = 0; i < yateto::numFamilyMembers<tensor::star>(); ++i) {
+  for (std::size_t i = 0; i < yateto::numFamilyMembers<tensor::star>(); ++i) {
     volKrnl.star(i) = data.get<LTS::LocalIntegration>().starMatrices[i];
   }
 

--- a/src/Kernels/LinearCKAnelastic/Neighbor.cpp
+++ b/src/Kernels/LinearCKAnelastic/Neighbor.cpp
@@ -77,10 +77,8 @@ void Neighbor::computeNeighborsIntegral(
     const std::array<real*, Cell::NumFaces>& faceNeighborsPrefetch) {
 #ifndef NDEBUG
   for (std::size_t neighbor = 0; neighbor < Cell::NumFaces; ++neighbor) {
-    // alignment of the time integrated dofs
-    if (data.get<LTS::CellInformation>().faceTypes[neighbor] != FaceType::Outflow &&
-        data.get<LTS::CellInformation>().faceTypes[neighbor] !=
-            FaceType::DynamicRupture) { // no alignment for outflow and DR boundaries required
+    // alignment of the time integrated dofs (only for linear interior)
+    if (data.get<LTS::CellInformation>().faceTypes[neighbor] == FaceType::Regular) {
       assert((reinterpret_cast<uintptr_t>(timeIntegrated[neighbor])) % Alignment == 0);
     }
   }
@@ -98,22 +96,17 @@ void Neighbor::computeNeighborsIntegral(
 
   // iterate over faces
   for (std::size_t face = 0; face < Cell::NumFaces; ++face) {
-    // no neighboring cell contribution in the case of absorbing and dynamic rupture boundary
-    // conditions
-    if (data.get<LTS::CellInformation>().faceTypes[face] != FaceType::Outflow &&
-        data.get<LTS::CellInformation>().faceTypes[face] != FaceType::DynamicRupture) {
-      // compute the neighboring elements flux matrix id.
-      if (data.get<LTS::CellInformation>().faceTypes[face] != FaceType::FreeSurface) {
-        assert(data.get<LTS::CellInformation>().faceRelations[face][0] < Cell::NumFaces &&
-               data.get<LTS::CellInformation>().faceRelations[face][1] < 3);
+    // neighboring cell contribution only for interior faces
+    if (data.get<LTS::CellInformation>().faceTypes[face] == FaceType::Regular) {
+      assert(data.get<LTS::CellInformation>().faceRelations[face][0] < Cell::NumFaces &&
+             data.get<LTS::CellInformation>().faceRelations[face][1] < 3);
 
-        nfKrnl.I = timeIntegrated[face];
-        nfKrnl.AminusT = data.get<LTS::NeighboringIntegration>().nAmNm1[face];
-        nfKrnl._prefetch.I = faceNeighborsPrefetch[face];
-        nfKrnl.execute(data.get<LTS::CellInformation>().faceRelations[face][1],
-                       data.get<LTS::CellInformation>().faceRelations[face][0],
-                       face);
-      }
+      nfKrnl.I = timeIntegrated[face];
+      nfKrnl.AminusT = data.get<LTS::NeighboringIntegration>().nAmNm1[face];
+      nfKrnl._prefetch.I = faceNeighborsPrefetch[face];
+      nfKrnl.execute(data.get<LTS::CellInformation>().faceRelations[face][1],
+                     data.get<LTS::CellInformation>().faceRelations[face][0],
+                     face);
     } else if (data.get<LTS::CellInformation>().faceTypes[face] == FaceType::DynamicRupture) {
       assert((reinterpret_cast<uintptr_t>(cellDrMapping[face].godunov)) % Alignment == 0);
 
@@ -150,21 +143,14 @@ void Neighbor::flopsNeighborsIntegral(
   drHardwareFlops = 0;
 
   for (std::size_t face = 0; face < Cell::NumFaces; ++face) {
-    // no neighboring cell contribution in the case of absorbing and dynamic rupture boundary
-    // conditions
-    if (faceTypes[face] != FaceType::Outflow && faceTypes[face] != FaceType::DynamicRupture) {
-      // compute the neighboring elements flux matrix id.
-      if (faceTypes[face] != FaceType::FreeSurface) {
-        assert(neighboringIndices[face][0] < Cell::NumFaces && neighboringIndices[face][1] < 3);
+    // neighboring cell contribution only for interior faces
+    if (faceTypes[face] == FaceType::Regular) {
+      assert(neighboringIndices[face][0] < Cell::NumFaces && neighboringIndices[face][1] < 3);
 
-        nonZeroFlops += seissol::kernel::neighborFluxExt::nonZeroFlops(
-            neighboringIndices[face][1], neighboringIndices[face][0], face);
-        hardwareFlops += seissol::kernel::neighborFluxExt::hardwareFlops(
-            neighboringIndices[face][1], neighboringIndices[face][0], face);
-      } else { // fall back to local matrices in case of free surface boundary conditions
-        nonZeroFlops += seissol::kernel::localFluxExt::nonZeroFlops(face);
-        hardwareFlops += seissol::kernel::localFluxExt::hardwareFlops(face);
-      }
+      nonZeroFlops += seissol::kernel::neighborFluxExt::nonZeroFlops(
+          neighboringIndices[face][1], neighboringIndices[face][0], face);
+      hardwareFlops += seissol::kernel::neighborFluxExt::hardwareFlops(
+          neighboringIndices[face][1], neighboringIndices[face][0], face);
     } else if (faceTypes[face] == FaceType::DynamicRupture) {
       drNonZeroFlops += dynamicRupture::kernel::nodalFlux::nonZeroFlops(
           cellDrMapping[face].side, cellDrMapping[face].faceRelation);

--- a/src/Kernels/LinearCKAnelastic/Neighbor.cpp
+++ b/src/Kernels/LinearCKAnelastic/Neighbor.cpp
@@ -217,10 +217,7 @@ void Neighbor::computeBatchedNeighborsIntegral(
             // regular and periodic
             unsigned faceRelation = i;
 
-            ConditionalKey key(*KernelNames::NeighborFlux,
-                               (FaceKinds::Regular || FaceKinds::Periodic),
-                               face,
-                               faceRelation);
+            ConditionalKey key(*KernelNames::NeighborFlux, FaceKinds::Regular, face, faceRelation);
 
             if (table.find(key) != table.end()) {
               auto& entry = table[key];

--- a/src/Kernels/LinearCKAnelastic/Neighbor.cpp
+++ b/src/Kernels/LinearCKAnelastic/Neighbor.cpp
@@ -39,12 +39,12 @@ void Neighbor::setGlobalData(const CompoundGlobalData& global) {
            0);
   }
 
-  for (int h = 0; h < 3; ++h) {
+  for (std::size_t h = 0; h < Cell::Dim; ++h) {
     assert((reinterpret_cast<uintptr_t>(global.onHost->neighborFluxMatrices(h))) % Alignment == 0);
   }
 
   for (std::size_t i = 0; i < Cell::NumFaces; ++i) {
-    for (int h = 0; h < 3; ++h) {
+    for (std::size_t h = 0; h < Cell::Dim; ++h) {
       assert((reinterpret_cast<uintptr_t>(global.onHost->nodalFluxMatrices(i, h))) % Alignment ==
              0);
     }
@@ -201,7 +201,7 @@ void Neighbor::computeBatchedNeighborsIntegral(
           // regular and periodic
           if (i < (*FaceRelations::Count)) {
             // regular and periodic
-            unsigned faceRelation = i;
+            const auto faceRelation = i;
 
             ConditionalKey key(*KernelNames::NeighborFlux, FaceKinds::Regular, face, faceRelation);
 
@@ -226,7 +226,7 @@ void Neighbor::computeBatchedNeighborsIntegral(
             }
           } else {
             // Dynamic Rupture
-            unsigned faceRelation = i - (*FaceRelations::Count);
+            const auto faceRelation = i - (*FaceRelations::Count);
 
             ConditionalKey key(
                 *KernelNames::NeighborFlux, *FaceKinds::DynamicRupture, face, faceRelation);

--- a/src/Kernels/LinearCKAnelastic/Neighbor.cpp
+++ b/src/Kernels/LinearCKAnelastic/Neighbor.cpp
@@ -203,7 +203,7 @@ void Neighbor::computeBatchedNeighborsIntegral(
             // regular and periodic
             const auto faceRelation = i;
 
-            ConditionalKey key(*KernelNames::NeighborFlux, FaceKinds::Regular, face, faceRelation);
+            ConditionalKey key(*KernelNames::NeighborFlux, *FaceKinds::Regular, face, faceRelation);
 
             if (table.find(key) != table.end()) {
               auto& entry = table[key];

--- a/src/Kernels/LinearCKAnelastic/Time.cpp
+++ b/src/Kernels/LinearCKAnelastic/Time.cpp
@@ -14,6 +14,7 @@
 #include "Kernels/MemoryOps.h"
 
 #include <cassert>
+#include <cstddef>
 #include <cstring>
 #include <stdint.h>
 #include <yateto.h>
@@ -80,18 +81,18 @@ void Spacetime::computeAder(const real* coeffs,
   if (timeDerivativesOrSTP != nullptr) {
     streamstore(tensor::dQ::size(0), data.get<LTS::Dofs>(), timeDerivativesOrSTP);
     real* derOut = timeDerivativesOrSTP;
-    for (unsigned i = 1; i < yateto::numFamilyMembers<tensor::dQ>(); ++i) {
+    for (std::size_t i = 1; i < yateto::numFamilyMembers<tensor::dQ>(); ++i) {
       derOut += tensor::dQ::size(i - 1);
       krnl.dQ(i) = derOut;
     }
   } else {
-    for (unsigned i = 1; i < yateto::numFamilyMembers<tensor::dQ>(); ++i) {
+    for (std::size_t i = 1; i < yateto::numFamilyMembers<tensor::dQ>(); ++i) {
       krnl.dQ(i) = temporaryBuffer[i % 2];
     }
   }
 
   krnl.dQane(0) = const_cast<real*>(data.get<LTS::DofsAne>());
-  for (unsigned i = 1; i < yateto::numFamilyMembers<tensor::dQ>(); ++i) {
+  for (std::size_t i = 1; i < yateto::numFamilyMembers<tensor::dQ>(); ++i) {
     krnl.dQane(i) = temporaryBufferAne[i % 2];
     krnl.dQext(i) = temporaryBufferExt[i % 2];
   }
@@ -99,7 +100,7 @@ void Spacetime::computeAder(const real* coeffs,
   krnl.I = timeIntegrated;
   krnl.Iane = tmp.timeIntegratedAne;
 
-  for (unsigned i = 0; i < yateto::numFamilyMembers<tensor::star>(); ++i) {
+  for (std::size_t i = 0; i < yateto::numFamilyMembers<tensor::star>(); ++i) {
     krnl.star(i) = data.get<LTS::LocalIntegration>().starMatrices[i];
   }
   krnl.w = data.get<LTS::LocalIntegration>().specific.w;
@@ -151,7 +152,7 @@ void Time::evaluate(const real* coeffs,
   kernel::derivativeTaylorExpansionEla krnl;
   krnl.I = timeEvaluated;
   const real* der = timeDerivativesOrSTP;
-  for (unsigned i = 0; i < yateto::numFamilyMembers<tensor::dQ>(); ++i) {
+  for (std::size_t i = 0; i < yateto::numFamilyMembers<tensor::dQ>(); ++i) {
     krnl.dQ(i) = der;
     der += tensor::dQ::size(i);
     krnl.power(i) = coeffs[i];
@@ -180,7 +181,7 @@ void Time::evaluateBatched(SEISSOL_GPU_PARAM const real* coeffs,
   krnl.numElements = numElements;
   krnl.I = timeIntegratedDofs;
   std::size_t derivativeOffset = 0;
-  for (unsigned i = 0; i < yateto::numFamilyMembers<tensor::dQ>(); ++i) {
+  for (std::size_t i = 0; i < yateto::numFamilyMembers<tensor::dQ>(); ++i) {
     krnl.dQ(i) = const_cast<const real**>(timeDerivativesOrSTP);
     krnl.extraOffset_dQ(i) = derivativeOffset;
     derivativeOffset += tensor::dQ::size(i);
@@ -218,10 +219,10 @@ void Spacetime::computeBatchedAder(
     krnl.I = (entry.get(inner_keys::Wp::Id::Idofs))->getDeviceDataPtr();
     krnl.Iane = (entry.get(inner_keys::Wp::Id::IdofsAne))->getDeviceDataPtr();
 
-    unsigned derivativesOffset = tensor::dQ::size(0);
+    std::size_t derivativesOffset = tensor::dQ::size(0);
     krnl.dQ(0) = (entry.get(inner_keys::Wp::Id::Derivatives))->getDeviceDataPtr();
     krnl.dQane(0) = (entry.get(inner_keys::Wp::Id::DofsAne))->getDeviceDataPtr();
-    for (unsigned i = 1; i < yateto::numFamilyMembers<tensor::dQ>(); ++i) {
+    for (std::size_t i = 1; i < yateto::numFamilyMembers<tensor::dQ>(); ++i) {
       krnl.dQ(i) = (entry.get(inner_keys::Wp::Id::Derivatives))->getDeviceDataPtr();
       krnl.extraOffset_dQ(i) = derivativesOffset;
       krnl.dQane(i) = (entry.get(inner_keys::Wp::Id::DerivativesAne))->getDeviceDataPtr();
@@ -235,7 +236,7 @@ void Spacetime::computeBatchedAder(
     krnl.Q = const_cast<const real**>((entry.get(inner_keys::Wp::Id::Dofs))->getDeviceDataPtr());
 
     SEISSOL_ARRAY_OFFSET_ASSERT(LocalIntegrationData, starMatrices);
-    for (unsigned i = 0; i < yateto::numFamilyMembers<tensor::star>(); ++i) {
+    for (std::size_t i = 0; i < yateto::numFamilyMembers<tensor::star>(); ++i) {
       krnl.star(i) = const_cast<const real**>(
           (entry.get(inner_keys::Wp::Id::LocalIntegrationData))->getDeviceDataPtr());
       krnl.extraOffset_star(i) = SEISSOL_ARRAY_OFFSET(LocalIntegrationData, starMatrices, i);

--- a/src/Kernels/STP/Time.cpp
+++ b/src/Kernels/STP/Time.cpp
@@ -14,6 +14,7 @@
 
 #include <Eigen/Dense>
 #include <cassert>
+#include <cstddef>
 #include <cstring>
 #include <stdint.h>
 #include <yateto.h>
@@ -34,7 +35,7 @@ namespace seissol::kernels::solver::stp {
 void Spacetime::setGlobalData(const CompoundGlobalData& global) {
   for (std::size_t n = 0; n < ConvergenceOrder; ++n) {
     if (n > 0) {
-      for (int d = 0; d < 3; ++d) {
+      for (std::size_t d = 0; d < Cell::Dim; ++d) {
         m_krnlPrototype.kDivMTSub(d, n) = init::kDivMTSub::Values[tensor::kDivMTSub::index(d, n)];
       }
     }
@@ -53,7 +54,7 @@ void Spacetime::setGlobalData(const CompoundGlobalData& global) {
   // TODO: adjust pointers
   for (std::size_t n = 0; n < ConvergenceOrder; ++n) {
     if (n > 0) {
-      for (int d = 0; d < 3; ++d) {
+      for (std::size_t d = 0; d < Cell::Dim; ++d) {
         deviceKrnlPrototype.kDivMTSub(d, n) =
             init::kDivMTSub::Values[tensor::kDivMTSub::index(d, n)];
       }
@@ -204,7 +205,7 @@ void Spacetime::computeBatchedAder(
     krnl.spaceTimePredictor = (entry.get(inner_keys::Wp::Id::Stp))->getDeviceDataPtr();
     krnl.spaceTimePredictorRhs = (entry.get(inner_keys::Wp::Id::StpRhs))->getDeviceDataPtr();
 
-    for (unsigned i = 0; i < yateto::numFamilyMembers<tensor::star>(); ++i) {
+    for (std::size_t i = 0; i < yateto::numFamilyMembers<tensor::star>(); ++i) {
       krnl.star(i) = const_cast<const real**>(
           (entry.get(inner_keys::Wp::Id::LocalIntegrationData))->getDeviceDataPtr());
       krnl.extraOffset_star(i) = SEISSOL_ARRAY_OFFSET(LocalIntegrationData, starMatrices, i);

--- a/src/Kernels/TimeCommon.cpp
+++ b/src/Kernels/TimeCommon.cpp
@@ -63,8 +63,7 @@ void TimeCommon::computeIntegrals(Time& time,
    */
   for (std::size_t dofneighbor = 0; dofneighbor < Cell::NumFaces; ++dofneighbor) {
     // collect information only in the case that neighboring element contributions are required
-    if (faceTypes[dofneighbor] != FaceType::Outflow &&
-        faceTypes[dofneighbor] != FaceType::DynamicRupture) {
+    if (faceTypes[dofneighbor] == FaceType::Regular) {
       // check if the time integration is already done (-> copy pointer)
       if (!ltsSetup.neighborHasDerivatives(dofneighbor)) {
         timeIntegrated[dofneighbor] = timeDofs[dofneighbor];

--- a/src/Proxy/Allocator.cpp
+++ b/src/Proxy/Allocator.cpp
@@ -92,7 +92,6 @@ void fakeData(LTS::Layer& layer, FaceType faceTp) {
         faceNeighbors[cell][f] = buffers[cell];
         faceNeighborsDevice[cell][f] = buffersDevice[cell];
         break;
-      case FaceType::Periodic:
       case FaceType::Regular:
         faceNeighbors[cell][f] = buffers[secondaryInformation[cell].faceNeighbors[f].cell];
         faceNeighborsDevice[cell][f] =

--- a/src/sources.cmake
+++ b/src/sources.cmake
@@ -176,6 +176,8 @@ Reader/AsagiModule.cpp
 Reader/AsagiReader.cpp
 
 Geometry/CubeGenerator.cpp
+
+Initializer/FaceMap.cpp
 )
 
 if (HDF5 AND MPI)

--- a/tests/Common/SegmentMap.t.h
+++ b/tests/Common/SegmentMap.t.h
@@ -1,0 +1,50 @@
+// SPDX-FileCopyrightText: 2025 SeisSol Group
+//
+// SPDX-License-Identifier: BSD-3-Clause
+// SPDX-LicenseComments: Full text under /LICENSE and /LICENSES/
+//
+// SPDX-FileContributor: Author lists in /AUTHORS and /CITATION.cff
+
+#include "Common/SegmentMap.h"
+
+namespace seissol::unit_test {
+
+using namespace seissol;
+
+TEST_CASE("SegmentMap" * doctest::test_suite("common")) {
+  SegmentMap<int32_t, int32_t> map;
+
+  map.addRange(0, 10, 123);
+  map.addRange(14, 14, 23);
+  map.addRange(23, 100, 543);
+  map.addRange(1000, {}, -9);
+  map.addRange({}, -10, -100);
+
+  CHECK(map.at(0) == 123);
+  CHECK(map.at(1) == 123);
+  CHECK(map.at(9) == 123);
+  CHECK(map.at(10) == 123);
+  CHECK_FALSE(map.at(11).has_value());
+  CHECK_FALSE(map.at(12).has_value());
+  CHECK_FALSE(map.at(13).has_value());
+  CHECK(map.at(14) == 23);
+  CHECK_FALSE(map.at(15).has_value());
+  CHECK_FALSE(map.at(16).has_value());
+  CHECK_FALSE(map.at(22).has_value());
+  CHECK(map.at(23) == 543);
+  CHECK(map.at(24) == 543);
+  CHECK(map.at(99) == 543);
+  CHECK(map.at(100) == 543);
+  CHECK_FALSE(map.at(101).has_value());
+  CHECK_FALSE(map.at(999).has_value());
+  CHECK(map.at(1000) == -9);
+  CHECK(map.at(1000000) == -9);
+
+  CHECK_FALSE(map.at(-1).has_value());
+  CHECK_FALSE(map.at(-9).has_value());
+  CHECK(map.at(-10) == -100);
+  CHECK(map.at(-11) == -100);
+  CHECK(map.at(-1000000) == -100);
+}
+
+} // namespace seissol::unit_test

--- a/tests/Common/TestCommon.cpp
+++ b/tests/Common/TestCommon.cpp
@@ -9,3 +9,4 @@
 
 #include "IntegerMaskParser.t.h"
 #include "Iterator.t.h"
+#include "SegmentMap.t.h"

--- a/tests/Geometry/MeshReader.t.h
+++ b/tests/Geometry/MeshReader.t.h
@@ -17,7 +17,7 @@
 namespace seissol::unit_test {
 class MockReader2 : public seissol::geometry::MeshReader {
   public:
-  explicit MockReader2(int boundaryType) : seissol::geometry::MeshReader(0) {
+  explicit MockReader2(FaceType boundaryType) : seissol::geometry::MeshReader(0) {
     m_vertices.resize(4);
 
     m_elements.resize(1);
@@ -34,14 +34,14 @@ class MockReader2 : public seissol::geometry::MeshReader {
 
 TEST_CASE("MeshReader") {
   SUBCASE("No DR") {
-    MockReader2 rdr(3);
+    MockReader2 rdr(FaceType::DynamicRupture);
 
     rdr.disableDR();
 
-    REQUIRE(rdr.getElements()[0].boundaries[0] == 0);
-    REQUIRE(rdr.getElements()[0].boundaries[1] == 0);
-    REQUIRE(rdr.getElements()[0].boundaries[2] == 0);
-    REQUIRE(rdr.getElements()[0].boundaries[3] == 0);
+    REQUIRE(rdr.getElements()[0].boundaries[0] == FaceType::Regular);
+    REQUIRE(rdr.getElements()[0].boundaries[1] == FaceType::Regular);
+    REQUIRE(rdr.getElements()[0].boundaries[2] == FaceType::Regular);
+    REQUIRE(rdr.getElements()[0].boundaries[3] == FaceType::Regular);
   }
 }
 

--- a/tests/Initializer/FaceMap.t.h
+++ b/tests/Initializer/FaceMap.t.h
@@ -1,0 +1,121 @@
+// SPDX-FileCopyrightText: 2020 SeisSol Group
+//
+// SPDX-License-Identifier: BSD-3-Clause
+// SPDX-LicenseComments: Full text under /LICENSE and /LICENSES/
+//
+// SPDX-FileContributor: Author lists in /AUTHORS and /CITATION.cff
+
+#include "Initializer/BasicTypedefs.h"
+#include "Initializer/FaceMap.h"
+
+#include <yaml-cpp/yaml.h>
+
+namespace seissol::unit_test {
+
+TEST_CASE("Default face map" * doctest::test_suite("initializer")) {
+  const auto map = defaultFaceMap();
+
+  CHECK(map.at(0) == FaceType::Regular);
+  CHECK(map.at(1) == FaceType::FreeSurface);
+  CHECK(map.at(2) == FaceType::FreeSurfaceGravity);
+  CHECK(map.at(3) == FaceType::DynamicRupture);
+  CHECK(map.at(4) == FaceType::Dirichlet);
+  CHECK(map.at(5) == FaceType::Outflow);
+  CHECK(map.at(6) == FaceType::Regular);
+  CHECK(map.at(7) == FaceType::Analytical);
+  for (std::size_t i = 8; i <= 64; ++i) {
+    CHECK_FALSE(map.at(i).has_value());
+  }
+  CHECK(map.at(65) == FaceType::DynamicRupture);
+  CHECK(map.at(66) == FaceType::DynamicRupture);
+  CHECK(map.at(100) == FaceType::DynamicRupture);
+  CHECK(map.at(1000) == FaceType::DynamicRupture);
+  CHECK(map.at(10000) == FaceType::DynamicRupture);
+}
+
+TEST_CASE("Default face map as input" * doctest::test_suite("initializer")) {
+  const auto node = YAML::Load(R"(
+        regular:
+            - 0
+            - 6
+        freeSurface:
+            - 1
+        freeSurfaceGravity:
+            - 2
+        dynamicRupture:
+            - 3
+            - 65- # note the open range
+        dirichlet:
+            - 4
+        outflow:
+            - 5
+        analytical:
+            - 7
+    )");
+  const auto map = parseFaceMap(node);
+
+  CHECK(map.at(0) == FaceType::Regular);
+  CHECK(map.at(1) == FaceType::FreeSurface);
+  CHECK(map.at(2) == FaceType::FreeSurfaceGravity);
+  CHECK(map.at(3) == FaceType::DynamicRupture);
+  CHECK(map.at(4) == FaceType::Dirichlet);
+  CHECK(map.at(5) == FaceType::Outflow);
+  CHECK(map.at(6) == FaceType::Regular);
+  CHECK(map.at(7) == FaceType::Analytical);
+  for (std::size_t i = 8; i <= 64; ++i) {
+    CHECK_FALSE(map.at(i).has_value());
+  }
+  CHECK(map.at(65) == FaceType::DynamicRupture);
+  CHECK(map.at(66) == FaceType::DynamicRupture);
+  CHECK(map.at(100) == FaceType::DynamicRupture);
+  CHECK(map.at(1000) == FaceType::DynamicRupture);
+  CHECK(map.at(10000) == FaceType::DynamicRupture);
+}
+
+TEST_CASE("Custom face map input" * doctest::test_suite("initializer")) {
+  const auto node = YAML::Load(R"(
+        regular: 1, 3
+        dynamicRupture:
+            - 4
+            - 6-10
+            - 102-
+        outflow: [2,5,11]
+        dirichlet: 23
+        freeSurface: 40-41, 44
+        freeSurfaceGravity: [50-51, 54]
+        analytical: []
+    )");
+  const auto map = parseFaceMap(node);
+
+  CHECK_FALSE(map.at(0).has_value());
+  CHECK_FALSE(map.at(12).has_value());
+  CHECK_FALSE(map.at(13).has_value());
+
+  CHECK(map.at(1) == FaceType::Regular);
+  CHECK(map.at(3) == FaceType::Regular);
+
+  CHECK(map.at(4) == FaceType::DynamicRupture);
+  CHECK(map.at(6) == FaceType::DynamicRupture);
+  CHECK(map.at(7) == FaceType::DynamicRupture);
+  CHECK(map.at(8) == FaceType::DynamicRupture);
+  CHECK(map.at(9) == FaceType::DynamicRupture);
+  CHECK(map.at(10) == FaceType::DynamicRupture);
+  CHECK(map.at(102) == FaceType::DynamicRupture);
+  CHECK(map.at(103) == FaceType::DynamicRupture);
+
+  CHECK(map.at(2) == FaceType::Outflow);
+  CHECK(map.at(5) == FaceType::Outflow);
+  CHECK(map.at(11) == FaceType::Outflow);
+
+  CHECK(map.at(23) == FaceType::Dirichlet);
+
+  CHECK(map.at(40) == FaceType::FreeSurface);
+  CHECK(map.at(41) == FaceType::FreeSurface);
+  CHECK(map.at(44) == FaceType::FreeSurface);
+
+  CHECK(map.at(50) == FaceType::FreeSurfaceGravity);
+  CHECK(map.at(51) == FaceType::FreeSurfaceGravity);
+  CHECK(map.at(54) == FaceType::FreeSurfaceGravity);
+}
+
+} // namespace seissol::unit_test

--- a/tests/Initializer/TestInitializer.cpp
+++ b/tests/Initializer/TestInitializer.cpp
@@ -7,5 +7,6 @@
 
 #include <doctest.h>
 
+#include "FaceMap.t.h"
 #include "PointMapper.t.h"
 #include "TimeStepping/LTSWeights.t.h"

--- a/tests/Initializer/TimeStepping/LTSWeights.t.h
+++ b/tests/Initializer/TimeStepping/LTSWeights.t.h
@@ -6,6 +6,7 @@
 // SPDX-FileContributor: Author lists in /AUTHORS and /CITATION.cff
 
 #include "Geometry/PUMLReader.h"
+#include "Initializer/FaceMap.h"
 #include "Initializer/Parameters/LtsParameters.h"
 #include "Initializer/Parameters/MeshParameters.h"
 #include "Initializer/Parameters/SeisSolParameters.h"
@@ -46,9 +47,11 @@ TEST_CASE("LTS Weights") {
   seissol::SeisSol seissolInstance(seissolParameters, env);
 
   auto ltsWeights = std::make_unique<ExponentialWeights>(config, seissolInstance);
+  const auto faceMap = defaultFaceMap();
   const auto pumlReader =
       seissol::geometry::PUMLReader(tpath("Testing/mesh.h5"),
                                     "Default",
+                                    faceMap,
                                     seissol::initializer::parameters::BoundaryFormat::I32,
                                     seissol::initializer::parameters::TopologyFormat::Geometric,
                                     ltsWeights.get());


### PR DESCRIPTION
* Unify face types `Regular` (0) and `Periodic` (6) internally (they're treated same way now)
* Classify the faces a bit better, and generalize the classification a bit. We now have internal and external faces; with external faces currently being factored into some with a fake neighbor (i.e. the same cell—that's only required if they call the neighboring kernel; which none of our current BCs actually does) and some with no neighbor. Also, there are currently no fake neighbor BCs. I've left it in for now—but we can also remove the bits of code for that case (mostly concerning the `LtsSetup.cpp` and `Buckets.cpp`).
* Clean up the face type usage internally; especially for viscoelastic (also fix a flop counting issue there)
* Add external face type/tag input. Allows a YAML dictionary for input; including open ranges (not that YAML-y, but it gives us backward compatibility to the current assignment). With maybe the whole input files being converted to YAML at some point in the future.
* Reduce data transfers for the boundary conditions—i.e. make all boundary conditions behave like outflow everywhere. That the BCs effectively behave like outflow in the kernels (but not the datastructures) was already so before even v1.0.0 (e.g. the visco2 kernels still had remnants of code in there that the `FreeSurface` BC should be run in the `Neighbor.cpp` kernel; but that's long been changed to the `Local.cpp` for elastic _and_ visco2); so we're now just concluding the changes and cleaning up.
* includes unit tests for the new features