### PR TITLE
Avoid host function calls with HIP

### DIFF
--- a/src/Parallel/Runtime/Stream.h
+++ b/src/Parallel/Runtime/Stream.h
@@ -106,7 +106,13 @@ class StreamRuntime {
 
   template <typename F>
   void enqueueHost(F&& handler) {
-    device().api->streamHostFunction(streamPtr->get(), std::forward<F>(handler));
+    if (Backend != DeviceBackend::Hip) {
+      device().api->streamHostFunction(streamPtr->get(), std::forward<F>(handler));
+    } else {
+      // if the stream host function call isn't implemented or slow, we'll need to synchronize
+      wait();
+      std::invoke(handler);
+    }
   }
 
   template <typename F>


### PR DESCRIPTION
Normally, the receiver (both on and off fault) computation should be offloaded to the CPU—that's currently done via extra streams which launch CPU tasks.

However, there seems to be a problem with at least the HIP internal implementation or SeisSol—so let's disable the host function calls for HIP until further evaluation.

Might help with #1559 
