### PR TITLE
Add gfx1250, gfx1251 to the arch list in the docs

### DIFF
--- a/docs/build-archs.rst
+++ b/docs/build-archs.rst
@@ -348,6 +348,16 @@ The following architectures are supported:
      - AMD RDNA 4
      - AMD Radeon 9000 series
      - split [#xnack2]_
+   * - ``gfx1250``
+     - ``hip``
+     - AMD CDNA 5
+     - AMD MI455X
+     - split [#xnack1]_
+   * - ``gfx1251``
+     - ``hip``
+     - AMD CDNA 5
+     - AMD MI430X
+     - split [#xnack1]_
    * - ``12_60_7`` (``pvc``)
      - ``oneapi``
      - Intel Ponte Vecchio


### PR DESCRIPTION
As the title says; since we sort of have them official now, (or cf. e.g. https://chipsandcheese.com/p/scrying-the-amd-gfx1250-llvm-tea or https://chipsandcheese.com/p/llvm-divination-of-gfx1251s-differences ), let's add them to the docs. Example archs based the fact that gfx1251 includes HPC features like WMMA for FP64. The arch name was more or less announced a few days ago officially.

Side note: maybe it's worth at some point retiring the extra-curated arch list and refer to documents maintained elsewhere (like e.g. https://llvm.org/docs/AMDGPUUsage.html#processors for AMD). We can by now infer the arch names mostly automatically if the user allows it.
