### PR TITLE
Add gfx1250, gfx1251 to the device option list

### DIFF
--- a/cmake/process_users_input.cmake
+++ b/cmake/process_users_input.cmake
@@ -71,9 +71,9 @@ set(DEVICE_ARCH "auto" CACHE STRING "Type of GPU architecture")
 # TODO: add vendor name here
 # (NOTE: bdw,skl,pvc as labels are kept for legacy reasons; prefer 8_0_0, 9_0_9, 12_60_7 resp.)
 set(DEVICE_ARCH_OPTIONS none auto generic
-        sm_60 sm_61 sm_62 sm_70 sm_71 sm_75 sm_80 sm_86 sm_87 sm_89 sm_90 sm_100 sm_101 sm_103 sm_110 sm_120 sm_121 # Nvidia
-        gfx900 gfx906 gfx908 gfx90a gfx942 gfx950 gfx1010 gfx1030 gfx1100 gfx1101 gfx1102 gfx1103 gfx1200 gfx1201   # AMD
-        8_0_0 9_0_9 12_10_0 12_55_8 12_56_5 12_57_0 12_60_7 12_61_7 20_1_4 20_2_0 bdw skl pvc)                      # Intel
+        sm_60 sm_61 sm_62 sm_70 sm_71 sm_75 sm_80 sm_86 sm_87 sm_89 sm_90 sm_100 sm_101 sm_103 sm_110 sm_120 sm_121                 # Nvidia
+        gfx900 gfx906 gfx908 gfx90a gfx942 gfx950 gfx1010 gfx1030 gfx1100 gfx1101 gfx1102 gfx1103 gfx1200 gfx1201 gfx1250 gfx1251   # AMD
+        8_0_0 9_0_9 12_10_0 12_55_8 12_56_5 12_57_0 12_60_7 12_61_7 20_1_4 20_2_0 bdw skl pvc)                                      # Intel
 set_property(CACHE DEVICE_ARCH PROPERTY STRINGS ${DEVICE_ARCH_OPTIONS})
 
 set(PRECISION "double" CACHE STRING "Type of floating point precision, namely: double/single")


### PR DESCRIPTION
Add the two archs to the options list—so that we can cycle through them in CCmake (TODO: at some point clean up the list or make it free form eventually).

While not officially named (yet), they (gfx1250, gfx1251) get a lot of attention in the LLVM backend (cf. https://llvm.org/docs/AMDGPUUsage.html ).
Moreover, gfx1251 has the row share DPP64 extensions that only CDNA 2-4 had so far (all at least up to my knowledge).

Tentative TensorForge support (without actual test hardware in use) is on the dev2 branch.
