### PR TITLE
Fix ICX 2025/2026 builds

### DIFF
--- a/src/DynamicRupture/FrictionLaws/CpuImpl/RateAndState.h
+++ b/src/DynamicRupture/FrictionLaws/CpuImpl/RateAndState.h
@@ -12,6 +12,12 @@
 #include "DynamicRupture/FrictionLaws/RateAndStateCommon.h"
 #include "Memory/Descriptor/DynamicRupture.h"
 
+#ifdef __INTEL_LLVM_COMPILER
+#if __INTEL_LLVM_COMPILER >= 20250000
+#define SEISSOL_INTEL_SIMD_EXCEPTION
+#endif
+#endif // __INTEL_LLVM_COMPILER
+
 namespace seissol::dr::friction_law::cpu {
 /**
  * General implementation of a rate and state solver
@@ -367,7 +373,10 @@ class RateAndStateBase : public BaseFrictionLaw<RateAndStateBase<Derived, TPMeth
         }
         return hasConverged;
       }
+
+#ifndef SEISSOL_INTEL_SIMD_EXCEPTION
 #pragma omp simd
+#endif
       for (std::uint32_t pointIndex = 0; pointIndex < misc::NumPaddedPoints; pointIndex++) {
         const auto localSlipRateTest = slipRateTest[pointIndex];
 

--- a/src/DynamicRupture/FrictionLaws/CpuImpl/RateAndState.h
+++ b/src/DynamicRupture/FrictionLaws/CpuImpl/RateAndState.h
@@ -351,7 +351,10 @@ class RateAndStateBase : public BaseFrictionLaw<RateAndStateBase<Derived, TPMeth
     }
 
     for (uint32_t i = 0; i < this->drParameters_.rsMaxNumberSlipRateUpdates; i++) {
+
+#ifndef SEISSOL_INTEL_SIMD_EXCEPTION
 #pragma omp simd
+#endif
       for (std::uint32_t pointIndex = 0; pointIndex < misc::NumPaddedPoints; pointIndex++) {
         // calculate friction coefficient and objective function
         muF[pointIndex] =

--- a/src/DynamicRupture/FrictionLaws/CpuImpl/RateAndState.h
+++ b/src/DynamicRupture/FrictionLaws/CpuImpl/RateAndState.h
@@ -334,9 +334,7 @@ class RateAndStateBase : public BaseFrictionLaw<RateAndStateBase<Derived, TPMeth
                                std::array<real, misc::NumPaddedPoints>& slipRateTest) {
 
     real muF[misc::NumPaddedPoints]{};
-    real dMuF[misc::NumPaddedPoints]{};
     real g[misc::NumPaddedPoints]{};
-    real dG[misc::NumPaddedPoints]{};
 
     const auto details = static_cast<Derived*>(this)->getMuDetails(ltsFace, localStateVariable);
 
@@ -371,16 +369,19 @@ class RateAndStateBase : public BaseFrictionLaw<RateAndStateBase<Derived, TPMeth
       }
 #pragma omp simd
       for (std::uint32_t pointIndex = 0; pointIndex < misc::NumPaddedPoints; pointIndex++) {
-        dMuF[pointIndex] = static_cast<Derived*>(this)->updateMuDerivative(
-            pointIndex, slipRateTest[pointIndex], details);
+        const auto localSlipRateTest = slipRateTest[pointIndex];
+
+        const auto dMuF =
+            static_cast<Derived*>(this)->updateMuDerivative(pointIndex, localSlipRateTest, details);
 
         // derivative of g
-        dG[pointIndex] = -this->impAndEta_[ltsFace].invEtaS *
-                             (std::abs(normalStress[pointIndex]) * dMuF[pointIndex]) -
-                         static_cast<real>(1.0);
+        const auto dG =
+            -this->impAndEta_[ltsFace].invEtaS * (std::abs(normalStress[pointIndex]) * dMuF) -
+            static_cast<real>(1.0);
+
         // newton update
-        const real tmp3 = g[pointIndex] / dG[pointIndex];
-        slipRateTest[pointIndex] = std::max(rs::almostZero(), slipRateTest[pointIndex] - tmp3);
+        const real tmp3 = g[pointIndex] / dG;
+        slipRateTest[pointIndex] = std::max(rs::almostZero(), localSlipRateTest - tmp3);
       }
     }
 

--- a/src/DynamicRupture/FrictionLaws/CpuImpl/RateAndState.h
+++ b/src/DynamicRupture/FrictionLaws/CpuImpl/RateAndState.h
@@ -15,6 +15,9 @@
 #ifdef __INTEL_LLVM_COMPILER
 #if __INTEL_LLVM_COMPILER >= 20250000
 #define SEISSOL_INTEL_SIMD_EXCEPTION
+#if __INTEL_LLVM_COMPILER < 20260000
+#define SEISSOL_INTEL_SIMD_EXCEPTION_STRICT
+#endif
 #endif
 #endif // __INTEL_LLVM_COMPILER
 
@@ -344,7 +347,9 @@ class RateAndStateBase : public BaseFrictionLaw<RateAndStateBase<Derived, TPMeth
 
     const auto details = static_cast<Derived*>(this)->getMuDetails(ltsFace, localStateVariable);
 
+#ifndef SEISSOL_INTEL_SIMD_EXCEPTION_STRICT
 #pragma omp simd
+#endif
     for (std::uint32_t pointIndex = 0; pointIndex < misc::NumPaddedPoints; pointIndex++) {
       // first guess = sliprate value of the previous step
       slipRateTest[pointIndex] = this->slipRateMagnitude_[ltsFace][pointIndex];
@@ -352,7 +357,7 @@ class RateAndStateBase : public BaseFrictionLaw<RateAndStateBase<Derived, TPMeth
 
     for (uint32_t i = 0; i < this->drParameters_.rsMaxNumberSlipRateUpdates; i++) {
 
-#ifndef SEISSOL_INTEL_SIMD_EXCEPTION
+#ifndef SEISSOL_INTEL_SIMD_EXCEPTION_STRICT
 #pragma omp simd
 #endif
       for (std::uint32_t pointIndex = 0; pointIndex < misc::NumPaddedPoints; pointIndex++) {
@@ -370,7 +375,9 @@ class RateAndStateBase : public BaseFrictionLaw<RateAndStateBase<Derived, TPMeth
         return std::abs(val) < this->drParameters_.rsSlipRateTolerance;
       });
       if (hasConverged) {
+#ifndef SEISSOL_INTEL_SIMD_EXCEPTION_STRICT
 #pragma omp simd
+#endif
         for (std::uint32_t pointIndex = 0; pointIndex < misc::NumPaddedPoints; pointIndex++) {
           this->mu_[ltsFace][pointIndex] = muF[pointIndex];
         }
@@ -398,7 +405,9 @@ class RateAndStateBase : public BaseFrictionLaw<RateAndStateBase<Derived, TPMeth
     }
 
     // update (non-)convergence
+#ifndef SEISSOL_INTEL_SIMD_EXCEPTION_STRICT
 #pragma omp simd
+#endif
     for (std::uint32_t pointIndex = 0; pointIndex < misc::NumPaddedPoints; pointIndex++) {
       convergenceInner_[ltsFace][pointIndex] &=
           std::abs(g[pointIndex]) < this->drParameters_.rsSlipRateTolerance;


### PR DESCRIPTION
Fix #1591 . (albeit a bit suboptimally—no SIMD for the second loop section; cf. also #1382 )

Also remove two unnecessary arrays.
