### PR TITLE
Use quadweights for the potency computation

### DIFF
--- a/docs/breaking-changes-backward-compatibility.rst
+++ b/docs/breaking-changes-backward-compatibility.rst
@@ -118,3 +118,13 @@ Name of the Strain Rate Output for Off-Fault Receivers
 The strain rate output was named just "strain" output for the off-fault receivers.
 The corresponding option was likewise called :code:`ReceiverComputeStrain`,
 not :code:`ReceiverComputeStrainRate`.
+
+Potency and Seismic Moment Quadrature
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+(since before 0.9.0, `#527 <https://github.com/SeisSol/SeisSol/pull/527>`_, April 2022)
+
+The potency and the seismic moment were computed by averaging the value over all points.
+Now, to make the integration more exact, they are instead weighed by the quadrature rule
+the underlying DR implementation uses. As a result, the computed seismic moment and magnitude
+may slightly change compared to before.

--- a/src/ResultWriter/EnergyOutput.cpp
+++ b/src/ResultWriter/EnergyOutput.cpp
@@ -314,10 +314,10 @@ void EnergyOutput::computeDynamicRuptureEnergies() {
           double potencyIncrease = 0.0;
           for (std::size_t k = 0; k < seissol::dr::misc::NumBoundaryGaussPoints; ++k) {
             potencyIncrease +=
-                drEnergyOutput[i].accumulatedSlip[k * seissol::multisim::NumSimulations + sim];
+                drEnergyOutput[i].accumulatedSlip[k * seissol::multisim::NumSimulations + sim] *
+                init::quadpoints::Values[k];
           }
-          potencyIncrease *=
-              0.5 * godunovData[i].doubledSurfaceArea / seissol::dr::misc::NumBoundaryGaussPoints;
+          potencyIncrease *= 0.5 * godunovData[i].doubledSurfaceArea;
           potency += potencyIncrease;
           seismicMoment += potencyIncrease * mu;
         }

--- a/src/ResultWriter/EnergyOutput.cpp
+++ b/src/ResultWriter/EnergyOutput.cpp
@@ -317,7 +317,7 @@ void EnergyOutput::computeDynamicRuptureEnergies() {
                 drEnergyOutput[i].accumulatedSlip[k * seissol::multisim::NumSimulations + sim] *
                 init::quadweights::Values[k];
           }
-          potencyIncrease *= 0.5 * godunovData[i].doubledSurfaceArea;
+          potencyIncrease *= godunovData[i].doubledSurfaceArea;
           potency += potencyIncrease;
           seismicMoment += potencyIncrease * mu;
         }

--- a/src/ResultWriter/EnergyOutput.cpp
+++ b/src/ResultWriter/EnergyOutput.cpp
@@ -315,7 +315,7 @@ void EnergyOutput::computeDynamicRuptureEnergies() {
           for (std::size_t k = 0; k < seissol::dr::misc::NumBoundaryGaussPoints; ++k) {
             potencyIncrease +=
                 drEnergyOutput[i].accumulatedSlip[k * seissol::multisim::NumSimulations + sim] *
-                init::quadpoints::Values[k];
+                init::quadweights::Values[k];
           }
           potencyIncrease *= 0.5 * godunovData[i].doubledSurfaceArea;
           potency += potencyIncrease;


### PR DESCRIPTION
Use the given quadrature rule for the potency (and seismic moment) computation in the energy; not the average.
