### PR TITLE
Rename `-p` for acoustic

### DIFF
--- a/postprocessing/validation/compare-receivers.py
+++ b/postprocessing/validation/compare-receivers.py
@@ -25,7 +25,7 @@ else:
 _LEGACY_NAMES = {
     "xx": "s_xx", "yy": "s_yy", "zz": "s_zz",
     "xy": "s_xy", "xz": "s_xz", "yz": "s_yz",
-    "u": "v1", "v": "v2", "w": "v3", "-p": "np",
+    "u": "v1", "v": "v2", "w": "v3", "-p": "pprime",
 }
 
 

--- a/postprocessing/validation/compare-receivers.py
+++ b/postprocessing/validation/compare-receivers.py
@@ -25,7 +25,7 @@ else:
 _LEGACY_NAMES = {
     "xx": "s_xx", "yy": "s_yy", "zz": "s_zz",
     "xy": "s_xy", "xz": "s_xz", "yz": "s_yz",
-    "u": "v1", "v": "v2", "w": "v3",
+    "u": "v1", "v": "v2", "w": "v3", "-p": "np",
 }
 
 

--- a/postprocessing/validation/meshcompare.py
+++ b/postprocessing/validation/meshcompare.py
@@ -118,7 +118,7 @@ def compare(file, file_ref, epsilon):
         if q in mesh_ref.ReadAvailableDataFields():
             q_ref = q
         else:
-            q_ref = {"v1": "u", "v2": "v", "v3": "w", "np": "-p"}[q]
+            q_ref = {"v1": "u", "v2": "v", "v3": "w", "pprime": "-p"}[q]
         quantity_ref = mesh_ref.ReadData(q_ref, last_index - 1)
 
         # re-assign data

--- a/postprocessing/validation/meshcompare.py
+++ b/postprocessing/validation/meshcompare.py
@@ -118,7 +118,7 @@ def compare(file, file_ref, epsilon):
         if q in mesh_ref.ReadAvailableDataFields():
             q_ref = q
         else:
-            q_ref = {"v1": "u", "v2": "v", "v3": "w"}[q]
+            q_ref = {"v1": "u", "v2": "v", "v3": "w", "np": "-p"}[q]
         quantity_ref = mesh_ref.ReadData(q_ref, last_index - 1)
 
         # re-assign data

--- a/src/Equations/acoustic/Model/Datastructures.h
+++ b/src/Equations/acoustic/Model/Datastructures.h
@@ -36,7 +36,8 @@ struct AcousticMaterial : public Material {
   static inline const std::string Text = "acoustic";
   // The stress-velocity formulation of the elastic model is reused.
   // By definition, the normal stress and pressure are negatives of each other.
-  static inline const std::array<std::string, NumQuantities> Quantities = {"np", "v1", "v2", "v3"};
+  static inline const std::array<std::string, NumQuantities> Quantities = {
+      "pprime", "v1", "v2", "v3"};
   static constexpr std::size_t Parameters = 1 + Material::Parameters;
 
   static constexpr bool SupportsDR = false;

--- a/src/Equations/acoustic/Model/Datastructures.h
+++ b/src/Equations/acoustic/Model/Datastructures.h
@@ -36,7 +36,7 @@ struct AcousticMaterial : public Material {
   static inline const std::string Text = "acoustic";
   // The stress-velocity formulation of the elastic model is reused.
   // By definition, the normal stress and pressure are negatives of each other.
-  static inline const std::array<std::string, NumQuantities> Quantities = {"-p", "v1", "v2", "v3"};
+  static inline const std::array<std::string, NumQuantities> Quantities = {"np", "v1", "v2", "v3"};
   static constexpr std::size_t Parameters = 1 + Material::Parameters;
 
   static constexpr bool SupportsDR = false;


### PR DESCRIPTION
Currently, the negative pressure output is denoted by `-p` for acoustic (i.e. true acoustic; not the elastic-emulated one). If used in some software, that might cause issues with the naming or at least require additional quotation marks (due to the `-` in the name).

Hence, we replace it here by `pprime`.
