### PR TITLE
Update runners to Ubuntu 26.04

### DIFF
--- a/.github/workflows/bandit.yml
+++ b/.github/workflows/bandit.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   bandit:
     name: bandit
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     steps:
       - uses: actions/checkout@v6
         name: checkout-seissol

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/build-seissol-cpu.yml
+++ b/.github/workflows/build-seissol-cpu.yml
@@ -15,7 +15,7 @@ env:
 jobs:
   seissol-build-test:
     name: seissol-build-test
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     container: ${{ matrix.setup.container }}
     continue-on-error: true
     strategy:
@@ -163,7 +163,7 @@ jobs:
 
   seissol-run-test:
     name: seissol-run-test
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     container: ${{ matrix.setup.container }}
     continue-on-error: true
     needs: [seissol-build-test]

--- a/.github/workflows/build-seissol-gpu.yml
+++ b/.github/workflows/build-seissol-gpu.yml
@@ -61,7 +61,7 @@ jobs:
             cxx: g++-13
             fc: gfortran-13
             container: seissol/gha-gpu-nv:davschneller-gpu-image
-            runner: ubuntu-24.04
+            runner: ubuntu-26.04
             pythonbreak: true
           - arch: sm_60
             backend: cuda
@@ -69,7 +69,7 @@ jobs:
             cxx: clang++-18
             fc: gfortran-13 # TODO?
             container: seissol/gha-gpu-nv:davschneller-gpu-image
-            runner: ubuntu-24.04
+            runner: ubuntu-26.04
             pythonbreak: true
           # TODO: needs a working GPU runner
           #- arch: sm_60
@@ -86,7 +86,7 @@ jobs:
             cxx: g++-13
             fc: gfortran-13
             container: seissol/gha-gpu-amd:davschneller-gpu-image
-            runner: ubuntu-24.04
+            runner: ubuntu-26.04
             pythonbreak: true
           - arch: gfx906
             backend: hip
@@ -94,7 +94,7 @@ jobs:
             cxx: clang++-18
             fc: gfortran-13 # TODO?
             container: seissol/gha-gpu-amd:davschneller-gpu-image
-            runner: ubuntu-24.04
+            runner: ubuntu-26.04
             pythonbreak: true
           - arch: skl
             backend: oneapi
@@ -102,7 +102,7 @@ jobs:
             cxx: icpx
             fc: ifx
             container: seissol/gha-gpu-intel:davschneller-gpu-image
-            runner: ubuntu-24.04
+            runner: ubuntu-26.04
             pythonbreak: false
     steps:
       - name: checkout-seissol

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   clang-format:
     name: clang-format
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -17,13 +17,13 @@ jobs:
       - name: apt-get
         run: |
           sudo apt-get update
-          sudo apt-get install hdf5-tools libeigen3-dev libhdf5-openmpi-dev libmetis-dev libomp-dev libopenmpi-dev libparmetis-dev libyaml-cpp-dev openmpi-bin openmpi-common python3.10 python3-pip
+          sudo apt-get install hdf5-tools libeigen3-dev libhdf5-openmpi-dev libomp-dev libopenmpi-dev libptscotch-dev libyaml-cpp-dev openmpi-bin openmpi-common python3 python3-pip
 
           # fetch the latest clang-tidy manually from the LLVM sources; since that's usually not provided in the Ubuntu default repos. (and we update the clang-tidy version more often than there are Ubuntu-LTS releases)
 
-          wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-          sudo add-apt-repository "deb http://apt.llvm.org/noble/ llvm-toolchain-noble-22 main"
-          sudo add-apt-repository "deb-src http://apt.llvm.org/noble/ llvm-toolchain-noble-22 main"
+          wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc
+          sudo add-apt-repository "deb http://apt.llvm.org/resolute/ llvm-toolchain-resolute-22 main"
+          sudo add-apt-repository "deb-src http://apt.llvm.org/resolute/ llvm-toolchain-resolute-22 main"
           sudo apt-get update
 
           sudo apt-get -y install clang-22 clang-tidy-22 libomp-22-dev
@@ -54,7 +54,7 @@ jobs:
           which clang-tidy-22
           git submodule update --init
           mkdir -p build && cd build
-          CMAKE_PREFIX_PATH=/opt/dependencies cmake -DGEMM_TOOLS_LIST=none -DNETCDF=OFF -DORDER=6 -DASAGI=OFF -DHDF5=ON -DCMAKE_BUILD_TYPE=Debug -DTESTING=ON -DLOG_LEVEL=warning -DLOG_LEVEL_MASTER=info -DHOST_ARCH=hsw -DPRECISION=double -DEQUATIONS=elastic -DNUMBER_OF_MECHANISMS=0 -DTESTING=ON -DCMAKE_EXPORT_COMPILE_COMMANDS=ON ..
+          CMAKE_PREFIX_PATH=/opt/dependencies cmake -DGEMM_TOOLS_LIST=none -DNETCDF=OFF -DORDER=6 -DASAGI=OFF -DHDF5=ON -DCMAKE_BUILD_TYPE=Debug -DTESTING=ON -DLOG_LEVEL=warning -DLOG_LEVEL_MASTER=info -DHOST_ARCH=hsw -DPRECISION=double -DEQUATIONS=elastic -DNUMBER_OF_MECHANISMS=0 -DTESTING=ON -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DGRAPH_PARTITIONING_LIBS=ptscotch ..
           make seissol-codegen
           # clang-tidy can not handle -fprofile-abs-path, so we remove it from the compile commands.
           sed -i 's/-fprofile-abs-path //g' compile_commands.json

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   clang-tidy:
     name: clang-tidy
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     steps:
       - name: apt-get
         run: |

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   coverage:
     name: coverage
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     steps:
       - name: apt-get
         run: |

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -17,7 +17,7 @@ jobs:
       - name: apt-get
         run: |
           sudo apt-get update
-          sudo apt-get install lcov ninja-build hdf5-tools libeigen3-dev libhdf5-openmpi-dev libmetis-dev libomp-dev libopenmpi-dev libparmetis-dev libyaml-cpp-dev openmpi-bin openmpi-common python3.10 python3-pip
+          sudo apt-get install lcov ninja-build hdf5-tools libeigen3-dev libhdf5-openmpi-dev libomp-dev libopenmpi-dev libptscotch-dev libyaml-cpp-dev openmpi-bin openmpi-common python3 python3-pip
 
           sudo pip3 install setuptools numpy --break-system-packages
           sudo mkdir -p /opt/dependencies
@@ -44,15 +44,15 @@ jobs:
         run: |
           mkdir build && cd build
 
-          export CC=gcc-13
-          export CXX=g++-13
-          export FC=gfortran-13
+          export CC=gcc-15
+          export CXX=g++-15
+          export FC=gfortran-15
 
           mkdir -p /opt/seissol
 
           # run w/o netcdf for consistency with the clang-tidy check
           export CMAKE_PREFIX_PATH=/opt/dependencies
-          cmake .. -GNinja -DCMAKE_INSTALL_PREFIX=/opt/seissol -DGEMM_TOOLS_LIST=none -DNETCDF=OFF -DCOVERAGE=ON -DTESTING=ON -DTESTING_GENERATED=ON -DHOST_ARCH=hsw -DORDER=6 -DCMAKE_BUILD_TYPE=Debug -DEQUATIONS=elastic -DPRECISION=double
+          cmake .. -GNinja -DCMAKE_INSTALL_PREFIX=/opt/seissol -DGEMM_TOOLS_LIST=none -DNETCDF=OFF -DCOVERAGE=ON -DTESTING=ON -DTESTING_GENERATED=ON -DHOST_ARCH=hsw -DORDER=6 -DCMAKE_BUILD_TYPE=Debug -DEQUATIONS=elastic -DPRECISION=double -DGRAPH_PARTITIONING_LIBS=ptscotch
           ninja
 
       - name: seissol-coverage

--- a/.github/workflows/doc-template.yml
+++ b/.github/workflows/doc-template.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   seissol-docs:
     name: seissol-docs
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/filename-check.yml
+++ b/.github/workflows/filename-check.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   filename-check:
     name: filename-check
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   flake8:
     name: flake8
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     steps:
       - uses: actions/checkout@v6
         name: checkout-seissol

--- a/.github/workflows/hadolint.yml
+++ b/.github/workflows/hadolint.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   hadolint:
     name: hadolint
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     container: ghcr.io/hadolint/hadolint:latest-alpine
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/header-check.yml
+++ b/.github/workflows/header-check.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   header-check:
     name: header-check
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/jsonlint.yml
+++ b/.github/workflows/jsonlint.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   jsonlint:
     name: jsonlint
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   markdown-lint:
     name: markdown-lint
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     steps:
       - uses: actions/checkout@v6
         name: checkout-seissol

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   pre-commit:
     name: pre-commit
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/pytest-python.yml
+++ b/.github/workflows/pytest-python.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
       - name: checkout-seissol

--- a/.github/workflows/pytest-python.yml
+++ b/.github/workflows/pytest-python.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   pytest:
     name: pytest-${{ matrix.python-version }}
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/reuse.yml
+++ b/.github/workflows/reuse.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   reuse:
     name: reuse
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     steps:
       - uses: actions/checkout@v6
       - uses: fsfe/reuse-action@v6

--- a/.github/workflows/sphinx-lint.yml
+++ b/.github/workflows/sphinx-lint.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   sphinx-lint:
     name: sphinx-lint
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     steps:
       - uses: actions/checkout@v6
         name: checkout-seissol

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -14,7 +14,7 @@ version: 2
 
 # Set the OS, Python version and other tools you might need
 build:
-   os: ubuntu-24.04
+   os: ubuntu-26.04
    tools:
       python: "3.12"
 


### PR DESCRIPTION
Switch all CI jobs to use Ubuntu 26.04 (as it's available now).

The Docker images in the `.ci` folder will be updated in a separate PR (there are already more modern versions of them on some branch).

Requires switching from ParMETIS to SCOTCH as the former isn't shipped with Ubuntu 26.04 anymore (luckily SeisSol supports both).

