### PR TITLE
Print some build options when supplying `-h`

### DIFF
--- a/app/Main/Main.cpp
+++ b/app/Main/Main.cpp
@@ -6,6 +6,7 @@
 // SPDX-FileContributor: Author lists in /AUTHORS and /CITATION.cff
 // SPDX-FileContributor: Sebastian Rettenberger
 
+#include "Common/ConfigHelper.h"
 #include "Initializer/InitProcedure/Init.h"
 #include "Initializer/Parameters/ParameterReader.h"
 #include "Initializer/Parameters/SeisSolParameters.h"
@@ -126,12 +127,11 @@ int main(int argc, char* argv[]) {
 #endif
     }
 
-    // TODO Read parameters here
-    // Parse command line arguments
     utils::Args args(
         "SeisSol is a scientific software for the numerical simulation of seismic wave "
-        "phenomena and earthquake dynamics.");
-    args.addAdditionalOption("file", "The parameter file", false);
+        "phenomena and earthquake dynamics. This version of SeisSol (" +
+        ConfigString + ") was built with the following properties:\n" + ConfigDescriptor);
+    args.addAdditionalOption("parameterfile", "The parameter file", false);
     args.addOption(
         "checkpoint", 'c', "The checkpoint file to restart from", utils::Args::Optional, false);
     switch (args.parse(argc, argv)) {
@@ -146,7 +146,7 @@ int main(int argc, char* argv[]) {
       break;
     }
     }
-    const auto* parameterFile = args.getAdditionalArgument("file", "parameters.par");
+    const auto* parameterFile = args.getAdditionalArgument("parameterfile", "parameters.par");
     logInfo() << "Using the parameter file" << parameterFile;
     // read parameter file input
     const auto yamlParams = readYamlParams(parameterFile);

--- a/app/Proxy/Main.cpp
+++ b/app/Proxy/Main.cpp
@@ -48,7 +48,7 @@ int main(int argc, char* argv[]) {
   const std::vector<std::string> formatValues = {"plain", "json"};
 
   utils::Args args("The SeisSol proxy is used to benchmark the kernels used in the SeisSol "
-                   "earthquake simulation software. This version of SeisSol (" +
+                   "earthquake simulation software. This version of SeisSol proxy (" +
                    seissol::ConfigString + ") was built with the following properties:\n" +
                    seissol::ConfigDescriptor);
   args.addAdditionalOption("cells", "Number of cells");

--- a/app/Proxy/Main.cpp
+++ b/app/Proxy/Main.cpp
@@ -6,6 +6,7 @@
 //
 // SPDX-FileContributor: Author lists in /AUTHORS and /CITATION.cff
 
+#include "Common/ConfigHelper.h"
 #include "Common/Executor.h"
 #include "Kernels/Common.h"
 #include "Proxy/Common.h"
@@ -47,7 +48,9 @@ int main(int argc, char* argv[]) {
   const std::vector<std::string> formatValues = {"plain", "json"};
 
   utils::Args args("The SeisSol proxy is used to benchmark the kernels used in the SeisSol "
-                   "earthquake simulation software.");
+                   "earthquake simulation software. This version of SeisSol (" +
+                   seissol::ConfigString + ") was built with the following properties:\n" +
+                   seissol::ConfigDescriptor);
   args.addAdditionalOption("cells", "Number of cells");
   args.addAdditionalOption("timesteps", "Number of timesteps");
   args.addAdditionalOption("kernel", kernelHelp.str());

--- a/src/Common/CMakeLists.txt
+++ b/src/Common/CMakeLists.txt
@@ -6,6 +6,7 @@
 # SPDX-FileContributor: Author lists in /AUTHORS and /CITATION.cff
 
 add_library(seissol-common OBJECT
+    ConfigHelper.cpp
     Filesystem.cpp
     IntegerMaskParser.cpp
 )

--- a/src/Common/ConfigHelper.cpp
+++ b/src/Common/ConfigHelper.cpp
@@ -1,0 +1,58 @@
+// SPDX-FileCopyrightText: 2026 SeisSol Group
+//
+// SPDX-License-Identifier: BSD-3-Clause
+// SPDX-LicenseComments: Full text under /LICENSE and /LICENSES/
+//
+// SPDX-FileContributor: Author lists in /AUTHORS and /CITATION.cff
+
+#include "ConfigHelper.h"
+
+#include "Common/Real.h"
+#include "Common/Typedefs.h"
+#include "Config.h"
+#include "Equations/Datastructures.h"
+
+namespace seissol {
+
+namespace {
+template <typename Cfg>
+std::string configToString() {
+  std::stringstream str;
+  str << seissol::model::MaterialT::Text << "-o" << Cfg::ConvergenceOrder << "-"
+      << stringRealType(Cfg::Precision);
+  if (Cfg::NumSimulations > 1) {
+    str << "-s" << Cfg::NumSimulations;
+  }
+  return str.str();
+}
+
+template <typename Cfg>
+std::string configToDescriptor() {
+  std::stringstream str;
+
+  str << "Material: \"" << seissol::model::MaterialT::Text << "\"\n";
+  str << "Convergence order: " << Cfg::ConvergenceOrder << "\n";
+  str << "Precision: " << stringRealType(Cfg::Precision) << "\n";
+  str << "Simulation count: " << Cfg::NumSimulations << "\n";
+  str << "Dynamic rupture quadrature rule: \"" << []() -> std::string {
+    switch (Cfg::DRQuadRule) {
+    case DRQuadRuleType::Dunavant:
+      return "Dunavant";
+    case DRQuadRuleType::Stroud:
+      return "Stroud";
+    case DRQuadRuleType::WitherdenVincent:
+      return "Witherden-Vincent";
+    default:
+      return "Unknown (consult the developers for more info)";
+    }
+  }() << "\"\n";
+
+  return str.str();
+}
+
+} // namespace
+
+const std::string ConfigString = configToString<Config>();
+const std::string ConfigDescriptor = configToDescriptor<Config>();
+
+} // namespace seissol

--- a/src/Common/ConfigHelper.cpp
+++ b/src/Common/ConfigHelper.cpp
@@ -12,6 +12,9 @@
 #include "Config.h"
 #include "Equations/Datastructures.h"
 
+#include <sstream>
+#include <string>
+
 namespace seissol {
 
 namespace {

--- a/src/Common/ConfigHelper.h
+++ b/src/Common/ConfigHelper.h
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: 2026 SeisSol Group
+//
+// SPDX-License-Identifier: BSD-3-Clause
+// SPDX-LicenseComments: Full text under /LICENSE and /LICENSES/
+//
+// SPDX-FileContributor: Author lists in /AUTHORS and /CITATION.cff
+#ifndef SEISSOL_SRC_COMMON_CONFIGHELPER_H_
+#define SEISSOL_SRC_COMMON_CONFIGHELPER_H_
+
+#include <string>
+namespace seissol {
+
+extern const std::string ConfigString;
+extern const std::string ConfigDescriptor;
+
+} // namespace seissol
+#endif // SEISSOL_SRC_COMMON_CONFIGHELPER_H_

--- a/src/Common/Real.h
+++ b/src/Common/Real.h
@@ -8,6 +8,7 @@
 #define SEISSOL_SRC_COMMON_REAL_H_
 
 #include <cstddef>
+#include <string>
 namespace seissol {
 
 enum class RealType { F32, F64 };
@@ -34,6 +35,19 @@ constexpr std::size_t sizeOfRealType(RealType type) {
     return 4;
   case seissol::RealType::F64:
     return 8;
+  default:
+    throw;
+  }
+}
+
+// TODO: make constexpr with C++20
+
+inline std::string stringRealType(RealType type) {
+  switch (type) {
+  case seissol::RealType::F32:
+    return "f32";
+  case seissol::RealType::F64:
+    return "f64";
   default:
     throw;
   }


### PR DESCRIPTION
As requested in https://github.com/SeisSol/SeisSol/pull/1585#issuecomment-4743894171 , print some current build configuration options. Notably still missing is the plasticity basis right now.

(or, once #1421 exists, a list of all included build options)

Might still need some pretty formatting.
