### PR TITLE
Fix a padding issue with the GPU-FSG implementation

### DIFF
--- a/src/Initializer/BatchRecorders/LocalIntegrationRecorder.cpp
+++ b/src/Initializer/BatchRecorders/LocalIntegrationRecorder.cpp
@@ -330,8 +330,8 @@ void LocalIntegrationRecorder::recordFreeSurfaceGravityBc() {
                                                     counter[face] * tensor::INodal::size());
           dofsFaceNodalPtrs[face].push_back(dofsFaceNodalScratch +
                                             counter[face] * tensor::INodal::size());
-          prevCoefficientsPtrs[face].push_back(
-              prevCoefficientsScratch + counter[face] * multisim::leadDim<nodal::init::nodes2D>());
+          prevCoefficientsPtrs[face].push_back(prevCoefficientsScratch +
+                                               counter[face] * NodalAvgDisplacementsSize);
           invImpedances[face].push_back(0);
 
           ++counter[face];

--- a/src/Initializer/BatchRecorders/LocalIntegrationRecorder.cpp
+++ b/src/Initializer/BatchRecorders/LocalIntegrationRecorder.cpp
@@ -331,8 +331,7 @@ void LocalIntegrationRecorder::recordFreeSurfaceGravityBc() {
           dofsFaceNodalPtrs[face].push_back(dofsFaceNodalScratch +
                                             counter[face] * tensor::INodal::size());
           prevCoefficientsPtrs[face].push_back(
-              prevCoefficientsScratch +
-              counter[face] * nodal::tensor::nodes2D::Shape[multisim::BasisFunctionDimension]);
+              prevCoefficientsScratch + counter[face] * multisim::leadDim<nodal::init::nodes2D>());
           invImpedances[face].push_back(0);
 
           ++counter[face];

--- a/src/Initializer/MemoryManager.cpp
+++ b/src/Initializer/MemoryManager.cpp
@@ -34,7 +34,6 @@
 #include "Memory/MemoryAllocator.h"
 #include "Memory/Tree/Layer.h"
 #include "SeisSol.h"
-#include "Solver/MultipleSimulations.h"
 
 #include <algorithm>
 #include <array>
@@ -251,7 +250,7 @@ void MemoryManager::deriveRequiredScratchpadMemoryForWp(bool plasticity, LTS::St
     layer.setEntrySize<LTS::DofsFaceNodalScratch>(sizeof(real) * freeSurfaceCount *
                                                   tensor::INodal::size());
     layer.setEntrySize<LTS::PrevCoefficientsScratch>(sizeof(real) * freeSurfaceCount *
-                                                     multisim::leadDim<nodal::init::nodes2D>());
+                                                     NodalDisplacementsSize);
   }
 }
 

--- a/src/Initializer/MemoryManager.cpp
+++ b/src/Initializer/MemoryManager.cpp
@@ -250,9 +250,8 @@ void MemoryManager::deriveRequiredScratchpadMemoryForWp(bool plasticity, LTS::St
                                                             init::rotatedFaceDisplacement::Size);
     layer.setEntrySize<LTS::DofsFaceNodalScratch>(sizeof(real) * freeSurfaceCount *
                                                   tensor::INodal::size());
-    layer.setEntrySize<LTS::PrevCoefficientsScratch>(
-        sizeof(real) * freeSurfaceCount *
-        nodal::tensor::nodes2D::Shape[multisim::BasisFunctionDimension]);
+    layer.setEntrySize<LTS::PrevCoefficientsScratch>(sizeof(real) * freeSurfaceCount *
+                                                     multisim::leadDim<nodal::init::nodes2D>());
   }
 }
 

--- a/src/Kernels/LinearCK/DeviceAux/cudahip/KernelsAux.cpp
+++ b/src/Kernels/LinearCK/DeviceAux/cudahip/KernelsAux.cpp
@@ -242,7 +242,7 @@ __global__ void kernelFreeSurfaceGravity(real** dofsFaceBoundaryNodalPtrs,
     real* elementBoundaryDofs = dofsFaceBoundaryNodalPtrs[elementId];
     real* elementDisplacement = displacementDataPtrs[elementId];
 
-    constexpr auto NumNodes = linearDim<seissol::nodal::init::nodes2D>();
+    constexpr auto NumNodes = linearDim<seissol::init::averageNormalDisplacement>();
     if (tid < NumNodes) {
       constexpr auto LdINodal = linearDim<seissol::init::INodal>();
 
@@ -263,7 +263,7 @@ void launchFreeSurfaceGravity(real** dofsFaceBoundaryNodalPtrs,
                               double g,
                               size_t numElements,
                               void* deviceStream) {
-  dim3 block = getblock(leadDim<seissol::nodal::init::nodes2D>());
+  dim3 block = getblock(leadDim<seissol::init::averageNormalDisplacement>());
   const dim3 grid(numElements, 1, 1);
   auto* stream = reinterpret_cast<StreamT>(deviceStream);
   kernelFreeSurfaceGravity<<<grid, block, 0, stream>>>(
@@ -412,11 +412,11 @@ __global__ void
     auto* integratedDisplacementNodal = integratedDisplacementNodalPtrs[elementId];
     const auto* rotatedFaceDisplacement = rotatedFaceDisplacementPtrs[elementId];
 
-    assert(linearDim<seissol::nodal::init::nodes2D>() <=
+    assert(linearDim<seissol::init::averageNormalDisplacement>() <=
            linearDim<seissol::init::rotatedFaceDisplacement>());
 
     const int tid = linearidx();
-    constexpr auto Num2dNodes = linearDim<seissol::nodal::init::nodes2D>();
+    constexpr auto Num2dNodes = linearDim<seissol::init::averageNormalDisplacement>();
     if (tid < Num2dNodes) {
       prevCoefficients[tid] = rotatedFaceDisplacement[tid];
       integratedDisplacementNodal[tid] = deltaTInt * rotatedFaceDisplacement[tid];
@@ -431,7 +431,7 @@ void initializeTaylorSeriesForGravitationalBoundary(real** prevCoefficientsPtrs,
                                                     size_t numElements,
                                                     void* deviceStream) {
 
-  dim3 block = getblock(leadDim<seissol::nodal::init::nodes2D>());
+  dim3 block = getblock(leadDim<seissol::init::averageNormalDisplacement>());
   const dim3 grid(numElements, 1, 1);
   auto* stream = reinterpret_cast<StreamT>(deviceStream);
   kernelInitializeTaylorSeriesForGravitationalBoundary<<<grid, block, 0, stream>>>(
@@ -477,7 +477,7 @@ __global__ void kernelUpdateRotatedFaceDisplacement(real** rotatedFaceDisplaceme
   if (elementId < numElements) {
     constexpr int PIdx = 0;
     constexpr int UIdx = model::MaterialT::TractionQuantities;
-    constexpr auto Num2dNodes = linearDim<seissol::nodal::init::nodes2D>();
+    constexpr auto Num2dNodes = linearDim<seissol::init::averageNormalDisplacement>();
 
     const int tid = linearidx();
     if (tid < Num2dNodes) {
@@ -527,7 +527,7 @@ void updateRotatedFaceDisplacement(real** rotatedFaceDisplacementPtrs,
                                    double factorInt,
                                    size_t numElements,
                                    void* deviceStream) {
-  dim3 block = getblock(leadDim<seissol::nodal::init::nodes2D>());
+  dim3 block = getblock(leadDim<seissol::init::averageNormalDisplacement>());
   const dim3 grid(numElements, 1, 1);
   auto* stream = reinterpret_cast<StreamT>(deviceStream);
   kernelUpdateRotatedFaceDisplacement<<<grid, block, 0, stream>>>(rotatedFaceDisplacementPtrs,

--- a/src/Kernels/LinearCK/DeviceAux/cudahip/KernelsAux.cpp
+++ b/src/Kernels/LinearCK/DeviceAux/cudahip/KernelsAux.cpp
@@ -186,24 +186,6 @@ void taylorSum(
 namespace {
 using namespace seissol::multisim;
 
-template <typename Tensor>
-constexpr size_t leadDim() {
-  if constexpr (MultisimEnabled) {
-    return Tensor::Stop[1] - Tensor::Start[1];
-  } else {
-    return Tensor::Stop[0] - Tensor::Start[0];
-  }
-}
-
-template <typename Tensor>
-constexpr size_t linearDim() {
-  if constexpr (MultisimEnabled) {
-    return (Tensor::Stop[1] - Tensor::Start[1]) * (Tensor::Stop[0] - Tensor::Start[0]);
-  } else {
-    return Tensor::Stop[0] - Tensor::Start[0];
-  }
-}
-
 constexpr auto getblock(int size) {
   if constexpr (MultisimEnabled) {
     return dim3(NumSimulations, size);

--- a/src/Kernels/LinearCK/DeviceAux/sycl/KernelsAux.cpp
+++ b/src/Kernels/LinearCK/DeviceAux/sycl/KernelsAux.cpp
@@ -193,7 +193,7 @@ void launchFreeSurfaceGravity(real** dofsFaceBoundaryNodalPtrs,
                               void* deviceStream) {
 
   auto queue = reinterpret_cast<sycl::queue*>(deviceStream);
-  const size_t workGroupSize = leadDim<seissol::nodal::init::nodes2D>();
+  const size_t workGroupSize = leadDim<seissol::init::averageNormalDisplacement>();
   auto rng = getrange(workGroupSize, numElements);
 
   queue->parallel_for(rng, [=](sycl::nd_item<1> item) {
@@ -204,7 +204,7 @@ void launchFreeSurfaceGravity(real** dofsFaceBoundaryNodalPtrs,
       real* elementBoundaryDofs = dofsFaceBoundaryNodalPtrs[elementId];
       real* elementDisplacement = displacementDataPtrs[elementId];
 
-      constexpr auto numNodes = linearDim<seissol::nodal::init::nodes2D>();
+      constexpr auto numNodes = linearDim<seissol::init::averageNormalDisplacement>();
       if (tid < numNodes) {
         constexpr auto ldINodal = linearDim<seissol::init::INodal>();
 
@@ -352,7 +352,7 @@ void initializeTaylorSeriesForGravitationalBoundary(real** prevCoefficientsPtrs,
                                                     void* deviceStream) {
 
   auto queue = reinterpret_cast<sycl::queue*>(deviceStream);
-  const size_t workGroupSize = leadDim<seissol::nodal::init::nodes2D>();
+  const size_t workGroupSize = leadDim<seissol::init::averageNormalDisplacement>();
   auto rng = getrange(workGroupSize, numElements);
 
   queue->parallel_for(rng, [=](sycl::nd_item<1> item) {
@@ -362,11 +362,11 @@ void initializeTaylorSeriesForGravitationalBoundary(real** prevCoefficientsPtrs,
       auto* integratedDisplacementNodal = integratedDisplacementNodalPtrs[elementId];
       const auto* rotatedFaceDisplacement = rotatedFaceDisplacementPtrs[elementId];
 
-      assert(linearDim<seissol::nodal::init::nodes2D>() <=
+      assert(linearDim<seissol::init::averageNormalDisplacement>() <=
              linearDim<seissol::init::rotatedFaceDisplacement>());
 
       const int tid = item.get_local_id(0);
-      constexpr auto num2dNodes = linearDim<seissol::nodal::init::nodes2D>();
+      constexpr auto num2dNodes = linearDim<seissol::init::averageNormalDisplacement>();
       if (tid < num2dNodes) {
         prevCoefficients[tid] = rotatedFaceDisplacement[tid];
         integratedDisplacementNodal[tid] = deltaTInt * rotatedFaceDisplacement[tid];
@@ -401,7 +401,7 @@ void updateRotatedFaceDisplacement(real** rotatedFaceDisplacementPtrs,
                                    void* deviceStream) {
 
   auto queue = reinterpret_cast<sycl::queue*>(deviceStream);
-  const size_t workGroupSize = leadDim<seissol::nodal::init::nodes2D>();
+  const size_t workGroupSize = leadDim<seissol::init::averageNormalDisplacement>();
   auto rng = getrange(workGroupSize, numElements);
 
   queue->parallel_for(rng, [=](sycl::nd_item<1> item) {
@@ -409,7 +409,7 @@ void updateRotatedFaceDisplacement(real** rotatedFaceDisplacementPtrs,
     if (elementId < numElements) {
       constexpr int pIdx = 0;
       constexpr int uIdx = model::MaterialT::TractionQuantities;
-      constexpr auto num2dNodes = linearDim<seissol::nodal::init::nodes2D>();
+      constexpr auto num2dNodes = linearDim<seissol::init::averageNormalDisplacement>();
 
       const int tid = item.get_local_id(0);
       if (tid < num2dNodes) {

--- a/src/Kernels/LinearCK/DeviceAux/sycl/KernelsAux.cpp
+++ b/src/Kernels/LinearCK/DeviceAux/sycl/KernelsAux.cpp
@@ -174,24 +174,6 @@ void taylorSum(
 namespace {
 using namespace seissol::multisim;
 
-template <typename Tensor>
-constexpr size_t leadDim() {
-  if constexpr (MultisimEnabled) {
-    return Tensor::Stop[1] - Tensor::Start[1];
-  } else {
-    return Tensor::Stop[0] - Tensor::Start[0];
-  }
-}
-
-template <typename Tensor>
-constexpr size_t linearDim() {
-  if constexpr (MultisimEnabled) {
-    return (Tensor::Stop[1] - Tensor::Start[1]) * (Tensor::Stop[0] - Tensor::Start[0]);
-  } else {
-    return Tensor::Stop[0] - Tensor::Start[0];
-  }
-}
-
 auto getrange(std::size_t size, std::size_t numElements) {
   if constexpr (MultisimEnabled) {
     return sycl::nd_range<1>({numElements * NumSimulations * size}, {NumSimulations * size});

--- a/src/Solver/MultipleSimulations.h
+++ b/src/Solver/MultipleSimulations.h
@@ -180,6 +180,24 @@ constexpr size_t MultisimStart = MultisimHelper::MultisimStart;
 constexpr size_t MultisimEnd = MultisimHelper::MultisimEnd;
 constexpr bool MultisimEnabled = MultisimHelper::MultisimEnabled;
 
+template <typename Tensor>
+constexpr size_t leadDim() {
+  if constexpr (MultisimEnabled) {
+    return Tensor::Stop[1] - Tensor::Start[1];
+  } else {
+    return Tensor::Stop[0] - Tensor::Start[0];
+  }
+}
+
+template <typename Tensor>
+constexpr size_t linearDim() {
+  if constexpr (MultisimEnabled) {
+    return (Tensor::Stop[1] - Tensor::Start[1]) * (Tensor::Stop[0] - Tensor::Start[0]);
+  } else {
+    return Tensor::Stop[0] - Tensor::Start[0];
+  }
+}
+
 } // namespace seissol::multisim
 
 #endif // SEISSOL_SRC_SOLVER_MULTIPLESIMULATIONS_H_


### PR DESCRIPTION
The previous dofs were allocated too small compared to what the kernel wanted (padding was missing); thus potentially reading out of bounds (and crashing the simulation).
In short, we just switch it with a definitely padded array.

(note to self: we might somehow wanna start trying to include the padding info to the type system somehow. Too many bugs from there—they feel avoidable. ... Possibly with C++20 spans or beyond. Also note #1466 for a complete refactor of the FSG kernels)
