### PR TITLE
Add global cell/face ID to the receiver header

### DIFF
--- a/src/DynamicRupture/Output/Builders/ElementWiseBuilder.h
+++ b/src/DynamicRupture/Output/Builders/ElementWiseBuilder.h
@@ -90,7 +90,7 @@ class ElementWiseBuilder : public ReceiverBasedOutputBuilder {
                                              static_cast<int>(faceIdx),
                                              faceSideIdx,
                                              elementIdx,
-                                             element.globalId},
+                                             &fault},
                                             std::make_pair(globalFace, referenceTriangle));
         }
       }
@@ -166,6 +166,8 @@ class ElementWiseBuilder : public ReceiverBasedOutputBuilder {
             receiverPoint.localFaceSideId = faceSideIdx;
             receiverPoint.elementIndex = element.localId;
             receiverPoint.elementGlobalIndex = element.globalId;
+            receiverPoint.localNeighborFaceSideId = fault.neighborSide;
+            receiverPoint.elementNeighborGlobalIndex = fault.neighborGlobalId;
             receiverPoint.globalReceiverIndex =
                 faceOffset * seissol::init::vtk2d::Shape[order][1] + i;
             receiverPoint.faultTag = fault.tag;

--- a/src/DynamicRupture/Output/Builders/PickPointBuilder.h
+++ b/src/DynamicRupture/Output/Builders/PickPointBuilder.h
@@ -114,6 +114,8 @@ class PickPointBuilder : public ReceiverBasedOutputBuilder {
           receiver.globalReceiverIndex = receiverIdx;
           receiver.elementIndex = element.localId;
           receiver.elementGlobalIndex = element.globalId;
+          receiver.localNeighborFaceSideId = faultItem.neighborSide;
+          receiver.elementNeighborGlobalIndex = faultItem.neighborGlobalId;
 
           receiver.reference = transformations::tetrahedronGlobalToReference(
               meshVertices[element.vertices[0]].coords,

--- a/src/DynamicRupture/Output/FaultRefiner/FaultRefiners.cpp
+++ b/src/DynamicRupture/Output/FaultRefiner/FaultRefiners.cpp
@@ -53,7 +53,9 @@ void FaultRefiner::addReceiver(Data data, TrianglePair& face) {
   receiver.faultFaceIndex = data.faultFaceIndex;
   receiver.localFaceSideId = data.localFaceSideId;
   receiver.elementIndex = data.elementId;
-  receiver.elementGlobalIndex = data.globalId;
+  receiver.elementGlobalIndex = data.fault->globalId;
+  receiver.localNeighborFaceSideId = data.fault->neighborSide;
+  receiver.elementNeighborGlobalIndex = data.fault->neighborGlobalId;
   receiver.globalReceiverIndex = points_.size();
   receiver.global = getMidPointTriangle(std::get<Global>(face));
   receiver.reference = getMidPointTriangle(std::get<Reference>(face));

--- a/src/DynamicRupture/Output/FaultRefiner/FaultRefiners.h
+++ b/src/DynamicRupture/Output/FaultRefiner/FaultRefiners.h
@@ -22,7 +22,7 @@ class FaultRefiner {
     int faultFaceIndex{};
     int localFaceSideId{};
     int elementId{-1};
-    std::size_t globalId{};
+    const Fault* fault{nullptr};
   };
   using PointsPair = std::pair<ExtVrtxCoords, ExtVrtxCoords>;
   using TrianglePair = std::pair<ExtTriangle, ExtTriangle>;

--- a/src/DynamicRupture/Output/Geometry.h
+++ b/src/DynamicRupture/Output/Geometry.h
@@ -104,11 +104,17 @@ struct ReceiverPoint {
   // Side ID of a reference element
   int localFaceSideId{-1};
 
+  // Side ID (minus) of a reference element
+  int localNeighborFaceSideId{-1};
+
   // Rank-local element ID to which the receiver belongs
   int elementIndex{-1};
 
   // Global element ID to which the receiver belongs
   std::size_t elementGlobalIndex{std::numeric_limits<std::size_t>::max()};
+
+  // Global element ID (minus) to which the receiver belongs
+  std::size_t elementNeighborGlobalIndex{std::numeric_limits<std::size_t>::max()};
 
   // receiver index of global list
   int globalReceiverIndex{-1};

--- a/src/DynamicRupture/Output/Geometry.h
+++ b/src/DynamicRupture/Output/Geometry.h
@@ -89,27 +89,54 @@ struct ExtTriangle {
 };
 
 struct ReceiverPoint {
-  ExtVrtxCoords global;       // physical coords of a receiver
-  ExtVrtxCoords reference;    // reference coords of a receiver
-  ExtTriangle globalTriangle; // a surrounding triangle of a receiver
-  int faultFaceIndex{-1};     // Face Fault index which the receiver belongs to
-  int localFaceSideId{-1};    // Side ID of a reference element
-  int elementIndex{-1};       // Element which the receiver belongs to
-  std::size_t elementGlobalIndex{
-      std::numeric_limits<std::size_t>::max()}; // Element which the receiver belongs to
-  int globalReceiverIndex{-1};                  // receiver index of global list
-  bool isInside{false};                         // If a point is inside the mesh or not
+  // physical coords of a receiver
+  ExtVrtxCoords global;
+
+  // reference coords of a receiver
+  ExtVrtxCoords reference;
+
+  // a surrounding triangle of a receiver
+  ExtTriangle globalTriangle;
+
+  // Face Fault index which the receiver belongs to
+  int faultFaceIndex{-1};
+
+  // Side ID of a reference element
+  int localFaceSideId{-1};
+
+  // Rank-local element ID to which the receiver belongs
+  int elementIndex{-1};
+
+  // Global element ID to which the receiver belongs
+  std::size_t elementGlobalIndex{std::numeric_limits<std::size_t>::max()};
+
+  // receiver index of global list
+  int globalReceiverIndex{-1};
+
+  // If a point is inside the mesh or not
+  bool isInside{false};
+
   int nearestGpIndex{-1};
+
   int faultTag{-1};
-  int simIndex{0}; // Simulation index for multisim
-  int gpIndex{-1}; // Index of the nearest gaussian point considering fused simulations
+
+  // Simulation index for multisim
+  int simIndex{0};
+
+  // Index of the nearest quadrature point considering fused simulations
+  int gpIndex{-1};
 
   // Internal points are required because computed gradients
   // are inaccurate near triangle edges,
   // specifically for low-order elements
   int nearestInternalGpIndex{-1};
-  int internalGpIndexFused{
-      -1}; // Index of the nearest internal gaussian point considering fused simulations
+
+  // Index of the nearest internal quadrature point considering fused simulations
+  int internalGpIndexFused{-1};
+
+  [[nodiscard]] constexpr auto globalFaultFaceId() const {
+    return elementGlobalIndex * Cell::NumFaces + localFaceSideId;
+  }
 };
 using ReceiverPoints = std::vector<ReceiverPoint>;
 

--- a/src/DynamicRupture/Output/OutputManager.cpp
+++ b/src/DynamicRupture/Output/OutputManager.cpp
@@ -418,6 +418,8 @@ void OutputManager::initPickpointOutput() {
               file << "# x1\t" << makeFormatted(point[0]) << '\n';
               file << "# x2\t" << makeFormatted(point[1]) << '\n';
               file << "# x3\t" << makeFormatted(point[2]) << '\n';
+              file << "# face-global-id\t"
+                   << receiver.elementGlobalIndex * 4 + receiver.localFaceSideId << '\n';
             }
 
             // stress info

--- a/src/DynamicRupture/Output/OutputManager.cpp
+++ b/src/DynamicRupture/Output/OutputManager.cpp
@@ -213,8 +213,7 @@ void OutputManager::initElementwiseOutput() {
 
 #pragma omp parallel for schedule(static)
     for (std::size_t i = 0; i < faceIdentifiers.size(); ++i) {
-      faceIdentifiers[i] =
-          receiverPoints[i].elementGlobalIndex * 4 + receiverPoints[i].localFaceSideId;
+      faceIdentifiers[i] = receiverPoints[i].globalFaultFaceId();
     }
 
     seissolInstance_.faultWriter().init(cellConnectivity.data(),
@@ -260,8 +259,7 @@ void OutputManager::initElementwiseOutput() {
 
     writer.addCellData<std::size_t>(
         "global-id", {}, [=, &receiverPoints](std::size_t* target, std::size_t index) {
-          *target =
-              receiverPoints[index].elementGlobalIndex * 4 + receiverPoints[index].localFaceSideId;
+          *target = receiverPoints[index].globalFaultFaceId();
         });
 
     misc::forEach(ewOutputData_->vars, [&](const auto& var, int i) {
@@ -418,8 +416,9 @@ void OutputManager::initPickpointOutput() {
               file << "# x1\t" << makeFormatted(point[0]) << '\n';
               file << "# x2\t" << makeFormatted(point[1]) << '\n';
               file << "# x3\t" << makeFormatted(point[2]) << '\n';
-              file << "# face-global-id\t"
-                   << receiver.elementGlobalIndex * 4 + receiver.localFaceSideId << '\n';
+              file << "# face-global-id\t" << receiver.globalFaultFaceId() << '\n';
+              file << "# plus-cell-global-id\t" << receiver.elementGlobalIndex << '\n';
+              file << "# plus-face-side\t" << receiver.localFaceSideId << '\n';
             }
 
             // stress info

--- a/src/DynamicRupture/Output/OutputManager.cpp
+++ b/src/DynamicRupture/Output/OutputManager.cpp
@@ -419,6 +419,8 @@ void OutputManager::initPickpointOutput() {
               file << "# face-global-id\t" << receiver.globalFaultFaceId() << '\n';
               file << "# plus-cell-global-id\t" << receiver.elementGlobalIndex << '\n';
               file << "# plus-face-side\t" << receiver.localFaceSideId << '\n';
+              file << "# minus-cell-global-id\t" << receiver.elementNeighborGlobalIndex << '\n';
+              file << "# minus-face-side\t" << receiver.localNeighborFaceSideId << '\n';
             }
 
             // stress info

--- a/src/ResultWriter/ReceiverWriter.cpp
+++ b/src/ResultWriter/ReceiverWriter.cpp
@@ -120,7 +120,9 @@ std::vector<std::string> ReceiverWriter::variableNames() const {
   return fullNames;
 }
 
-void ReceiverWriter::writeHeader(std::size_t pointId, const Eigen::Vector3d& point) {
+void ReceiverWriter::writeHeader(std::size_t pointId,
+                                 const Eigen::Vector3d& point,
+                                 std::size_t globalId) {
   auto name = fileName(pointId);
 
   /// \todo Find a nicer solution that is not so hard-coded.
@@ -130,7 +132,7 @@ void ReceiverWriter::writeHeader(std::size_t pointId, const Eigen::Vector3d& poi
     std::ofstream file;
     file.open(name);
     file << "TITLE = \"Temporal Signal for receiver number " << std::setfill('0') << std::setw(5)
-         << (pointId + 1) << "\"" << std::endl;
+         << (pointId + 1) << "\"" << '\n';
     file << "VARIABLES = ";
 
     auto names = variableNames();
@@ -140,11 +142,14 @@ void ReceiverWriter::writeHeader(std::size_t pointId, const Eigen::Vector3d& poi
       }
       file << "\"" << names[i] << "\"";
     }
-    file << std::endl;
+    file << '\n';
+
+    // metadata header
     for (int d = 0; d < 3; ++d) {
       file << "# x" << (d + 1) << "       " << std::scientific << std::setprecision(12) << point[d]
-           << std::endl;
+           << '\n';
     }
+    file << "# cell-global-id " << globalId << '\n';
     file.close();
   }
 }
@@ -242,7 +247,7 @@ void ReceiverWriter::addPoints(const seissol::geometry::MeshReader& mesh,
       }
 
       if (format_ == seissol::initializer::parameters::ReceiverOutputFormat::Csv) {
-        writeHeader(point, points[point]);
+        writeHeader(point, points[point], mesh.getElements()[meshId].globalId);
       }
       localReceiverCount++;
 

--- a/src/ResultWriter/ReceiverWriter.h
+++ b/src/ResultWriter/ReceiverWriter.h
@@ -90,7 +90,7 @@ class ReceiverWriter : public seissol::Module {
   static std::string hdf5FileName(const std::string& prefix);
   [[nodiscard]] std::string fileName(std::size_t pointId) const;
   [[nodiscard]] std::vector<std::string> variableNames() const;
-  void writeHeader(std::size_t pointId, const Eigen::Vector3d& point);
+  void writeHeader(std::size_t pointId, const Eigen::Vector3d& point, std::size_t globalId);
 
   // -- Members --
   seissol::initializer::parameters::ReceiverOutputFormat format_{


### PR DESCRIPTION
Add a reference to the cell or face on which we've found the receiver; mainly for debugging purposes—but mainly it'll also have other uses.

Happy to discuss the naming (`face/cell-global-id`), and/or the layout.
