### PR TITLE
Correctly name the parameters for strain rate output

### DIFF
--- a/docs/breaking-changes-backward-compatibility.rst
+++ b/docs/breaking-changes-backward-compatibility.rst
@@ -109,3 +109,12 @@ The adjustment was propagated to the GPU implementation after 1.3.0.
 The respective `commit <https://github.com/SeisSol/SeisSol/commit/73b284b7a8a2323170766f3ab594312a31f514c1>`_
 updated the CPU implementation; the GPU implementation was updated by
 `#1288 <https://github.com/SeisSol/SeisSol/pull/1288>`_.
+
+Name of the Strain Rate Output for Off-Fault Receivers
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+(since 1.2.0, `#1126 <https://github.com/SeisSol/SeisSol/pull/1126>`_, June 2024)
+
+The strain rate output was named just "strain" output for the off-fault receivers.
+The corresponding option was likewise called :code:`ReceiverComputeStrain`,
+not :code:`ReceiverComputeStrainRate`.

--- a/docs/off-fault-receivers.rst
+++ b/docs/off-fault-receivers.rst
@@ -56,9 +56,9 @@ Rotational Output
 You can additionally choose to write the rotation of the velocity field by setting :code:`ReceiverComputeRotation=1` in the parameter file.
 The rotation of the vector field is defined as :math:`\text{rot} v = \begin{pmatrix} \partial_2 v_3 - \partial_3 v_2 \\ \partial_3 v_1 - \partial_1 v_3 \\ \partial_1 v_2 - \partial_2 v_1 \\ \end{pmatrix}`.
 
-Strain Output
--------------
-Furthermore, you can also output the strain by setting :code:`ReceiverComputeStrain=1`.
+Strain Rate Output
+------------------
+Furthermore, you can also output the strain rate by setting :code:`ReceiverComputeStrainRate=1`.
 
 Placing free-surface receivers
 ------------------------------

--- a/docs/parameters.par
+++ b/docs/parameters.par
@@ -166,7 +166,7 @@ pickdt = 0.005                       ! Pickpoint Sampling
 !            If omitted, receivers are written at the end of the simulation.
 ReceiverOutputInterval = 10.0
 ReceiverComputeRotation = 0          ! Compute Rotation of the velocity field at the receivers
-ReceiverComputeStrain = 0          ! Compute strain at the receivers
+ReceiverComputeStrainRate = 0            ! Compute strain rate at the receivers
 
 ! Free surface output
 SurfaceOutput = 1

--- a/src/Initializer/Parameters/OutputParameters.cpp
+++ b/src/Initializer/Parameters/OutputParameters.cpp
@@ -154,7 +154,7 @@ ReceiverOutputParameters readReceiverParameters(ParameterReader* baseReader) {
       });
 
   const auto computeRotation = reader->readWithDefault("receivercomputerotation", false);
-  const auto computeStrain = reader->readWithDefault("receivercomputestrain", false);
+  const auto computeStrain = reader->readWithDefault("ReceiverComputeStrainRate", false);
   const auto samplingInterval = reader->readWithDefault("pickdt", 0.005);
   const auto fileName = reader->readPath("rfilename");
 


### PR DESCRIPTION
Previously called just "strain" output (but it was always strain rate—since we didn't integrate over the whole displacement. Cf. also how the energies are computed), for the off-fault receivers.
