### PR TITLE
Fix receiver strain rate parameter name

### DIFF
--- a/src/Initializer/Parameters/OutputParameters.cpp
+++ b/src/Initializer/Parameters/OutputParameters.cpp
@@ -154,7 +154,7 @@ ReceiverOutputParameters readReceiverParameters(ParameterReader* baseReader) {
       });
 
   const auto computeRotation = reader->readWithDefault("receivercomputerotation", false);
-  const auto computeStrain = reader->readWithDefault("ReceiverComputeStrainRate", false);
+  const auto computeStrain = reader->readWithDefault("receivercomputestrainrate", false);
   const auto samplingInterval = reader->readWithDefault("pickdt", 0.005);
   const auto fileName = reader->readPath("rfilename");
 


### PR DESCRIPTION
(always needs to be all lower case)
(... maybe it's good to catch that in software at some point)