### PR TITLE
Split Yateto kernel builds per Yateto call

### DIFF
--- a/codegen/CMakeLists.txt
+++ b/codegen/CMakeLists.txt
@@ -10,15 +10,11 @@ add_custom_target(build-time-make-directory ALL
     COMMAND ${CMAKE_COMMAND} -E make_directory "${CMAKE_CURRENT_BINARY_DIR}/GeneratedCode")
 
 set(GENERATED_FILES_FOR_SEISSOL "${CMAKE_CURRENT_BINARY_DIR}/GeneratedCode/subroutine.h"
-                                "${CMAKE_CURRENT_BINARY_DIR}/GeneratedCode/tensor.cpp"
                                 "${CMAKE_CURRENT_BINARY_DIR}/GeneratedCode/subroutine.cpp"
                                 "${CMAKE_CURRENT_BINARY_DIR}/GeneratedCode/gpulike_subroutine.cpp"
                                 "${CMAKE_CURRENT_BINARY_DIR}/GeneratedCode/tensor.h"
-                                "${CMAKE_CURRENT_BINARY_DIR}/GeneratedCode/init.cpp"
                                 "${CMAKE_CURRENT_BINARY_DIR}/GeneratedCode/init.h"
-                                "${CMAKE_CURRENT_BINARY_DIR}/GeneratedCode/kernel.h"
-                                "${CMAKE_CURRENT_BINARY_DIR}/GeneratedCode/kernel.cpp"
-                                "${CMAKE_CURRENT_BINARY_DIR}/GeneratedCode/test-kernel.cpp")
+                                "${CMAKE_CURRENT_BINARY_DIR}/GeneratedCode/kernel.h")
 
 file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/GeneratedCode/)
 
@@ -34,9 +30,8 @@ else()
   set(OVERRIDE_VECTORSIZE_PARAM "")
 endif()
 
-add_custom_command(
-  COMMAND
-  "${Python3_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/generate.py"
+# common arguments between configure and build
+set(GENERATE_ARGS "${Python3_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/generate.py"
      "--equations" ${EQUATIONS}
      "--matricesDir" ${CMAKE_CURRENT_SOURCE_DIR}/matrices
      "--outputDir" ${CMAKE_CURRENT_BINARY_DIR}/GeneratedCode
@@ -56,7 +51,59 @@ add_custom_command(
      "--executable_libxsmm=${Libxsmm_executable_PROGRAM}"
      "--executable_pspamm=${PSpaMM_PROGRAM}"
      ${PREMULTIPLY_FLUX_VALUE} # boolean flag
-     ${OVERRIDE_VECTORSIZE_PARAM}
+     ${OVERRIDE_VECTORSIZE_PARAM})
+
+# find out which files will be generated
+execute_process(COMMAND ${GENERATE_ARGS} "--mode" "collect"
+     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+
+file(READ "${CMAKE_CURRENT_BINARY_DIR}/GeneratedCode/targets.json" SEISSOL_CODEGEN_TARGETS)
+
+string(JSON TARGETCOUNT LENGTH ${SEISSOL_CODEGEN_TARGETS})
+math(EXPR TARGETCOUNT "${TARGETCOUNT} - 1")
+
+set(SEISSOL_CODEGEN_KERNELS)
+set(SEISSOL_CODEGEN_TESTS)
+set(SEISSOL_CODEGEN_HEADERS)
+
+foreach(IDX RANGE ${TARGETCOUNT})
+  string(JSON TARGETNAME MEMBER ${SEISSOL_CODEGEN_TARGETS} ${IDX})
+
+  string(JSON TARGET_COUNT LENGTH ${SEISSOL_CODEGEN_TARGETS} "${TARGETNAME}" "kernels")
+  math(EXPR TARGET_COUNT "${TARGET_COUNT} - 1")
+  foreach (IDX2 RANGE ${TARGET_COUNT})
+    string(JSON TARGET_FILE GET ${SEISSOL_CODEGEN_TARGETS} "${TARGETNAME}" "kernels" ${IDX2})
+    list(APPEND SEISSOL_CODEGEN_KERNELS "${CMAKE_CURRENT_BINARY_DIR}/GeneratedCode/${TARGET_FILE}")
+  endforeach()
+
+  string(JSON TARGET_COUNT LENGTH ${SEISSOL_CODEGEN_TARGETS} "${TARGETNAME}" "tests")
+  math(EXPR TARGET_COUNT "${TARGET_COUNT} - 1")
+  foreach (IDX2 RANGE ${TARGET_COUNT})
+    string(JSON TARGET_FILE GET ${SEISSOL_CODEGEN_TARGETS} "${TARGETNAME}" "tests" ${IDX2})
+    list(APPEND SEISSOL_CODEGEN_TESTS "${CMAKE_CURRENT_BINARY_DIR}/GeneratedCode/${TARGET_FILE}")
+  endforeach()
+
+  string(JSON TARGET_COUNT LENGTH ${SEISSOL_CODEGEN_TARGETS} "${TARGETNAME}" "headers")
+  math(EXPR TARGET_COUNT "${TARGET_COUNT} - 1")
+  foreach (IDX2 RANGE ${TARGET_COUNT})
+    string(JSON TARGET_FILE GET ${SEISSOL_CODEGEN_TARGETS} "${TARGETNAME}" "headers" ${IDX2})
+    list(APPEND SEISSOL_CODEGEN_HEADERS "${CMAKE_CURRENT_BINARY_DIR}/GeneratedCode/${TARGET_FILE}")
+  endforeach()
+
+endforeach()
+
+# TODO: fix PARENT_SCOPE usage
+set(SEISSOL_CODEGEN_TESTS ${SEISSOL_CODEGEN_TESTS} PARENT_SCOPE)
+
+set(GENERATED_FILES_FOR_SEISSOL
+      ${GENERATED_FILES_FOR_SEISSOL}
+      ${SEISSOL_CODEGEN_KERNELS}
+      ${SEISSOL_CODEGEN_TESTS}
+      ${SEISSOL_CODEGEN_HEADERS})
+
+add_custom_command(
+  COMMAND
+     ${GENERATE_ARGS} "--mode" "codegen"
      WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
      DEPENDS
         build-time-make-directory
@@ -70,3 +117,8 @@ add_custom_command(
        )
 
 add_custom_target(seissol-codegen ALL DEPENDS ${GENERATED_FILES_FOR_SEISSOL})
+
+add_library(seissol-kernel-lib
+  ${SEISSOL_CODEGEN_KERNELS}
+  ${CMAKE_CURRENT_BINARY_DIR}/GeneratedCode/subroutine.cpp
+)

--- a/codegen/generate.py
+++ b/codegen/generate.py
@@ -11,6 +11,7 @@
 
 import argparse
 import importlib.util
+import json
 import os
 import re
 import sys
@@ -68,6 +69,13 @@ def main():
     )
     cmdLineParser.add_argument("--executable_libxsmm", default="")
     cmdLineParser.add_argument("--executable_pspamm", default="")
+
+    # "dry run" parameter for use directly in CMake (before building)
+    cmdLineParser.add_argument(
+        "--mode", type=str, choices=["collect", "codegen"], default="codegen"
+    )
+    cmdLineParser.add_argument("--codegen_target", type=str, default="__all__")
+
     cmdLineParser.set_defaults(enable_premultiply_flux=False)
     cmdLineArgs = cmdLineParser.parse_args()
 
@@ -171,6 +179,12 @@ def main():
 
     gemmTools = GeneratorCollection(gemm_generators)
 
+    def check_run_codegen(name):
+        return cmdLineArgs.mode == "codegen" and cmdLineArgs.codegen_target in (
+            "__all__",
+            name,
+        )
+
     def generate_equation(subfolders, equation, order):
         precision = "double" if cmdLineArgs.precision in ["d", "f64"] else "single"
         fusedSuffix = (
@@ -264,16 +278,17 @@ def main():
 
         subfolders += [outputDirName]
 
-        # Generate code
-        generator.generate(
-            outputDir=trueOutputDir,
-            namespace="seissol",
-            gemm_cfg=gemmTools,
-            cost_estimator=cost_estimators,
-            include_tensors=include_tensors,
-            routine_exporters=custom_routine_generators,
-            routine_cache=routine_cache,
-        )
+        # Generate code (if we need to)
+        if check_run_codegen(outputDirName):
+            generator.generate(
+                outputDir=trueOutputDir,
+                namespace="seissol",
+                gemm_cfg=gemmTools,
+                cost_estimator=cost_estimators,
+                include_tensors=include_tensors,
+                routine_exporters=custom_routine_generators,
+                routine_cache=routine_cache,
+            )
 
     def generate_general(subfolders):
         # we use always use double here,
@@ -297,15 +312,18 @@ def main():
             NamespacedGenerator(generator, namespace="dynamicRupture")
         )
 
-        generator.generate(
-            outputDir=outputDir,
-            namespace="seissol::general",
-            gemm_cfg=gemmTools,
-            cost_estimator=cost_estimators,
-            include_tensors=kernels.general.includeMatrices(cmdLineArgs.matricesDir),
-            routine_exporters=custom_routine_generators,
-            routine_cache=routine_cache,
-        )
+        if check_run_codegen("general"):
+            generator.generate(
+                outputDir=outputDir,
+                namespace="seissol::general",
+                gemm_cfg=gemmTools,
+                cost_estimator=cost_estimators,
+                include_tensors=kernels.general.includeMatrices(
+                    cmdLineArgs.matricesDir
+                ),
+                routine_exporters=custom_routine_generators,
+                routine_cache=routine_cache,
+            )
 
     def forward_files(filename):
         with open(os.path.join(cmdLineArgs.outputDir, filename), "w") as file:
@@ -321,15 +339,34 @@ def main():
     generate_equation(subfolders, equation_class, cmdLineArgs.order)
     generate_general(subfolders)
 
-    routine_cache.generate(cmdLineArgs.outputDir, "seissol")
+    if cmdLineArgs.mode == "codegen":
+        routine_cache.generate(cmdLineArgs.outputDir, "seissol")
 
-    forward_files("init.h")
-    forward_files("kernel.h")
-    forward_files("tensor.h")
-    forward_files("init.cpp")
-    forward_files("kernel.cpp")
-    forward_files("tensor.cpp")
-    forward_files("test-kernel.cpp")
+        # for now
+        forward_files("init.h")
+        forward_files("kernel.h")
+        forward_files("tensor.h")
+
+    if cmdLineArgs.mode == "collect":
+        targets = {
+            folder: {
+                "kernels": [
+                    os.path.join(folder, "init.cpp"),
+                    os.path.join(folder, "kernel.cpp"),
+                    os.path.join(folder, "tensor.cpp"),
+                ],
+                "tests": [os.path.join(folder, "test-kernel.cpp")],
+                "headers": [
+                    os.path.join(folder, "init.h"),
+                    os.path.join(folder, "kernel.h"),
+                    os.path.join(folder, "tensor.h"),
+                ],
+            }
+            for folder in subfolders
+        }
+
+        with open(os.path.join(cmdLineArgs.outputDir, "targets.json"), "w") as file:
+            json.dump(targets, file)
 
 
 if __name__ == "__main__":

--- a/src/sources.cmake
+++ b/src/sources.cmake
@@ -5,19 +5,6 @@
 #
 # SPDX-FileContributor: Author lists in /AUTHORS and /CITATION.cff
 
-# Source code
-add_library(seissol-kernel-lib
-
-# run YATeTo first, since kernel.cpp usually takes really long
-
-# kernel.cpp usually takes the longest
-# (for CPUs, at least; for GPUs, we have a different library alltogether)
-${CMAKE_BINARY_DIR}/codegen/GeneratedCode/kernel.cpp
-${CMAKE_BINARY_DIR}/codegen/GeneratedCode/tensor.cpp
-${CMAKE_BINARY_DIR}/codegen/GeneratedCode/subroutine.cpp
-${CMAKE_BINARY_DIR}/codegen/GeneratedCode/init.cpp
-)
-
 # Generated code does only work without red-zone.
 if (HAS_REDZONE)
   set_source_files_properties(

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -73,7 +73,7 @@ if (TESTING_GENERATED)
     if (WITH_GPU)
 
         # for the GPU, create an extra library with device linking flags etc.
-        make_device_lib(seissol-serial-test-device "${CMAKE_BINARY_DIR}/codegen/GeneratedCode/test-kernel.cpp")
+        make_device_lib(seissol-serial-test-device ${SEISSOL_CODEGEN_TESTS})
         target_link_libraries(seissol-serial-test-device PRIVATE seissol-kernel-lib)
         target_link_libraries(seissol-serial-test-device PRIVATE seissol-external)
         target_include_directories(seissol-serial-test-device PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
@@ -84,7 +84,7 @@ if (TESTING_GENERATED)
     else()
 
         # else (i.e. CPU only), just add it to the main test binary
-        target_sources(seissol-serial-test PRIVATE "${CMAKE_BINARY_DIR}/codegen/GeneratedCode/test-kernel.cpp")
+        target_sources(seissol-serial-test PRIVATE ${SEISSOL_CODEGEN_TESTS})
     endif()
 endif()
 

--- a/tests/python/codegen/test_generate_goldenfile.py
+++ b/tests/python/codegen/test_generate_goldenfile.py
@@ -109,10 +109,6 @@ class TestGeneratedFilesExist:
         "init.h",
         "kernel.h",
         "tensor.h",
-        "init.cpp",
-        "kernel.cpp",
-        "tensor.cpp",
-        "test-kernel.cpp",
     }
 
     def test_forward_files_produced(self, generated_elastic_o3):
@@ -188,8 +184,8 @@ class TestGeneratedContent:
         assert "equation-elastic-3-double/init.h" in content
         assert "general/init.h" in content
 
-    def test_kernel_h_declares_adergd_kernels(self, generated_elastic_o3):
-        """ADERDG pipeline kernels must appear in kernel.h. If generate.py
+    def test_kernel_h_declares_aderdg_kernels(self, generated_elastic_o3):
+        """ADER-DG pipeline kernels must appear in kernel.h. If generate.py
         or the kernel-name contract changes, the C++ side breaks."""
         outdir, _ = generated_elastic_o3
         content = (outdir / "equation-elastic-3-double" / "kernel.h").read_text()
@@ -203,10 +199,14 @@ class TestGeneratedContent:
     def test_test_kernel_cpp_not_empty(self, generated_elastic_o3):
         """test-kernel.cpp feeds the TESTING_GENERATED compile path."""
         outdir, _ = generated_elastic_o3
-        content = (outdir / "test-kernel.cpp").read_text()
+        content = (outdir / "equation-elastic-3-double" / "test-kernel.cpp").read_text()
         assert len(content.strip()) > 0
-        # Forward file aggregates per-equation test kernels
-        assert "test-kernel.cpp" in content
+        # A handful of canonical kernel names
+        for name in [
+            "computeFluxSolverLocal",
+            "computeFluxSolverNeighbor",
+        ]:
+            assert name in content, f"Expected kernel '{name}' in test-kernel.cpp"
 
 
 # =============================================================================


### PR DESCRIPTION
Split up the build of Yateto kernels per Yateto call.
(mostly relevant for #1421 ; but also to a little extent now already)

Each Yateto call generates its own set of files—now we forward it to the build system; and we do not require any more "aggregator files" for the CPP ones; only the header files.

The code generation still happens in a single sweep (due to the subroutines; we might need to pickle them to get around that).

Small tidbit of the current setup: we will now need to run Python during configure, as we run the generation script now twice (once during configure to obtain all files to compile, and once during build to actually generate the files).
