### PR TITLE
Display mesh errors from all ranks

### DIFF
--- a/src/Geometry/PUMLReader.cpp
+++ b/src/Geometry/PUMLReader.cpp
@@ -119,25 +119,26 @@ inline bool
     // else:
     if (getBCType(faceType.value()) == BCType::Internal) {
       if (cellNeighbors[side] < 0 && !face.isShared()) {
-        logWarning() << "Element" << cellIdAsInFile << ", side" << side << " has a"
-                     << bcToString(sideBC, faceMap)
-                     << "boundary condition, but the neighboring element doesn't exist";
+        logWarning(true) << "Element" << cellIdAsInFile << ", side" << side << " has a"
+                         << bcToString(sideBC, faceMap)
+                         << "boundary condition, but the neighboring element doesn't exist";
         return false;
       }
     }
     // external boundaries must not have neighboring elements:
     else {
       if (cellNeighbors[side] >= 0 || face.isShared()) {
-        logWarning() << "Element" << cellIdAsInFile << ", side" << side << " has a"
-                     << bcToString(sideBC, faceMap)
-                     << "boundary condition, but a neighboring element exists";
+        logWarning(true) << "Element" << cellIdAsInFile << ", side" << side << " has a"
+                         << bcToString(sideBC, faceMap)
+                         << "boundary condition, but a neighboring element exists";
         return false;
       }
     }
   } else {
     // ignore unknown boundary conditions and warn
-    logWarning() << "Element" << cellIdAsInFile << ", side" << side << " has a boundary condition ("
-                 << sideBC << ") which is not understood by this version of SeisSol";
+    logWarning(true) << "Element" << cellIdAsInFile << ", side" << side
+                     << " has a boundary condition (" << sideBC
+                     << ") which is not understood by this version of SeisSol";
     return false;
   }
   return true;


### PR DESCRIPTION
Show mesh errors from all ranks.
Currently SeisSol only shows the mesh errors from rank zero, but still fails (i.e. without error). That changed probably when switching to the new logging system.
