### PR TITLE
Fix ITM scheduling and output alignment

### DIFF
--- a/src/Initializer/InitProcedure/InitIO.cpp
+++ b/src/Initializer/InitProcedure/InitIO.cpp
@@ -7,6 +7,7 @@
 
 #include "InitIO.h"
 
+#include "Alignment.h"
 #include "Common/Constants.h"
 #include "Common/Filesystem.h"
 #include "Equations/Datastructures.h"
@@ -282,6 +283,8 @@ void setupOutput(seissol::SeisSol& seissolInstance) {
       for (std::size_t quantity = 0; quantity < seissol::model::MaterialT::Quantities.size();
            ++quantity) {
         if (seissolParams.output.waveFieldParameters.outputMask[quantity]) {
+          constexpr std::size_t MaxVtk3dPoints = tensor::vtk3d::Shape
+              [(sizeof(tensor::vtk3d::Shape) / sizeof(tensor::vtk3d::Shape[0])) - 1][1];
           writer.addPointData<real>(
               namewrap(seissol::model::MaterialT::Quantities[quantity], sim),
               {},
@@ -291,13 +294,15 @@ void setupOutput(seissol::SeisSol& seissolInstance) {
                 const auto* dofsSingleQuantity = dofsAllQuantities + QDofSizePadded * quantity;
                 kernel::projectBasisToVtkVolume vtkproj{};
                 memory::AlignedArray<real, multisim::NumSimulations> simselect{};
+                alignas(Alignment) std::array<real, MaxVtk3dPoints> alignedTarget{};
                 simselect[sim] = 1;
                 vtkproj.simselect = simselect.data();
                 vtkproj.qb = dofsSingleQuantity;
-                vtkproj.xv(order) = target;
+                vtkproj.xv(order) = alignedTarget.data();
                 vtkproj.collvv(ConvergenceOrder, order) =
                     init::collvv::Values[ConvergenceOrder + (ConvergenceOrder + 1) * order];
                 vtkproj.execute(order);
+                std::copy_n(alignedTarget.data(), tensor::vtk3d::Shape[order][1], target);
               });
         }
       }
@@ -305,6 +310,8 @@ void setupOutput(seissol::SeisSol& seissolInstance) {
         for (std::size_t quantity = 0; quantity < seissol::model::PlasticityData::Quantities.size();
              ++quantity) {
           if (seissolParams.output.waveFieldParameters.plasticityMask[quantity]) {
+            constexpr std::size_t MaxVtk3dPoints = tensor::vtk3d::Shape
+                [(sizeof(tensor::vtk3d::Shape) / sizeof(tensor::vtk3d::Shape[0])) - 1][1];
             writer.addPointData<real>(
                 namewrap(seissol::model::PlasticityData::Quantities[quantity], sim),
                 {},
@@ -315,14 +322,16 @@ void setupOutput(seissol::SeisSol& seissolInstance) {
                       dofsAllQuantities + QDofPointsPadded * quantity;
                   kernel::projectNodalToVtkVolume vtkproj{};
                   memory::AlignedArray<real, multisim::NumSimulations> simselect{};
+                  alignas(Alignment) std::array<real, MaxVtk3dPoints> alignedTarget{};
                   simselect[sim] = 1;
                   vtkproj.simselect = simselect.data();
                   vtkproj.qn = pointsSingleQuantity;
                   vtkproj.vInv = init::vInv::Values;
-                  vtkproj.xv(order) = target;
+                  vtkproj.xv(order) = alignedTarget.data();
                   vtkproj.collvv(ConvergenceOrder, order) =
                       init::collvv::Values[ConvergenceOrder + (ConvergenceOrder + 1) * order];
                   vtkproj.execute(order);
+                  std::copy_n(alignedTarget.data(), tensor::vtk3d::Shape[order][1], target);
                 });
           }
         }
@@ -410,6 +419,9 @@ void setupOutput(seissol::SeisSol& seissolInstance) {
       for (std::size_t quantity = 0;
            quantity < seissol::solver::FreeSurfaceIntegrator::NumComponents;
            ++quantity) {
+        constexpr std::size_t MaxVtk2dPoints =
+            tensor::vtk2d::Shape[(sizeof(tensor::vtk2d::Shape) / sizeof(tensor::vtk2d::Shape[0])) -
+                                 1][1];
         writer.addPointData<real>(
             namewrap(quantityLabels[quantity], sim),
             {},
@@ -422,19 +434,24 @@ void setupOutput(seissol::SeisSol& seissolInstance) {
                   dofsAllQuantities + QDofSizePadded * (6 + quantity); // velocities
               kernel::projectBasisToVtkFaceFromVolume vtkproj{};
               memory::AlignedArray<real, multisim::NumSimulations> simselect{};
+              alignas(Alignment) std::array<real, MaxVtk2dPoints> alignedTarget{};
               simselect[sim] = 1;
               vtkproj.simselect = simselect.data();
               vtkproj.qb = dofsSingleQuantity;
-              vtkproj.xf(order) = target;
+              vtkproj.xf(order) = alignedTarget.data();
               vtkproj.collvf(ConvergenceOrder, order, side) =
                   init::collvf::Values[ConvergenceOrder +
                                        (ConvergenceOrder + 1) * (order + 9 * side)];
               vtkproj.execute(order, side);
+              std::copy_n(alignedTarget.data(), tensor::vtk2d::Shape[order][1], target);
             });
       }
       for (std::size_t quantity = 0;
            quantity < seissol::solver::FreeSurfaceIntegrator::NumComponents;
            ++quantity) {
+        constexpr std::size_t MaxVtk2dPoints =
+            tensor::vtk2d::Shape[(sizeof(tensor::vtk2d::Shape) / sizeof(tensor::vtk2d::Shape[0])) -
+                                 1][1];
         writer.addPointData<real>(
             namewrap(
                 quantityLabels[quantity + seissol::solver::FreeSurfaceIntegrator::NumComponents],
@@ -449,14 +466,16 @@ void setupOutput(seissol::SeisSol& seissolInstance) {
                   faceDisplacements[side] + FaceDisplacementPadded * quantity;
               kernel::projectNodalToVtkFace vtkproj{};
               memory::AlignedArray<real, multisim::NumSimulations> simselect{};
+              alignas(Alignment) std::array<real, MaxVtk2dPoints> alignedTarget{};
               simselect[sim] = 1;
               vtkproj.simselect = simselect.data();
               vtkproj.pn = faceDisplacementVariable;
               vtkproj.MV2nTo2m = nodal::init::MV2nTo2m::Values;
-              vtkproj.xf(order) = target;
+              vtkproj.xf(order) = alignedTarget.data();
               vtkproj.collff(ConvergenceOrder, order) =
                   init::collff::Values[ConvergenceOrder + (ConvergenceOrder + 1) * order];
               vtkproj.execute(order);
+              std::copy_n(alignedTarget.data(), tensor::vtk2d::Shape[order][1], target);
             });
       }
     }

--- a/src/Modules/Modules.cpp
+++ b/src/Modules/Modules.cpp
@@ -82,9 +82,17 @@ double Modules::_callSyncHook(double currentTime, double timeTolerance, bool for
 void Modules::_callSimulationStartHook(std::optional<double> checkpointTime) {
   assert(static_cast<int>(nextHook_) <= static_cast<int>(ModuleHook::SynchronizationPoint));
 
+  const auto startTime = checkpointTime.value_or(0);
+
   for (auto& [_, module] : hooks_[static_cast<size_t>(ModuleHook::SimulationStart)]) {
     module->simulationStart(checkpointTime);
-    module->setSimulationStartTime(checkpointTime.value_or(0));
+    module->setSimulationStartTime(startTime);
+  }
+
+  // Modules that register only for synchronization points still need a valid
+  // initial sync schedule (e.g., ITM managers).
+  for (auto& [_, module] : hooks_[static_cast<size_t>(ModuleHook::SynchronizationPoint)]) {
+    module->setSimulationStartTime(startTime);
   }
 }
 

--- a/src/Modules/Modules.cpp
+++ b/src/Modules/Modules.cpp
@@ -86,10 +86,9 @@ void Modules::_callSimulationStartHook(std::optional<double> checkpointTime) {
 
   for (auto& [_, module] : hooks_[static_cast<size_t>(ModuleHook::SimulationStart)]) {
     module->simulationStart(checkpointTime);
-    module->setSimulationStartTime(startTime);
   }
 
-  // Modules that register only for synchronization points still need a valid
+  // Modules that register only for synchronization points need a valid
   // initial sync schedule (e.g., ITM managers).
   for (auto& [_, module] : hooks_[static_cast<size_t>(ModuleHook::SynchronizationPoint)]) {
     module->setSimulationStartTime(startTime);

--- a/src/Physics/InstantaneousTimeMirrorManager.cpp
+++ b/src/Physics/InstantaneousTimeMirrorManager.cpp
@@ -60,7 +60,14 @@ void InstantaneousTimeMirrorManager::syncPoint(double currentTime) {
   initializer::initializeCellLocalMatrices(
       *meshReader_, *ltsStorage_, *clusterLayout_, seissolInstance_.getSeisSolParameters().model);
   // An empty timestepping is added. Need to discuss what exactly is to be sent here
-
+#ifdef ACL_DEVICE
+  void* stream = device::DeviceInstance::getInstance().api->getDefaultStream();
+  ltsStorage_->varSynchronizeTo<LTS::LocalIntegration>(
+      seissol::initializer::AllocationPlace::Device, stream);
+  ltsStorage_->varSynchronizeTo<LTS::NeighboringIntegration>(
+      seissol::initializer::AllocationPlace::Device, stream);
+  device::DeviceInstance::getInstance().api->syncDefaultStreamWithHost();
+#endif
   logInfo() << "Updating TimeSteps by a factor of " << 1 / velocityScalingFactor_;
   updateTimeSteps();
 
@@ -89,13 +96,15 @@ void InstantaneousTimeMirrorManager::updateVelocities() {
     } else if (reflectionType == seissol::initializer::parameters::ReflectionType::Swave) {
       // Refocusing only S-waves
 
-      // (preserved comment from before the refactor)
-      // lambda = -2.0 * velocityScalingFactor * mu + (lambda + 2.0 * mu) / velocityScalingFactor;
-      // mu *= velocityScalingFactor;
-      // rho *= velocityScalingFactor;
+      const auto newLambda =
+          -2.0 * velocityScalingFactor_ * mu + (lambda + 2.0 * mu) / velocityScalingFactor_;
 
-      const auto newLambda = lambda + 2.0 * mu * (1 - velocityScalingFactor_);
-      material.setDensity(rho * lambda / newLambda);
+      if (newLambda < 0.0) {
+        logError()
+            << "New lambda is negative. This is not allowed. Please adjust your scaling factor.";
+      }
+
+      material.setDensity(rho * velocityScalingFactor_);
       material.setLameParameters(velocityScalingFactor_ * mu, newLambda);
     } else {
       logError() << "Unknown reflection type; material cannot be updated.";
@@ -139,13 +148,7 @@ void InstantaneousTimeMirrorManager::updateTimeSteps() {
   if (reflectionType ==
       seissol::initializer::parameters::ReflectionType::Swave) { // refocusing only S-waves
 
-    if (abs(timeStepScalingFactor_ - 1.0) < 1e-6) {
-      timeStepScalingFactor_ = 0.5;
-    }
-
-    if (abs(timeStepScalingFactor_ - 0.5) < 1e-6) {
-      timeStepScalingFactor_ = 2.0;
-    }
+    timeStepScalingFactor_ = velocityScalingFactor_;
 
     for (auto& cluster : clusters_) {
       cluster->setClusterTimes(cluster->getClusterTimes() * timeStepScalingFactor_);

--- a/tests/Modules/Module.t.h
+++ b/tests/Modules/Module.t.h
@@ -72,9 +72,24 @@ class TestModule : public seissol::Module {
   }
 };
 
+class SyncOnlyModule : public seissol::Module {
+public:
+  ModuleHook state{ModuleHook::NullHook};
+  double time{0};
+  explicit SyncOnlyModule(double interval) {
+    setSyncInterval(interval);
+    seissol::Modules::registerHook(*this, ModuleHook::SynchronizationPoint);
+  }
+  void syncPoint(double time) override {
+    state = ModuleHook::SynchronizationPoint;
+    this->time = time;
+  }
+};
+
 TEST_CASE("Module runthrough") {
   TestModule mod1(true, 2);
   TestModule mod2(false, 3);
+  SyncOnlyModule syncOnly(1000);
 
   Modules::callHook<ModuleHook::PreMPI>();
   REQUIRE(mod1.state == ModuleHook::PreMPI);
@@ -113,10 +128,19 @@ TEST_CASE("Module runthrough") {
   Modules::callSimulationStartHook(startTime);
   REQUIRE(mod1.state == ModuleHook::SimulationStart);
   REQUIRE(mod2.state == ModuleHook::SimulationStart);
+  REQUIRE(syncOnly.state == ModuleHook::NullHook);
 
   // exact comparison is ok here
   REQUIRE(mod1.time == startTime);
   REQUIRE(mod2.time == startTime);
+  REQUIRE(syncOnly.time == 0);
+
+  // Regression check: modules that register only for synchronization points
+  // must still receive their initial schedule via setSimulationStartTime().
+  // Without that, nextSyncPoint_ would remain at 0 and could cause a 0s->0s step.
+  REQUIRE(syncOnly.potentialSyncPoint(startTime, 1e-14, false) == AbsApprox(1000));
+  REQUIRE(syncOnly.state == ModuleHook::NullHook);
+  REQUIRE(syncOnly.time == 0);
 
   std::vector<int32_t> expectedTimes{2, 3, 4, 6, 8, 9, 10, 12, 14, 15};
 
@@ -126,6 +150,8 @@ TEST_CASE("Module runthrough") {
 
   // first check; noone will be called
   time = Modules::callSyncHook(time, 1e-14, false);
+  REQUIRE(syncOnly.state == ModuleHook::NullHook);
+  REQUIRE(syncOnly.time == 0);
 
   for (std::size_t i = 0; i < expectedTimes.size(); ++i) {
     REQUIRE(time == AbsApprox(expectedTimes[i]));
@@ -150,6 +176,9 @@ TEST_CASE("Module runthrough") {
     if (mod2Time > startTime) {
       REQUIRE(mod2.state == ModuleHook::SynchronizationPoint);
     }
+
+    REQUIRE(syncOnly.state == ModuleHook::NullHook);
+    REQUIRE(syncOnly.time == 0);
   }
 
   Modules::callHook<ModuleHook::SimulationEnd>();

--- a/tests/Modules/Module.t.h
+++ b/tests/Modules/Module.t.h
@@ -90,6 +90,7 @@ TEST_CASE("Module runthrough") {
   TestModule mod1(true, 2);
   TestModule mod2(false, 3);
   SyncOnlyModule syncOnly(1000);
+  SyncOnlyModule syncOnlyShort(2);
 
   Modules::callHook<ModuleHook::PreMPI>();
   REQUIRE(mod1.state == ModuleHook::PreMPI);
@@ -129,29 +130,37 @@ TEST_CASE("Module runthrough") {
   REQUIRE(mod1.state == ModuleHook::SimulationStart);
   REQUIRE(mod2.state == ModuleHook::SimulationStart);
   REQUIRE(syncOnly.state == ModuleHook::NullHook);
+  REQUIRE(syncOnlyShort.state == ModuleHook::NullHook);
 
   // exact comparison is ok here
   REQUIRE(mod1.time == startTime);
   REQUIRE(mod2.time == startTime);
   REQUIRE(syncOnly.time == 0);
+  REQUIRE(syncOnlyShort.time == 0);
 
   // Regression check: modules that register only for synchronization points
   // must still receive their initial schedule via setSimulationStartTime().
   // Without that, nextSyncPoint_ would remain at 0 and could cause a 0s->0s step.
   REQUIRE(syncOnly.potentialSyncPoint(startTime, 1e-14, false) == AbsApprox(1000));
+  REQUIRE(syncOnlyShort.potentialSyncPoint(startTime, 1e-14, false) == AbsApprox(2.0));
   REQUIRE(syncOnly.state == ModuleHook::NullHook);
+  REQUIRE(syncOnlyShort.state == ModuleHook::NullHook);
   REQUIRE(syncOnly.time == 0);
+  REQUIRE(syncOnlyShort.time == 0);
 
   std::vector<int32_t> expectedTimes{2, 3, 4, 6, 8, 9, 10, 12, 14, 15};
 
   double time = startTime;
   double mod1Time = startTime;
   double mod2Time = startTime;
+  double syncOnlyShortTime = 0;
 
   // first check; noone will be called
   time = Modules::callSyncHook(time, 1e-14, false);
   REQUIRE(syncOnly.state == ModuleHook::NullHook);
+  REQUIRE(syncOnlyShort.state == ModuleHook::NullHook);
   REQUIRE(syncOnly.time == 0);
+  REQUIRE(syncOnlyShort.time == 0);
 
   for (std::size_t i = 0; i < expectedTimes.size(); ++i) {
     REQUIRE(time == AbsApprox(expectedTimes[i]));
@@ -161,6 +170,9 @@ TEST_CASE("Module runthrough") {
     }
     if (expectedTimes[i] % 3 == 0) {
       mod2Time = expectedTimes[i];
+    }
+    if (expectedTimes[i] % 2 == 0) {
+      syncOnlyShortTime = expectedTimes[i];
     }
 
     time = Modules::callSyncHook(time, 1e-14, false);
@@ -179,6 +191,13 @@ TEST_CASE("Module runthrough") {
 
     REQUIRE(syncOnly.state == ModuleHook::NullHook);
     REQUIRE(syncOnly.time == 0);
+
+    REQUIRE(syncOnlyShort.time == AbsApprox(syncOnlyShortTime));
+    if (syncOnlyShortTime > 0) {
+      REQUIRE(syncOnlyShort.state == ModuleHook::SynchronizationPoint);
+    } else {
+      REQUIRE(syncOnlyShort.state == ModuleHook::NullHook);
+    }
   }
 
   Modules::callHook<ModuleHook::SimulationEnd>();

--- a/tests/Modules/Module.t.h
+++ b/tests/Modules/Module.t.h
@@ -73,7 +73,7 @@ class TestModule : public seissol::Module {
 };
 
 class SyncOnlyModule : public seissol::Module {
-public:
+  public:
   ModuleHook state{ModuleHook::NullHook};
   double time{0};
   explicit SyncOnlyModule(double interval) {


### PR DESCRIPTION
As part of research with the Helsinki team, they encountered a bug when running ITM-acoustic simulations. The two bugs that this PR is supposed to fix are as follows:

1. Alignment issues with LIBXSMM when using higher-order output.
2. ITM startup synchronization bug (0s -> 0s). ITM modules registered on `SynchronizationPoint` but were not getting their initial sync schedule at simulation start. So, the next sync time stayed at 0, and the simulator aborted with "did not advance in time". This fix also initializes the simulation start time for synchronization-point modules, ensuring that ITM's first trigger is scheduled correctly. 